### PR TITLE
[FEAT] Add pytorch policy class

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,16 @@ A Python reinforcement learning library providing core RL infrastructure includi
 
 - **Environment Sampling**: Single and parallel environment sampling using Ray
 - **Replay Buffers**: Efficient circular buffer implementation for experience replay
-- **Data Models & Sampling Environments**: Type-safe dataclasses that match environment specifications
+- **Data Models**: Type-safe dataclasses that match environment specifications
 - **Policies**: Support for PyTorch policies 
 - **CLI Tools**: Command-line interface for sampling and data collection
 - **Configuration Management**: Centralized settings via Dynaconf
 
-### Data Models & Sampling Environments
+### Environment Sampling
+
+This repository provides some helper classes for sampling from environments. This includes the ability to sample whole episodes simply, and the ability to distribute the sampling through the use of Ray. The distributed samplers have the same API as the standard samplers, so it should be possible to swap in distributed sampling as required with no code changes. 
+
+### Data Models
 
 This repository includes a range of dataclasses that are used to designed the samples steps from environments. These dataclasses detect the specification of the environment, e.g. a discrete or continuous action space, and set the appropriate types for the corresponding fields in the data model. All actions, observations and rewards will be stored in NumPy arrays, with any required conversion automatically managed by these data classes. For example, when sampling from a toy environment with a discrete space, the integer state observations returned by Gym will automatically be stored in a NumPy array.
 

--- a/README.md
+++ b/README.md
@@ -68,13 +68,13 @@ Perform basic stochastic gradient ascent to optimise the policy. This is intende
 
 ```bash
 # Perform stochastic gradient ascent on the given environment
-poetry run tfrlrl-sgd --env-id FrozenLake-v1 --n-iterations 100
+poetry run tfrlrl-sgd --env-id FrozenLake-v1 --policy-class linear --n-iterations 100 
 
 # With environment-specific configuration
-poetry run tfrlrl-sgd --env-id FrozenLake-v1 --n-iterations 100 --env-kwargs '{"is_slippery": false}'
+poetry run tfrlrl-sgd --env-id FrozenLake-v1 --policy-class linear --n-iterations 100 --env-kwargs '{"is_slippery": false}'
 
 # With custom hyperparameters
-poetry run tfrlrl-sgd --env-id FrozenLake-v1 --n-iterations 50 --n-episodes 200 --alpha 10.0
+poetry run tfrlrl-sgd --env-id FrozenLake-v1 --policy-class linear --n-iterations 50 --n-episodes 200 --alpha 10.0
 ```
 
 **Options:**
@@ -83,7 +83,11 @@ poetry run tfrlrl-sgd --env-id FrozenLake-v1 --n-iterations 50 --n-episodes 200 
 - `--n-iterations`: Total number of policy updates to perform (default: 100)
 - `--n-episodes`: Total number of episodes to sample during each policy update (default: 100)
 - `--alpha`: The initial step size in stochastic gradient ascent. Step sizes are linearly decreased w.r.t. the iteration of stochastic gradients (default: 100.0)
+- `--n-samplers`: The number of samplers to use during sampling (default: 1)
 - `--env-kwargs`: Environment-specific keyword arguments as a JSON string (default: `{}`). For example, `'{"is_slippery": false}'` for FrozenLake-v1
+- `--n-samplers`: The number of samplers to use during sampling (default: 1)
+- `--policy-class`: The class of policy to use in the environment. Allowed values are `linear` and `dense`.
+- `--n-hidden`: The number of hidden dimensions to use in the case of a dense policy.
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -6,9 +6,20 @@ A Python reinforcement learning library providing core RL infrastructure includi
 
 - **Environment Sampling**: Single and parallel environment sampling using Ray
 - **Replay Buffers**: Efficient circular buffer implementation for experience replay
-- **Dynamic Data Models**: Type-safe dataclasses that adapt to environment specifications
+- **Data Models & Sampling Environments**: Type-safe dataclasses that match environment specifications
+- **Policies**: Support for PyTorch policies 
 - **CLI Tools**: Command-line interface for sampling and data collection
 - **Configuration Management**: Centralized settings via Dynaconf
+
+### Data Models & Sampling Environments
+
+This repository includes a range of dataclasses that are used to designed the samples steps from environments. These dataclasses detect the specification of the environment, e.g. a discrete or continuous action space, and set the appropriate types for the corresponding fields in the data model. All actions, observations and rewards will be stored in NumPy arrays, with any required conversion automatically managed by these data classes. For example, when sampling from a toy environment with a discrete space, the integer state observations returned by Gym will automatically be stored in a NumPy array.
+
+These classes automatically manage an additional dimension to the samples that allows aggregation of samples across multiple steps. This dimension is always the last dimension of the field. For example, `N` discrete actions will be store in a `(1, N)` NumPy array, while `N` observations, each of size `(o_1, o_2)`, will be stored in a `(o_1, 0_2, N)` array. 
+
+### Policies
+
+This repository provides flexible support for different policies. The only requirement is policies are implemented in PyTorch and inherit from the `BasePyTorchPolicy` base class. See the `DensePolicyNetwork` and `LinearSoftMaxNetwork` for examples. 
 
 ## Installation
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -13,6 +13,177 @@ files = [
 ]
 
 [[package]]
+name = "aiohappyeyeballs"
+version = "2.6.1"
+description = "Happy Eyeballs for asyncio"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "aiohappyeyeballs-2.6.1-py3-none-any.whl", hash = "sha256:f349ba8f4b75cb25c99c5c2d84e997e485204d2902a9597802b0371f09331fb8"},
+    {file = "aiohappyeyeballs-2.6.1.tar.gz", hash = "sha256:c3f9d0113123803ccadfdf3f0faa505bc78e6a72d1cc4806cbd719826e943558"},
+]
+
+[[package]]
+name = "aiohttp"
+version = "3.13.3"
+description = "Async http client/server framework (asyncio)"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "aiohttp-3.13.3-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:d5a372fd5afd301b3a89582817fdcdb6c34124787c70dbcc616f259013e7eef7"},
+    {file = "aiohttp-3.13.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:147e422fd1223005c22b4fe080f5d93ced44460f5f9c105406b753612b587821"},
+    {file = "aiohttp-3.13.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:859bd3f2156e81dd01432f5849fc73e2243d4a487c4fd26609b1299534ee1845"},
+    {file = "aiohttp-3.13.3-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dca68018bf48c251ba17c72ed479f4dafe9dbd5a73707ad8d28a38d11f3d42af"},
+    {file = "aiohttp-3.13.3-cp310-cp310-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:fee0c6bc7db1de362252affec009707a17478a00ec69f797d23ca256e36d5940"},
+    {file = "aiohttp-3.13.3-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c048058117fd649334d81b4b526e94bde3ccaddb20463a815ced6ecbb7d11160"},
+    {file = "aiohttp-3.13.3-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:215a685b6fbbfcf71dfe96e3eba7a6f58f10da1dfdf4889c7dd856abe430dca7"},
+    {file = "aiohttp-3.13.3-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:de2c184bb1fe2cbd2cefba613e9db29a5ab559323f994b6737e370d3da0ac455"},
+    {file = "aiohttp-3.13.3-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:75ca857eba4e20ce9f546cd59c7007b33906a4cd48f2ff6ccf1ccfc3b646f279"},
+    {file = "aiohttp-3.13.3-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:81e97251d9298386c2b7dbeb490d3d1badbdc69107fb8c9299dd04eb39bddc0e"},
+    {file = "aiohttp-3.13.3-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:c0e2d366af265797506f0283487223146af57815b388623f0357ef7eac9b209d"},
+    {file = "aiohttp-3.13.3-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:4e239d501f73d6db1522599e14b9b321a7e3b1de66ce33d53a765d975e9f4808"},
+    {file = "aiohttp-3.13.3-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:0db318f7a6f065d84cb1e02662c526294450b314a02bd9e2a8e67f0d8564ce40"},
+    {file = "aiohttp-3.13.3-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:bfc1cc2fe31a6026a8a88e4ecfb98d7f6b1fec150cfd708adbfd1d2f42257c29"},
+    {file = "aiohttp-3.13.3-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:af71fff7bac6bb7508956696dce8f6eec2bbb045eceb40343944b1ae62b5ef11"},
+    {file = "aiohttp-3.13.3-cp310-cp310-win32.whl", hash = "sha256:37da61e244d1749798c151421602884db5270faf479cf0ef03af0ff68954c9dd"},
+    {file = "aiohttp-3.13.3-cp310-cp310-win_amd64.whl", hash = "sha256:7e63f210bc1b57ef699035f2b4b6d9ce096b5914414a49b0997c839b2bd2223c"},
+    {file = "aiohttp-3.13.3-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:5b6073099fb654e0a068ae678b10feff95c5cae95bbfcbfa7af669d361a8aa6b"},
+    {file = "aiohttp-3.13.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:1cb93e166e6c28716c8c6aeb5f99dfb6d5ccf482d29fe9bf9a794110e6d0ab64"},
+    {file = "aiohttp-3.13.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:28e027cf2f6b641693a09f631759b4d9ce9165099d2b5d92af9bd4e197690eea"},
+    {file = "aiohttp-3.13.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3b61b7169ababd7802f9568ed96142616a9118dd2be0d1866e920e77ec8fa92a"},
+    {file = "aiohttp-3.13.3-cp311-cp311-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:80dd4c21b0f6237676449c6baaa1039abae86b91636b6c91a7f8e61c87f89540"},
+    {file = "aiohttp-3.13.3-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:65d2ccb7eabee90ce0503c17716fc77226be026dcc3e65cce859a30db715025b"},
+    {file = "aiohttp-3.13.3-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5b179331a481cb5529fca8b432d8d3c7001cb217513c94cd72d668d1248688a3"},
+    {file = "aiohttp-3.13.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9d4c940f02f49483b18b079d1c27ab948721852b281f8b015c058100e9421dd1"},
+    {file = "aiohttp-3.13.3-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f9444f105664c4ce47a2a7171a2418bce5b7bae45fb610f4e2c36045d85911d3"},
+    {file = "aiohttp-3.13.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:694976222c711d1d00ba131904beb60534f93966562f64440d0c9d41b8cdb440"},
+    {file = "aiohttp-3.13.3-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:f33ed1a2bf1997a36661874b017f5c4b760f41266341af36febaf271d179f6d7"},
+    {file = "aiohttp-3.13.3-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:e636b3c5f61da31a92bf0d91da83e58fdfa96f178ba682f11d24f31944cdd28c"},
+    {file = "aiohttp-3.13.3-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:5d2d94f1f5fcbe40838ac51a6ab5704a6f9ea42e72ceda48de5e6b898521da51"},
+    {file = "aiohttp-3.13.3-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:2be0e9ccf23e8a94f6f0650ce06042cefc6ac703d0d7ab6c7a917289f2539ad4"},
+    {file = "aiohttp-3.13.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:9af5e68ee47d6534d36791bbe9b646d2a7c7deb6fc24d7943628edfbb3581f29"},
+    {file = "aiohttp-3.13.3-cp311-cp311-win32.whl", hash = "sha256:a2212ad43c0833a873d0fb3c63fa1bacedd4cf6af2fee62bf4b739ceec3ab239"},
+    {file = "aiohttp-3.13.3-cp311-cp311-win_amd64.whl", hash = "sha256:642f752c3eb117b105acbd87e2c143de710987e09860d674e068c4c2c441034f"},
+    {file = "aiohttp-3.13.3-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:b903a4dfee7d347e2d87697d0713be59e0b87925be030c9178c5faa58ea58d5c"},
+    {file = "aiohttp-3.13.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:a45530014d7a1e09f4a55f4f43097ba0fd155089372e105e4bff4ca76cb1b168"},
+    {file = "aiohttp-3.13.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:27234ef6d85c914f9efeb77ff616dbf4ad2380be0cda40b4db086ffc7ddd1b7d"},
+    {file = "aiohttp-3.13.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d32764c6c9aafb7fb55366a224756387cd50bfa720f32b88e0e6fa45b27dcf29"},
+    {file = "aiohttp-3.13.3-cp312-cp312-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:b1a6102b4d3ebc07dad44fbf07b45bb600300f15b552ddf1851b5390202ea2e3"},
+    {file = "aiohttp-3.13.3-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c014c7ea7fb775dd015b2d3137378b7be0249a448a1612268b5a90c2d81de04d"},
+    {file = "aiohttp-3.13.3-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:2b8d8ddba8f95ba17582226f80e2de99c7a7948e66490ef8d947e272a93e9463"},
+    {file = "aiohttp-3.13.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9ae8dd55c8e6c4257eae3a20fd2c8f41edaea5992ed67156642493b8daf3cecc"},
+    {file = "aiohttp-3.13.3-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:01ad2529d4b5035578f5081606a465f3b814c542882804e2e8cda61adf5c71bf"},
+    {file = "aiohttp-3.13.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:bb4f7475e359992b580559e008c598091c45b5088f28614e855e42d39c2f1033"},
+    {file = "aiohttp-3.13.3-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:c19b90316ad3b24c69cd78d5c9b4f3aa4497643685901185b65166293d36a00f"},
+    {file = "aiohttp-3.13.3-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:96d604498a7c782cb15a51c406acaea70d8c027ee6b90c569baa6e7b93073679"},
+    {file = "aiohttp-3.13.3-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:084911a532763e9d3dd95adf78a78f4096cd5f58cdc18e6fdbc1b58417a45423"},
+    {file = "aiohttp-3.13.3-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:7a4a94eb787e606d0a09404b9c38c113d3b099d508021faa615d70a0131907ce"},
+    {file = "aiohttp-3.13.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:87797e645d9d8e222e04160ee32aa06bc5c163e8499f24db719e7852ec23093a"},
+    {file = "aiohttp-3.13.3-cp312-cp312-win32.whl", hash = "sha256:b04be762396457bef43f3597c991e192ee7da460a4953d7e647ee4b1c28e7046"},
+    {file = "aiohttp-3.13.3-cp312-cp312-win_amd64.whl", hash = "sha256:e3531d63d3bdfa7e3ac5e9b27b2dd7ec9df3206a98e0b3445fa906f233264c57"},
+    {file = "aiohttp-3.13.3-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:5dff64413671b0d3e7d5918ea490bdccb97a4ad29b3f311ed423200b2203e01c"},
+    {file = "aiohttp-3.13.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:87b9aab6d6ed88235aa2970294f496ff1a1f9adcd724d800e9b952395a80ffd9"},
+    {file = "aiohttp-3.13.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:425c126c0dc43861e22cb1c14ba4c8e45d09516d0a3ae0a3f7494b79f5f233a3"},
+    {file = "aiohttp-3.13.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7f9120f7093c2a32d9647abcaf21e6ad275b4fbec5b55969f978b1a97c7c86bf"},
+    {file = "aiohttp-3.13.3-cp313-cp313-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:697753042d57f4bf7122cab985bf15d0cef23c770864580f5af4f52023a56bd6"},
+    {file = "aiohttp-3.13.3-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:6de499a1a44e7de70735d0b39f67c8f25eb3d91eb3103be99ca0fa882cdd987d"},
+    {file = "aiohttp-3.13.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:37239e9f9a7ea9ac5bf6b92b0260b01f8a22281996da609206a84df860bc1261"},
+    {file = "aiohttp-3.13.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f76c1e3fe7d7c8afad7ed193f89a292e1999608170dcc9751a7462a87dfd5bc0"},
+    {file = "aiohttp-3.13.3-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:fc290605db2a917f6e81b0e1e0796469871f5af381ce15c604a3c5c7e51cb730"},
+    {file = "aiohttp-3.13.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:4021b51936308aeea0367b8f006dc999ca02bc118a0cc78c303f50a2ff6afb91"},
+    {file = "aiohttp-3.13.3-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:49a03727c1bba9a97d3e93c9f93ca03a57300f484b6e935463099841261195d3"},
+    {file = "aiohttp-3.13.3-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:3d9908a48eb7416dc1f4524e69f1d32e5d90e3981e4e37eb0aa1cd18f9cfa2a4"},
+    {file = "aiohttp-3.13.3-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:2712039939ec963c237286113c68dbad80a82a4281543f3abf766d9d73228998"},
+    {file = "aiohttp-3.13.3-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:7bfdc049127717581866fa4708791220970ce291c23e28ccf3922c700740fdc0"},
+    {file = "aiohttp-3.13.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8057c98e0c8472d8846b9c79f56766bcc57e3e8ac7bfd510482332366c56c591"},
+    {file = "aiohttp-3.13.3-cp313-cp313-win32.whl", hash = "sha256:1449ceddcdbcf2e0446957863af03ebaaa03f94c090f945411b61269e2cb5daf"},
+    {file = "aiohttp-3.13.3-cp313-cp313-win_amd64.whl", hash = "sha256:693781c45a4033d31d4187d2436f5ac701e7bbfe5df40d917736108c1cc7436e"},
+    {file = "aiohttp-3.13.3-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:ea37047c6b367fd4bd632bff8077449b8fa034b69e812a18e0132a00fae6e808"},
+    {file = "aiohttp-3.13.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:6fc0e2337d1a4c3e6acafda6a78a39d4c14caea625124817420abceed36e2415"},
+    {file = "aiohttp-3.13.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c685f2d80bb67ca8c3837823ad76196b3694b0159d232206d1e461d3d434666f"},
+    {file = "aiohttp-3.13.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:48e377758516d262bde50c2584fc6c578af272559c409eecbdd2bae1601184d6"},
+    {file = "aiohttp-3.13.3-cp314-cp314-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:34749271508078b261c4abb1767d42b8d0c0cc9449c73a4df494777dc55f0687"},
+    {file = "aiohttp-3.13.3-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:82611aeec80eb144416956ec85b6ca45a64d76429c1ed46ae1b5f86c6e0c9a26"},
+    {file = "aiohttp-3.13.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:2fff83cfc93f18f215896e3a190e8e5cb413ce01553901aca925176e7568963a"},
+    {file = "aiohttp-3.13.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bbe7d4cecacb439e2e2a8a1a7b935c25b812af7a5fd26503a66dadf428e79ec1"},
+    {file = "aiohttp-3.13.3-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b928f30fe49574253644b1ca44b1b8adbd903aa0da4b9054a6c20fc7f4092a25"},
+    {file = "aiohttp-3.13.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7b5e8fe4de30df199155baaf64f2fcd604f4c678ed20910db8e2c66dc4b11603"},
+    {file = "aiohttp-3.13.3-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:8542f41a62bcc58fc7f11cf7c90e0ec324ce44950003feb70640fc2a9092c32a"},
+    {file = "aiohttp-3.13.3-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:5e1d8c8b8f1d91cd08d8f4a3c2b067bfca6ec043d3ff36de0f3a715feeedf926"},
+    {file = "aiohttp-3.13.3-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:90455115e5da1c3c51ab619ac57f877da8fd6d73c05aacd125c5ae9819582aba"},
+    {file = "aiohttp-3.13.3-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:042e9e0bcb5fba81886c8b4fbb9a09d6b8a00245fd8d88e4d989c1f96c74164c"},
+    {file = "aiohttp-3.13.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2eb752b102b12a76ca02dff751a801f028b4ffbbc478840b473597fc91a9ed43"},
+    {file = "aiohttp-3.13.3-cp314-cp314-win32.whl", hash = "sha256:b556c85915d8efaed322bf1bdae9486aa0f3f764195a0fb6ee962e5c71ef5ce1"},
+    {file = "aiohttp-3.13.3-cp314-cp314-win_amd64.whl", hash = "sha256:9bf9f7a65e7aa20dd764151fb3d616c81088f91f8df39c3893a536e279b4b984"},
+    {file = "aiohttp-3.13.3-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:05861afbbec40650d8a07ea324367cb93e9e8cc7762e04dd4405df99fa65159c"},
+    {file = "aiohttp-3.13.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:2fc82186fadc4a8316768d61f3722c230e2c1dcab4200d52d2ebdf2482e47592"},
+    {file = "aiohttp-3.13.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:0add0900ff220d1d5c5ebbf99ed88b0c1bbf87aa7e4262300ed1376a6b13414f"},
+    {file = "aiohttp-3.13.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:568f416a4072fbfae453dcf9a99194bbb8bdeab718e08ee13dfa2ba0e4bebf29"},
+    {file = "aiohttp-3.13.3-cp314-cp314t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:add1da70de90a2569c5e15249ff76a631ccacfe198375eead4aadf3b8dc849dc"},
+    {file = "aiohttp-3.13.3-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:10b47b7ba335d2e9b1239fa571131a87e2d8ec96b333e68b2a305e7a98b0bae2"},
+    {file = "aiohttp-3.13.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:3dd4dce1c718e38081c8f35f323209d4c1df7d4db4bab1b5c88a6b4d12b74587"},
+    {file = "aiohttp-3.13.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:34bac00a67a812570d4a460447e1e9e06fae622946955f939051e7cc895cfab8"},
+    {file = "aiohttp-3.13.3-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a19884d2ee70b06d9204b2727a7b9f983d0c684c650254679e716b0b77920632"},
+    {file = "aiohttp-3.13.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:5f8ca7f2bb6ba8348a3614c7918cc4bb73268c5ac2a207576b7afea19d3d9f64"},
+    {file = "aiohttp-3.13.3-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:b0d95340658b9d2f11d9697f59b3814a9d3bb4b7a7c20b131df4bcef464037c0"},
+    {file = "aiohttp-3.13.3-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:a1e53262fd202e4b40b70c3aff944a8155059beedc8a89bba9dc1f9ef06a1b56"},
+    {file = "aiohttp-3.13.3-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:d60ac9663f44168038586cab2157e122e46bdef09e9368b37f2d82d354c23f72"},
+    {file = "aiohttp-3.13.3-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:90751b8eed69435bac9ff4e3d2f6b3af1f57e37ecb0fbeee59c0174c9e2d41df"},
+    {file = "aiohttp-3.13.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:fc353029f176fd2b3ec6cfc71be166aba1936fe5d73dd1992ce289ca6647a9aa"},
+    {file = "aiohttp-3.13.3-cp314-cp314t-win32.whl", hash = "sha256:2e41b18a58da1e474a057b3d35248d8320029f61d70a37629535b16a0c8f3767"},
+    {file = "aiohttp-3.13.3-cp314-cp314t-win_amd64.whl", hash = "sha256:44531a36aa2264a1860089ffd4dce7baf875ee5a6079d5fb42e261c704ef7344"},
+    {file = "aiohttp-3.13.3-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:31a83ea4aead760dfcb6962efb1d861db48c34379f2ff72db9ddddd4cda9ea2e"},
+    {file = "aiohttp-3.13.3-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:988a8c5e317544fdf0d39871559e67b6341065b87fceac641108c2096d5506b7"},
+    {file = "aiohttp-3.13.3-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:9b174f267b5cfb9a7dba9ee6859cecd234e9a681841eb85068059bc867fb8f02"},
+    {file = "aiohttp-3.13.3-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:947c26539750deeaee933b000fb6517cc770bbd064bad6033f1cff4803881e43"},
+    {file = "aiohttp-3.13.3-cp39-cp39-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:9ebf57d09e131f5323464bd347135a88622d1c0976e88ce15b670e7ad57e4bd6"},
+    {file = "aiohttp-3.13.3-cp39-cp39-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:4ae5b5a0e1926e504c81c5b84353e7a5516d8778fbbff00429fe7b05bb25cbce"},
+    {file = "aiohttp-3.13.3-cp39-cp39-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:2ba0eea45eb5cc3172dbfc497c066f19c41bac70963ea1a67d51fc92e4cf9a80"},
+    {file = "aiohttp-3.13.3-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bae5c2ed2eae26cc382020edad80d01f36cb8e746da40b292e68fec40421dc6a"},
+    {file = "aiohttp-3.13.3-cp39-cp39-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:8a60e60746623925eab7d25823329941aee7242d559baa119ca2b253c88a7bd6"},
+    {file = "aiohttp-3.13.3-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:e50a2e1404f063427c9d027378472316201a2290959a295169bcf25992d04558"},
+    {file = "aiohttp-3.13.3-cp39-cp39-musllinux_1_2_armv7l.whl", hash = "sha256:9a9dc347e5a3dc7dfdbc1f82da0ef29e388ddb2ed281bfce9dd8248a313e62b7"},
+    {file = "aiohttp-3.13.3-cp39-cp39-musllinux_1_2_ppc64le.whl", hash = "sha256:b46020d11d23fe16551466c77823df9cc2f2c1e63cc965daf67fa5eec6ca1877"},
+    {file = "aiohttp-3.13.3-cp39-cp39-musllinux_1_2_riscv64.whl", hash = "sha256:69c56fbc1993fa17043e24a546959c0178fe2b5782405ad4559e6c13975c15e3"},
+    {file = "aiohttp-3.13.3-cp39-cp39-musllinux_1_2_s390x.whl", hash = "sha256:b99281b0704c103d4e11e72a76f1b543d4946fea7dd10767e7e1b5f00d4e5704"},
+    {file = "aiohttp-3.13.3-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:40c5e40ecc29ba010656c18052b877a1c28f84344825efa106705e835c28530f"},
+    {file = "aiohttp-3.13.3-cp39-cp39-win32.whl", hash = "sha256:56339a36b9f1fc708260c76c87e593e2afb30d26de9ae1eb445b5e051b98a7a1"},
+    {file = "aiohttp-3.13.3-cp39-cp39-win_amd64.whl", hash = "sha256:c6b8568a3bb5819a0ad087f16d40e5a3fb6099f39ea1d5625a3edc1e923fc538"},
+    {file = "aiohttp-3.13.3.tar.gz", hash = "sha256:a949eee43d3782f2daae4f4a2819b2cb9b0c5d3b7f7a927067cc84dafdbb9f88"},
+]
+
+[package.dependencies]
+aiohappyeyeballs = ">=2.5.0"
+aiosignal = ">=1.4.0"
+async-timeout = {version = ">=4.0,<6.0", markers = "python_version < \"3.11\""}
+attrs = ">=17.3.0"
+frozenlist = ">=1.1.1"
+multidict = ">=4.5,<7.0"
+propcache = ">=0.2.0"
+yarl = ">=1.17.0,<2.0"
+
+[package.extras]
+speedups = ["Brotli (>=1.2) ; platform_python_implementation == \"CPython\"", "aiodns (>=3.3.0)", "backports.zstd ; platform_python_implementation == \"CPython\" and python_version < \"3.14\"", "brotlicffi (>=1.2) ; platform_python_implementation != \"CPython\""]
+
+[[package]]
+name = "aiosignal"
+version = "1.4.0"
+description = "aiosignal: a list of registered asynchronous callbacks"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "aiosignal-1.4.0-py3-none-any.whl", hash = "sha256:053243f8b92b990551949e63930a839ff0cf0b0ebbe0597b0f3fb19e1a0fe82e"},
+    {file = "aiosignal-1.4.0.tar.gz", hash = "sha256:f47eecd9468083c2029cc99945502cb7708b082c232f9aca65da147157b251c7"},
+]
+
+[package.dependencies]
+frozenlist = ">=1.1.0"
+typing-extensions = {version = ">=4.2", markers = "python_version < \"3.13\""}
+
+[[package]]
 name = "ale-py"
 version = "0.11.2"
 description = "The Arcade Learning Environment (ALE) - a platform for AI research."
@@ -56,6 +227,18 @@ typing-extensions = {version = "*", markers = "python_version < \"3.11\""}
 test = ["chex ; python_version > \"3.9\" and (sys_platform == \"win32\" or sys_platform == \"linux\")", "gymnasium (>=1.1.0)", "jax (>=0.4.31) ; python_version > \"3.9\" and (sys_platform == \"win32\" or sys_platform == \"linux\")", "opencv-python (>=3.0)", "pytest (>=7.0)"]
 vector = ["gymnasium (>=1.1.0)", "opencv-python (>=3.0)"]
 xla = ["gymnasium (>=1.1.0)", "jax (>=0.4.31) ; python_version > \"3.9\" and (sys_platform == \"win32\" or sys_platform == \"linux\")", "opencv-python (>=3.0)"]
+
+[[package]]
+name = "async-timeout"
+version = "5.0.1"
+description = "Timeout context manager for asyncio programs"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "async_timeout-5.0.1-py3-none-any.whl", hash = "sha256:39e3809566ff85354557ec2398b55e096c8364bacac9405a7a1fa429e77fe76c"},
+    {file = "async_timeout-5.0.1.tar.gz", hash = "sha256:d9321a7a3d5a6a5e187e824d2fa0793ce379a202935782d555d6e9d2735677d3"},
+]
 
 [[package]]
 name = "attrs"
@@ -392,6 +575,60 @@ tomli = {version = "*", optional = true, markers = "python_full_version <= \"3.1
 toml = ["tomli ; python_full_version <= \"3.11.0a6\""]
 
 [[package]]
+name = "cuda-bindings"
+version = "12.9.4"
+description = "Python bindings for CUDA"
+optional = false
+python-versions = "*"
+groups = ["main"]
+markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""
+files = [
+    {file = "cuda_bindings-12.9.4-cp310-cp310-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a022c96b8bd847e8dc0675523431149a4c3e872f440e3002213dbb9e08f0331a"},
+    {file = "cuda_bindings-12.9.4-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4d3c842c2a4303b2a580fe955018e31aea30278be19795ae05226235268032e5"},
+    {file = "cuda_bindings-12.9.4-cp310-cp310-win_amd64.whl", hash = "sha256:f69107389e6b9948969bfd0a20c4f571fd1aefcfb1d2e1b72cc8ba5ecb7918ab"},
+    {file = "cuda_bindings-12.9.4-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a6a429dc6c13148ff1e27c44f40a3dd23203823e637b87fd0854205195988306"},
+    {file = "cuda_bindings-12.9.4-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c912a3d9e6b6651853eed8eed96d6800d69c08e94052c292fec3f282c5a817c9"},
+    {file = "cuda_bindings-12.9.4-cp311-cp311-win_amd64.whl", hash = "sha256:443b0875916879c2e4c3722941e25e42d5ab9bcbf34c9e83404fb100fa1f6913"},
+    {file = "cuda_bindings-12.9.4-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:694ba35023846625ef471257e6b5a4bc8af690f961d197d77d34b1d1db393f56"},
+    {file = "cuda_bindings-12.9.4-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fda147a344e8eaeca0c6ff113d2851ffca8f7dfc0a6c932374ee5c47caa649c8"},
+    {file = "cuda_bindings-12.9.4-cp312-cp312-win_amd64.whl", hash = "sha256:696ca75d249ddf287d01b9a698b8e2d8a05046495a9c051ca15659dc52d17615"},
+    {file = "cuda_bindings-12.9.4-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cf8bfaedc238f3b115d957d1fd6562b7e8435ba57f6d0e2f87d0e7149ccb2da5"},
+    {file = "cuda_bindings-12.9.4-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:32bdc5a76906be4c61eb98f546a6786c5773a881f3b166486449b5d141e4a39f"},
+    {file = "cuda_bindings-12.9.4-cp313-cp313-win_amd64.whl", hash = "sha256:a2e82c8985948f953c2be51df45c3fe11c812a928fca525154fb9503190b3e64"},
+    {file = "cuda_bindings-12.9.4-cp313-cp313t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3adf4958dcf68ae7801a59b73fb00a8b37f8d0595060d66ceae111b1002de38d"},
+    {file = "cuda_bindings-12.9.4-cp313-cp313t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:56e0043c457a99ac473ddc926fe0dc4046694d99caef633e92601ab52cbe17eb"},
+    {file = "cuda_bindings-12.9.4-cp313-cp313t-win_amd64.whl", hash = "sha256:b32d8b685f0e66f5658bcf4601ef034e89fc2843582886f0a58784a4302da06c"},
+    {file = "cuda_bindings-12.9.4-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1f53a7f453d4b2643d8663d036bafe29b5ba89eb904c133180f295df6dc151e5"},
+    {file = "cuda_bindings-12.9.4-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8b72ee72a9cc1b531db31eebaaee5c69a8ec3500e32c6933f2d3b15297b53686"},
+    {file = "cuda_bindings-12.9.4-cp314-cp314-win_amd64.whl", hash = "sha256:53a10c71fdbdb743e0268d07964e5a996dd00b4e43831cbfce9804515d97d575"},
+    {file = "cuda_bindings-12.9.4-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:20f2699d61d724de3eb3f3369d57e2b245f93085cab44fd37c3bea036cea1a6f"},
+    {file = "cuda_bindings-12.9.4-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d80bffc357df9988dca279734bc9674c3934a654cab10cadeed27ce17d8635ee"},
+    {file = "cuda_bindings-12.9.4-cp314-cp314t-win_amd64.whl", hash = "sha256:53e11991a92ff6f26a0c8a98554cd5d6721c308a6b7bfb08bebac9201e039e43"},
+    {file = "cuda_bindings-12.9.4-cp39-cp39-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:893ca68114b5b769c1d4c02583b91ed22691887c3ed513b59467d23540104db4"},
+    {file = "cuda_bindings-12.9.4-cp39-cp39-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9866ceec83e39337d1a1d64837864c964ad902992478caa288a0bc1be95f21aa"},
+    {file = "cuda_bindings-12.9.4-cp39-cp39-win_amd64.whl", hash = "sha256:37744e721a18a514423e81863f52a4f7f46f5a6f9cccd569f2735f8067f4d8c2"},
+]
+
+[package.dependencies]
+cuda-pathfinder = ">=1.1,<2.0"
+
+[package.extras]
+all = ["nvidia-cuda-nvcc-cu12", "nvidia-cuda-nvrtc-cu12", "nvidia-cufile-cu12 ; sys_platform == \"linux\"", "nvidia-nvjitlink-cu12 (>=12.3)"]
+test = ["cython (>=3.1,<3.2)", "numpy (>=1.21.1)", "pyglet (>=2.1.9)", "pytest (>=6.2.4)", "pytest-benchmark (>=3.4.1)", "setuptools (>=77.0.0)"]
+
+[[package]]
+name = "cuda-pathfinder"
+version = "1.3.3"
+description = "Pathfinder for CUDA components"
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""
+files = [
+    {file = "cuda_pathfinder-1.3.3-py3-none-any.whl", hash = "sha256:9984b664e404f7c134954a771be8775dfd6180ea1e1aef4a5a37d4be05d9bbb1"},
+]
+
+[[package]]
 name = "distlib"
 version = "0.4.0"
 description = "Distribution utilities"
@@ -506,6 +743,146 @@ files = [
 ]
 
 [[package]]
+name = "frozenlist"
+version = "1.8.0"
+description = "A list-like structure which implements collections.abc.MutableSequence"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "frozenlist-1.8.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:b37f6d31b3dcea7deb5e9696e529a6aa4a898adc33db82da12e4c60a7c4d2011"},
+    {file = "frozenlist-1.8.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:ef2b7b394f208233e471abc541cc6991f907ffd47dc72584acee3147899d6565"},
+    {file = "frozenlist-1.8.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:a88f062f072d1589b7b46e951698950e7da00442fc1cacbe17e19e025dc327ad"},
+    {file = "frozenlist-1.8.0-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:f57fb59d9f385710aa7060e89410aeb5058b99e62f4d16b08b91986b9a2140c2"},
+    {file = "frozenlist-1.8.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:799345ab092bee59f01a915620b5d014698547afd011e691a208637312db9186"},
+    {file = "frozenlist-1.8.0-cp310-cp310-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:c23c3ff005322a6e16f71bf8692fcf4d5a304aaafe1e262c98c6d4adc7be863e"},
+    {file = "frozenlist-1.8.0-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:8a76ea0f0b9dfa06f254ee06053d93a600865b3274358ca48a352ce4f0798450"},
+    {file = "frozenlist-1.8.0-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:c7366fe1418a6133d5aa824ee53d406550110984de7637d65a178010f759c6ef"},
+    {file = "frozenlist-1.8.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:13d23a45c4cebade99340c4165bd90eeb4a56c6d8a9d8aa49568cac19a6d0dc4"},
+    {file = "frozenlist-1.8.0-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:e4a3408834f65da56c83528fb52ce7911484f0d1eaf7b761fc66001db1646eff"},
+    {file = "frozenlist-1.8.0-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:42145cd2748ca39f32801dad54aeea10039da6f86e303659db90db1c4b614c8c"},
+    {file = "frozenlist-1.8.0-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:e2de870d16a7a53901e41b64ffdf26f2fbb8917b3e6ebf398098d72c5b20bd7f"},
+    {file = "frozenlist-1.8.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:20e63c9493d33ee48536600d1a5c95eefc870cd71e7ab037763d1fbb89cc51e7"},
+    {file = "frozenlist-1.8.0-cp310-cp310-win32.whl", hash = "sha256:adbeebaebae3526afc3c96fad434367cafbfd1b25d72369a9e5858453b1bb71a"},
+    {file = "frozenlist-1.8.0-cp310-cp310-win_amd64.whl", hash = "sha256:667c3777ca571e5dbeb76f331562ff98b957431df140b54c85fd4d52eea8d8f6"},
+    {file = "frozenlist-1.8.0-cp310-cp310-win_arm64.whl", hash = "sha256:80f85f0a7cc86e7a54c46d99c9e1318ff01f4687c172ede30fd52d19d1da1c8e"},
+    {file = "frozenlist-1.8.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:09474e9831bc2b2199fad6da3c14c7b0fbdd377cce9d3d77131be28906cb7d84"},
+    {file = "frozenlist-1.8.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:17c883ab0ab67200b5f964d2b9ed6b00971917d5d8a92df149dc2c9779208ee9"},
+    {file = "frozenlist-1.8.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:fa47e444b8ba08fffd1c18e8cdb9a75db1b6a27f17507522834ad13ed5922b93"},
+    {file = "frozenlist-1.8.0-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:2552f44204b744fba866e573be4c1f9048d6a324dfe14475103fd51613eb1d1f"},
+    {file = "frozenlist-1.8.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:957e7c38f250991e48a9a73e6423db1bb9dd14e722a10f6b8bb8e16a0f55f695"},
+    {file = "frozenlist-1.8.0-cp311-cp311-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:8585e3bb2cdea02fc88ffa245069c36555557ad3609e83be0ec71f54fd4abb52"},
+    {file = "frozenlist-1.8.0-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:edee74874ce20a373d62dc28b0b18b93f645633c2943fd90ee9d898550770581"},
+    {file = "frozenlist-1.8.0-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:c9a63152fe95756b85f31186bddf42e4c02c6321207fd6601a1c89ebac4fe567"},
+    {file = "frozenlist-1.8.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:b6db2185db9be0a04fecf2f241c70b63b1a242e2805be291855078f2b404dd6b"},
+    {file = "frozenlist-1.8.0-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:f4be2e3d8bc8aabd566f8d5b8ba7ecc09249d74ba3c9ed52e54dc23a293f0b92"},
+    {file = "frozenlist-1.8.0-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:c8d1634419f39ea6f5c427ea2f90ca85126b54b50837f31497f3bf38266e853d"},
+    {file = "frozenlist-1.8.0-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:1a7fa382a4a223773ed64242dbe1c9c326ec09457e6b8428efb4118c685c3dfd"},
+    {file = "frozenlist-1.8.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:11847b53d722050808926e785df837353bd4d75f1d494377e59b23594d834967"},
+    {file = "frozenlist-1.8.0-cp311-cp311-win32.whl", hash = "sha256:27c6e8077956cf73eadd514be8fb04d77fc946a7fe9f7fe167648b0b9085cc25"},
+    {file = "frozenlist-1.8.0-cp311-cp311-win_amd64.whl", hash = "sha256:ac913f8403b36a2c8610bbfd25b8013488533e71e62b4b4adce9c86c8cea905b"},
+    {file = "frozenlist-1.8.0-cp311-cp311-win_arm64.whl", hash = "sha256:d4d3214a0f8394edfa3e303136d0575eece0745ff2b47bd2cb2e66dd92d4351a"},
+    {file = "frozenlist-1.8.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:78f7b9e5d6f2fdb88cdde9440dc147259b62b9d3b019924def9f6478be254ac1"},
+    {file = "frozenlist-1.8.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:229bf37d2e4acdaf808fd3f06e854a4a7a3661e871b10dc1f8f1896a3b05f18b"},
+    {file = "frozenlist-1.8.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f833670942247a14eafbb675458b4e61c82e002a148f49e68257b79296e865c4"},
+    {file = "frozenlist-1.8.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:494a5952b1c597ba44e0e78113a7266e656b9794eec897b19ead706bd7074383"},
+    {file = "frozenlist-1.8.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:96f423a119f4777a4a056b66ce11527366a8bb92f54e541ade21f2374433f6d4"},
+    {file = "frozenlist-1.8.0-cp312-cp312-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:3462dd9475af2025c31cc61be6652dfa25cbfb56cbbf52f4ccfe029f38decaf8"},
+    {file = "frozenlist-1.8.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c4c800524c9cd9bac5166cd6f55285957fcfc907db323e193f2afcd4d9abd69b"},
+    {file = "frozenlist-1.8.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:d6a5df73acd3399d893dafc71663ad22534b5aa4f94e8a2fabfe856c3c1b6a52"},
+    {file = "frozenlist-1.8.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:405e8fe955c2280ce66428b3ca55e12b3c4e9c336fb2103a4937e891c69a4a29"},
+    {file = "frozenlist-1.8.0-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:908bd3f6439f2fef9e85031b59fd4f1297af54415fb60e4254a95f75b3cab3f3"},
+    {file = "frozenlist-1.8.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:294e487f9ec720bd8ffcebc99d575f7eff3568a08a253d1ee1a0378754b74143"},
+    {file = "frozenlist-1.8.0-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:74c51543498289c0c43656701be6b077f4b265868fa7f8a8859c197006efb608"},
+    {file = "frozenlist-1.8.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:776f352e8329135506a1d6bf16ac3f87bc25b28e765949282dcc627af36123aa"},
+    {file = "frozenlist-1.8.0-cp312-cp312-win32.whl", hash = "sha256:433403ae80709741ce34038da08511d4a77062aa924baf411ef73d1146e74faf"},
+    {file = "frozenlist-1.8.0-cp312-cp312-win_amd64.whl", hash = "sha256:34187385b08f866104f0c0617404c8eb08165ab1272e884abc89c112e9c00746"},
+    {file = "frozenlist-1.8.0-cp312-cp312-win_arm64.whl", hash = "sha256:fe3c58d2f5db5fbd18c2987cba06d51b0529f52bc3a6cdc33d3f4eab725104bd"},
+    {file = "frozenlist-1.8.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:8d92f1a84bb12d9e56f818b3a746f3efba93c1b63c8387a73dde655e1e42282a"},
+    {file = "frozenlist-1.8.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:96153e77a591c8adc2ee805756c61f59fef4cf4073a9275ee86fe8cba41241f7"},
+    {file = "frozenlist-1.8.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f21f00a91358803399890ab167098c131ec2ddd5f8f5fd5fe9c9f2c6fcd91e40"},
+    {file = "frozenlist-1.8.0-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:fb30f9626572a76dfe4293c7194a09fb1fe93ba94c7d4f720dfae3b646b45027"},
+    {file = "frozenlist-1.8.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:eaa352d7047a31d87dafcacbabe89df0aa506abb5b1b85a2fb91bc3faa02d822"},
+    {file = "frozenlist-1.8.0-cp313-cp313-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:03ae967b4e297f58f8c774c7eabcce57fe3c2434817d4385c50661845a058121"},
+    {file = "frozenlist-1.8.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:f6292f1de555ffcc675941d65fffffb0a5bcd992905015f85d0592201793e0e5"},
+    {file = "frozenlist-1.8.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:29548f9b5b5e3460ce7378144c3010363d8035cea44bc0bf02d57f5a685e084e"},
+    {file = "frozenlist-1.8.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:ec3cc8c5d4084591b4237c0a272cc4f50a5b03396a47d9caaf76f5d7b38a4f11"},
+    {file = "frozenlist-1.8.0-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:517279f58009d0b1f2e7c1b130b377a349405da3f7621ed6bfae50b10adf20c1"},
+    {file = "frozenlist-1.8.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:db1e72ede2d0d7ccb213f218df6a078a9c09a7de257c2fe8fcef16d5925230b1"},
+    {file = "frozenlist-1.8.0-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:b4dec9482a65c54a5044486847b8a66bf10c9cb4926d42927ec4e8fd5db7fed8"},
+    {file = "frozenlist-1.8.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:21900c48ae04d13d416f0e1e0c4d81f7931f73a9dfa0b7a8746fb2fe7dd970ed"},
+    {file = "frozenlist-1.8.0-cp313-cp313-win32.whl", hash = "sha256:8b7b94a067d1c504ee0b16def57ad5738701e4ba10cec90529f13fa03c833496"},
+    {file = "frozenlist-1.8.0-cp313-cp313-win_amd64.whl", hash = "sha256:878be833caa6a3821caf85eb39c5ba92d28e85df26d57afb06b35b2efd937231"},
+    {file = "frozenlist-1.8.0-cp313-cp313-win_arm64.whl", hash = "sha256:44389d135b3ff43ba8cc89ff7f51f5a0bb6b63d829c8300f79a2fe4fe61bcc62"},
+    {file = "frozenlist-1.8.0-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:e25ac20a2ef37e91c1b39938b591457666a0fa835c7783c3a8f33ea42870db94"},
+    {file = "frozenlist-1.8.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:07cdca25a91a4386d2e76ad992916a85038a9b97561bf7a3fd12d5d9ce31870c"},
+    {file = "frozenlist-1.8.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:4e0c11f2cc6717e0a741f84a527c52616140741cd812a50422f83dc31749fb52"},
+    {file = "frozenlist-1.8.0-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:b3210649ee28062ea6099cfda39e147fa1bc039583c8ee4481cb7811e2448c51"},
+    {file = "frozenlist-1.8.0-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:581ef5194c48035a7de2aefc72ac6539823bb71508189e5de01d60c9dcd5fa65"},
+    {file = "frozenlist-1.8.0-cp313-cp313t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:3ef2d026f16a2b1866e1d86fc4e1291e1ed8a387b2c333809419a2f8b3a77b82"},
+    {file = "frozenlist-1.8.0-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:5500ef82073f599ac84d888e3a8c1f77ac831183244bfd7f11eaa0289fb30714"},
+    {file = "frozenlist-1.8.0-cp313-cp313t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:50066c3997d0091c411a66e710f4e11752251e6d2d73d70d8d5d4c76442a199d"},
+    {file = "frozenlist-1.8.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:5c1c8e78426e59b3f8005e9b19f6ff46e5845895adbde20ece9218319eca6506"},
+    {file = "frozenlist-1.8.0-cp313-cp313t-musllinux_1_2_armv7l.whl", hash = "sha256:eefdba20de0d938cec6a89bd4d70f346a03108a19b9df4248d3cf0d88f1b0f51"},
+    {file = "frozenlist-1.8.0-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:cf253e0e1c3ceb4aaff6df637ce033ff6535fb8c70a764a8f46aafd3d6ab798e"},
+    {file = "frozenlist-1.8.0-cp313-cp313t-musllinux_1_2_s390x.whl", hash = "sha256:032efa2674356903cd0261c4317a561a6850f3ac864a63fc1583147fb05a79b0"},
+    {file = "frozenlist-1.8.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:6da155091429aeba16851ecb10a9104a108bcd32f6c1642867eadaee401c1c41"},
+    {file = "frozenlist-1.8.0-cp313-cp313t-win32.whl", hash = "sha256:0f96534f8bfebc1a394209427d0f8a63d343c9779cda6fc25e8e121b5fd8555b"},
+    {file = "frozenlist-1.8.0-cp313-cp313t-win_amd64.whl", hash = "sha256:5d63a068f978fc69421fb0e6eb91a9603187527c86b7cd3f534a5b77a592b888"},
+    {file = "frozenlist-1.8.0-cp313-cp313t-win_arm64.whl", hash = "sha256:bf0a7e10b077bf5fb9380ad3ae8ce20ef919a6ad93b4552896419ac7e1d8e042"},
+    {file = "frozenlist-1.8.0-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:cee686f1f4cadeb2136007ddedd0aaf928ab95216e7691c63e50a8ec066336d0"},
+    {file = "frozenlist-1.8.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:119fb2a1bd47307e899c2fac7f28e85b9a543864df47aa7ec9d3c1b4545f096f"},
+    {file = "frozenlist-1.8.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:4970ece02dbc8c3a92fcc5228e36a3e933a01a999f7094ff7c23fbd2beeaa67c"},
+    {file = "frozenlist-1.8.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:cba69cb73723c3f329622e34bdbf5ce1f80c21c290ff04256cff1cd3c2036ed2"},
+    {file = "frozenlist-1.8.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:778a11b15673f6f1df23d9586f83c4846c471a8af693a22e066508b77d201ec8"},
+    {file = "frozenlist-1.8.0-cp314-cp314-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:0325024fe97f94c41c08872db482cf8ac4800d80e79222c6b0b7b162d5b13686"},
+    {file = "frozenlist-1.8.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:97260ff46b207a82a7567b581ab4190bd4dfa09f4db8a8b49d1a958f6aa4940e"},
+    {file = "frozenlist-1.8.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:54b2077180eb7f83dd52c40b2750d0a9f175e06a42e3213ce047219de902717a"},
+    {file = "frozenlist-1.8.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:2f05983daecab868a31e1da44462873306d3cbfd76d1f0b5b69c473d21dbb128"},
+    {file = "frozenlist-1.8.0-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:33f48f51a446114bc5d251fb2954ab0164d5be02ad3382abcbfe07e2531d650f"},
+    {file = "frozenlist-1.8.0-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:154e55ec0655291b5dd1b8731c637ecdb50975a2ae70c606d100750a540082f7"},
+    {file = "frozenlist-1.8.0-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:4314debad13beb564b708b4a496020e5306c7333fa9a3ab90374169a20ffab30"},
+    {file = "frozenlist-1.8.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:073f8bf8becba60aa931eb3bc420b217bb7d5b8f4750e6f8b3be7f3da85d38b7"},
+    {file = "frozenlist-1.8.0-cp314-cp314-win32.whl", hash = "sha256:bac9c42ba2ac65ddc115d930c78d24ab8d4f465fd3fc473cdedfccadb9429806"},
+    {file = "frozenlist-1.8.0-cp314-cp314-win_amd64.whl", hash = "sha256:3e0761f4d1a44f1d1a47996511752cf3dcec5bbdd9cc2b4fe595caf97754b7a0"},
+    {file = "frozenlist-1.8.0-cp314-cp314-win_arm64.whl", hash = "sha256:d1eaff1d00c7751b7c6662e9c5ba6eb2c17a2306ba5e2a37f24ddf3cc953402b"},
+    {file = "frozenlist-1.8.0-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:d3bb933317c52d7ea5004a1c442eef86f426886fba134ef8cf4226ea6ee1821d"},
+    {file = "frozenlist-1.8.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:8009897cdef112072f93a0efdce29cd819e717fd2f649ee3016efd3cd885a7ed"},
+    {file = "frozenlist-1.8.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:2c5dcbbc55383e5883246d11fd179782a9d07a986c40f49abe89ddf865913930"},
+    {file = "frozenlist-1.8.0-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:39ecbc32f1390387d2aa4f5a995e465e9e2f79ba3adcac92d68e3e0afae6657c"},
+    {file = "frozenlist-1.8.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:92db2bf818d5cc8d9c1f1fc56b897662e24ea5adb36ad1f1d82875bd64e03c24"},
+    {file = "frozenlist-1.8.0-cp314-cp314t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:2dc43a022e555de94c3b68a4ef0b11c4f747d12c024a520c7101709a2144fb37"},
+    {file = "frozenlist-1.8.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:cb89a7f2de3602cfed448095bab3f178399646ab7c61454315089787df07733a"},
+    {file = "frozenlist-1.8.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:33139dc858c580ea50e7e60a1b0ea003efa1fd42e6ec7fdbad78fff65fad2fd2"},
+    {file = "frozenlist-1.8.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:168c0969a329b416119507ba30b9ea13688fafffac1b7822802537569a1cb0ef"},
+    {file = "frozenlist-1.8.0-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:28bd570e8e189d7f7b001966435f9dac6718324b5be2990ac496cf1ea9ddb7fe"},
+    {file = "frozenlist-1.8.0-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:b2a095d45c5d46e5e79ba1e5b9cb787f541a8dee0433836cea4b96a2c439dcd8"},
+    {file = "frozenlist-1.8.0-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:eab8145831a0d56ec9c4139b6c3e594c7a83c2c8be25d5bcf2d86136a532287a"},
+    {file = "frozenlist-1.8.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:974b28cf63cc99dfb2188d8d222bc6843656188164848c4f679e63dae4b0708e"},
+    {file = "frozenlist-1.8.0-cp314-cp314t-win32.whl", hash = "sha256:342c97bf697ac5480c0a7ec73cd700ecfa5a8a40ac923bd035484616efecc2df"},
+    {file = "frozenlist-1.8.0-cp314-cp314t-win_amd64.whl", hash = "sha256:06be8f67f39c8b1dc671f5d83aaefd3358ae5cdcf8314552c57e7ed3e6475bdd"},
+    {file = "frozenlist-1.8.0-cp314-cp314t-win_arm64.whl", hash = "sha256:102e6314ca4da683dca92e3b1355490fed5f313b768500084fbe6371fddfdb79"},
+    {file = "frozenlist-1.8.0-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:d8b7138e5cd0647e4523d6685b0eac5d4be9a184ae9634492f25c6eb38c12a47"},
+    {file = "frozenlist-1.8.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:a6483e309ca809f1efd154b4d37dc6d9f61037d6c6a81c2dc7a15cb22c8c5dca"},
+    {file = "frozenlist-1.8.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:1b9290cf81e95e93fdf90548ce9d3c1211cf574b8e3f4b3b7cb0537cf2227068"},
+    {file = "frozenlist-1.8.0-cp39-cp39-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:59a6a5876ca59d1b63af8cd5e7ffffb024c3dc1e9cf9301b21a2e76286505c95"},
+    {file = "frozenlist-1.8.0-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6dc4126390929823e2d2d9dc79ab4046ed74680360fc5f38b585c12c66cdf459"},
+    {file = "frozenlist-1.8.0-cp39-cp39-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:332db6b2563333c5671fecacd085141b5800cb866be16d5e3eb15a2086476675"},
+    {file = "frozenlist-1.8.0-cp39-cp39-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:9ff15928d62a0b80bb875655c39bf517938c7d589554cbd2669be42d97c2cb61"},
+    {file = "frozenlist-1.8.0-cp39-cp39-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:7bf6cdf8e07c8151fba6fe85735441240ec7f619f935a5205953d58009aef8c6"},
+    {file = "frozenlist-1.8.0-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:48e6d3f4ec5c7273dfe83ff27c91083c6c9065af655dc2684d2c200c94308bb5"},
+    {file = "frozenlist-1.8.0-cp39-cp39-musllinux_1_2_armv7l.whl", hash = "sha256:1a7607e17ad33361677adcd1443edf6f5da0ce5e5377b798fba20fae194825f3"},
+    {file = "frozenlist-1.8.0-cp39-cp39-musllinux_1_2_ppc64le.whl", hash = "sha256:5a3a935c3a4e89c733303a2d5a7c257ea44af3a56c8202df486b7f5de40f37e1"},
+    {file = "frozenlist-1.8.0-cp39-cp39-musllinux_1_2_s390x.whl", hash = "sha256:940d4a017dbfed9daf46a3b086e1d2167e7012ee297fef9e1c545c4d022f5178"},
+    {file = "frozenlist-1.8.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:b9be22a69a014bc47e78072d0ecae716f5eb56c15238acca0f43d6eb8e4a5bda"},
+    {file = "frozenlist-1.8.0-cp39-cp39-win32.whl", hash = "sha256:1aa77cb5697069af47472e39612976ed05343ff2e84a3dcf15437b232cbfd087"},
+    {file = "frozenlist-1.8.0-cp39-cp39-win_amd64.whl", hash = "sha256:7398c222d1d405e796970320036b1b563892b65809d9e5261487bb2c7f7b5c6a"},
+    {file = "frozenlist-1.8.0-cp39-cp39-win_arm64.whl", hash = "sha256:b4f3b365f31c6cd4af24545ca0a244a53688cad8834e32f56831c4923b50a103"},
+    {file = "frozenlist-1.8.0-py3-none-any.whl", hash = "sha256:0c18a16eab41e82c295618a77502e17b195883241c563b00f0aa5106fc4eaa0d"},
+    {file = "frozenlist-1.8.0.tar.gz", hash = "sha256:3ede829ed8d842f6cd48fc7081d7a41001a56f1f38603f9d49bf3020d59a31ad"},
+]
+
+[[package]]
 name = "fsspec"
 version = "2025.9.0"
 description = "File-system specification"
@@ -516,6 +893,9 @@ files = [
     {file = "fsspec-2025.9.0-py3-none-any.whl", hash = "sha256:530dc2a2af60a414a832059574df4a6e10cce927f6f4a78209390fe38955cfb7"},
     {file = "fsspec-2025.9.0.tar.gz", hash = "sha256:19fd429483d25d28b65ec68f9f4adc16c17ea2c7c7bf54ec61360d478fb19c19"},
 ]
+
+[package.dependencies]
+aiohttp = {version = "<4.0.0a0 || >4.0.0a0,<4.0.0a1 || >4.0.0a1", optional = true, markers = "extra == \"http\""}
 
 [package.extras]
 abfs = ["adlfs"]
@@ -734,6 +1114,24 @@ files = [
 ]
 
 [[package]]
+name = "jinja2"
+version = "3.1.6"
+description = "A very fast and expressive template engine."
+optional = false
+python-versions = ">=3.7"
+groups = ["main"]
+files = [
+    {file = "jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67"},
+    {file = "jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d"},
+]
+
+[package.dependencies]
+MarkupSafe = ">=2.0"
+
+[package.extras]
+i18n = ["Babel (>=2.7)"]
+
+[[package]]
 name = "jsonschema"
 version = "4.25.1"
 description = "An implementation of JSON Schema validation for Python"
@@ -769,6 +1167,189 @@ files = [
 
 [package.dependencies]
 referencing = ">=0.31.0"
+
+[[package]]
+name = "lightning"
+version = "2.6.1"
+description = "The Deep Learning framework to train, deploy, and ship AI products Lightning fast."
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+files = [
+    {file = "lightning-2.6.1-py3-none-any.whl", hash = "sha256:30e1adac23004c713663928541bd72ecb1371b7abc9aff9f46b7fd2644988d30"},
+    {file = "lightning-2.6.1.tar.gz", hash = "sha256:859104b98c61add6fe60d0c623abf749baf25f2950a66ebdfb4bd18aa7decba9"},
+]
+
+[package.dependencies]
+fsspec = {version = ">=2022.5.0,<2028.0", extras = ["http"]}
+lightning-utilities = ">=0.10.0,<2.0"
+packaging = ">=23.0,<27.0"
+pytorch-lightning = "*"
+PyYAML = ">5.4,<8.0"
+torch = ">=2.1.0,<4.0"
+torchmetrics = ">0.7.0,<3.0"
+tqdm = ">=4.57.0,<6.0"
+typing-extensions = ">4.5.0,<6.0"
+
+[package.extras]
+all = ["bitsandbytes (>=0.45.2,<1.0) ; platform_system != \"Darwin\"", "deepspeed (>=0.15.0,<0.17.0) ; platform_system != \"Windows\" and platform_system != \"Darwin\"", "hydra-core (>=1.2.0,<2.0)", "ipython[all] (>=8.0.0,<11.0)", "jsonargparse[jsonnet,signatures] (>=4.39.0,<5.0)", "matplotlib (>3.1,<4.0)", "omegaconf (>=2.2.3,<3.0)", "requests (<3.0)", "rich (>=12.3.0,<15.0)", "tensorboardX (>=2.2,<3.0)", "torchmetrics (>=0.10.0,<2.0)", "torchvision (>=0.16.0,<1.0)"]
+data = ["litdata (>=0.2.0rc,<1.0)"]
+dev = ["bitsandbytes (>=0.45.2,<1.0) ; platform_system != \"Darwin\"", "click (==8.1.8) ; python_version < \"3.11\"", "click (==8.3.1) ; python_version > \"3.10\"", "cloudpickle (>=1.3,<4.0)", "coverage (==7.10.7) ; python_version < \"3.10\"", "coverage (==7.13.1) ; python_version >= \"3.10\"", "deepspeed (>=0.15.0,<0.17.0) ; platform_system != \"Windows\" and platform_system != \"Darwin\"", "fastapi", "huggingface-hub", "hydra-core (>=1.2.0,<2.0)", "ipython[all] (>=8.0.0,<11.0)", "jsonargparse[jsonnet,signatures] (>=4.39.0,<5.0)", "matplotlib (>3.1,<4.0)", "numpy (>1.21.0,<2.0) ; python_version < \"3.12\"", "numpy (>2.1.0,<3.0) ; python_version >= \"3.12\"", "omegaconf (>=2.2.3,<3.0)", "onnx (>1.12.0,<2.0)", "onnxruntime (>=1.12.0,<2.0)", "onnxscript (>=0.1.0,<1.0)", "pandas (>2.0,<3.0)", "psutil (<8.0)", "pytest (==9.0.2)", "pytest-cov (==7.0.0)", "pytest-random-order (==1.2.0)", "pytest-rerunfailures (==16.0.1) ; python_version < \"3.10\"", "pytest-rerunfailures (==16.1) ; python_version >= \"3.10\"", "pytest-timeout (==2.4.0)", "requests (<3.0)", "rich (>=12.3.0,<15.0)", "scikit-learn (>0.22.1,<2.0)", "tensorboard (>=2.11,<3.0)", "tensorboardX (>=2.2,<3.0)", "tensorboardX (>=2.6,<3.0)", "torch-tensorrt ; platform_system != \"Darwin\" and python_version >= \"3.12\"", "torchmetrics (>=0.10.0,<2.0)", "torchvision (>=0.16.0,<1.0)", "uvicorn"]
+examples = ["ipython[all] (>=8.0.0,<11.0)", "requests (<3.0)", "torchmetrics (>=0.10.0,<2.0)", "torchvision (>=0.16.0,<1.0)"]
+extra = ["bitsandbytes (>=0.45.2,<1.0) ; platform_system != \"Darwin\"", "hydra-core (>=1.2.0,<2.0)", "jsonargparse[jsonnet,signatures] (>=4.39.0,<5.0)", "matplotlib (>3.1,<4.0)", "omegaconf (>=2.2.3,<3.0)", "rich (>=12.3.0,<15.0)", "tensorboardX (>=2.2,<3.0)"]
+fabric-all = ["bitsandbytes (>=0.45.2,<1.0) ; platform_system != \"Darwin\"", "deepspeed (>=0.15.0,<0.17.0) ; platform_system != \"Windows\" and platform_system != \"Darwin\"", "hydra-core (>=1.2.0,<2.0)", "torchmetrics (>=0.10.0,<2.0)", "torchvision (>=0.16.0,<1.0)"]
+fabric-dev = ["bitsandbytes (>=0.45.2,<1.0) ; platform_system != \"Darwin\"", "click (==8.1.8) ; python_version < \"3.11\"", "click (==8.3.1) ; python_version > \"3.10\"", "coverage (==7.10.7) ; python_version < \"3.10\"", "coverage (==7.13.1) ; python_version >= \"3.10\"", "deepspeed (>=0.15.0,<0.17.0) ; platform_system != \"Windows\" and platform_system != \"Darwin\"", "huggingface-hub", "hydra-core (>=1.2.0,<2.0)", "numpy (>1.21.0,<2.0) ; python_version < \"3.12\"", "numpy (>2.1.0,<3.0) ; python_version >= \"3.12\"", "pytest (==9.0.2)", "pytest-cov (==7.0.0)", "pytest-random-order (==1.2.0)", "pytest-rerunfailures (==16.0.1) ; python_version < \"3.10\"", "pytest-rerunfailures (==16.1) ; python_version >= \"3.10\"", "pytest-timeout (==2.4.0)", "tensorboardX (>=2.6,<3.0)", "torchmetrics (>=0.10.0,<2.0)", "torchvision (>=0.16.0,<1.0)"]
+fabric-examples = ["torchmetrics (>=0.10.0,<2.0)", "torchvision (>=0.16.0,<1.0)"]
+fabric-extra = ["hydra-core (>=1.2.0,<2.0)"]
+fabric-strategies = ["bitsandbytes (>=0.45.2,<1.0) ; platform_system != \"Darwin\"", "deepspeed (>=0.15.0,<0.17.0) ; platform_system != \"Windows\" and platform_system != \"Darwin\""]
+fabric-test = ["click (==8.1.8) ; python_version < \"3.11\"", "click (==8.3.1) ; python_version > \"3.10\"", "coverage (==7.10.7) ; python_version < \"3.10\"", "coverage (==7.13.1) ; python_version >= \"3.10\"", "huggingface-hub", "numpy (>1.21.0,<2.0) ; python_version < \"3.12\"", "numpy (>2.1.0,<3.0) ; python_version >= \"3.12\"", "pytest (==9.0.2)", "pytest-cov (==7.0.0)", "pytest-random-order (==1.2.0)", "pytest-rerunfailures (==16.0.1) ; python_version < \"3.10\"", "pytest-rerunfailures (==16.1) ; python_version >= \"3.10\"", "pytest-timeout (==2.4.0)", "tensorboardX (>=2.6,<3.0)"]
+pytorch-all = ["bitsandbytes (>=0.45.2,<1.0) ; platform_system != \"Darwin\"", "deepspeed (>=0.15.0,<0.17.0) ; platform_system != \"Windows\" and platform_system != \"Darwin\"", "hydra-core (>=1.2.0,<2.0)", "ipython[all] (>=8.0.0,<11.0)", "jsonargparse[jsonnet,signatures] (>=4.39.0,<5.0)", "matplotlib (>3.1,<4.0)", "omegaconf (>=2.2.3,<3.0)", "requests (<3.0)", "rich (>=12.3.0,<15.0)", "tensorboardX (>=2.2,<3.0)", "torchmetrics (>=0.10.0,<2.0)", "torchvision (>=0.16.0,<1.0)"]
+pytorch-dev = ["bitsandbytes (>=0.45.2,<1.0) ; platform_system != \"Darwin\"", "cloudpickle (>=1.3,<4.0)", "coverage (==7.10.7) ; python_version < \"3.10\"", "coverage (==7.13.1) ; python_version >= \"3.10\"", "deepspeed (>=0.15.0,<0.17.0) ; platform_system != \"Windows\" and platform_system != \"Darwin\"", "fastapi", "huggingface-hub", "hydra-core (>=1.2.0,<2.0)", "ipython[all] (>=8.0.0,<11.0)", "jsonargparse[jsonnet,signatures] (>=4.39.0,<5.0)", "matplotlib (>3.1,<4.0)", "numpy (>1.21.0,<2.0) ; python_version < \"3.12\"", "numpy (>2.1.0,<3.0) ; python_version >= \"3.12\"", "omegaconf (>=2.2.3,<3.0)", "onnx (>1.12.0,<2.0)", "onnxruntime (>=1.12.0,<2.0)", "onnxscript (>=0.1.0,<1.0)", "pandas (>2.0,<3.0)", "psutil (<8.0)", "pytest (==9.0.2)", "pytest-cov (==7.0.0)", "pytest-random-order (==1.2.0)", "pytest-rerunfailures (==16.0.1) ; python_version < \"3.10\"", "pytest-rerunfailures (==16.1) ; python_version >= \"3.10\"", "pytest-timeout (==2.4.0)", "requests (<3.0)", "rich (>=12.3.0,<15.0)", "scikit-learn (>0.22.1,<2.0)", "tensorboard (>=2.11,<3.0)", "tensorboardX (>=2.2,<3.0)", "torch-tensorrt ; platform_system != \"Darwin\" and python_version >= \"3.12\"", "torchmetrics (>=0.10.0,<2.0)", "torchvision (>=0.16.0,<1.0)", "uvicorn"]
+pytorch-examples = ["ipython[all] (>=8.0.0,<11.0)", "requests (<3.0)", "torchmetrics (>=0.10.0,<2.0)", "torchvision (>=0.16.0,<1.0)"]
+pytorch-extra = ["bitsandbytes (>=0.45.2,<1.0) ; platform_system != \"Darwin\"", "hydra-core (>=1.2.0,<2.0)", "jsonargparse[jsonnet,signatures] (>=4.39.0,<5.0)", "matplotlib (>3.1,<4.0)", "omegaconf (>=2.2.3,<3.0)", "rich (>=12.3.0,<15.0)", "tensorboardX (>=2.2,<3.0)"]
+pytorch-strategies = ["deepspeed (>=0.15.0,<0.17.0) ; platform_system != \"Windows\" and platform_system != \"Darwin\""]
+pytorch-test = ["cloudpickle (>=1.3,<4.0)", "coverage (==7.10.7) ; python_version < \"3.10\"", "coverage (==7.13.1) ; python_version >= \"3.10\"", "fastapi", "huggingface-hub", "numpy (>1.21.0,<2.0) ; python_version < \"3.12\"", "numpy (>2.1.0,<3.0) ; python_version >= \"3.12\"", "onnx (>1.12.0,<2.0)", "onnxruntime (>=1.12.0,<2.0)", "onnxscript (>=0.1.0,<1.0)", "pandas (>2.0,<3.0)", "psutil (<8.0)", "pytest (==9.0.2)", "pytest-cov (==7.0.0)", "pytest-random-order (==1.2.0)", "pytest-rerunfailures (==16.0.1) ; python_version < \"3.10\"", "pytest-rerunfailures (==16.1) ; python_version >= \"3.10\"", "pytest-timeout (==2.4.0)", "scikit-learn (>0.22.1,<2.0)", "tensorboard (>=2.11,<3.0)", "torch-tensorrt ; platform_system != \"Darwin\" and python_version >= \"3.12\"", "uvicorn"]
+strategies = ["bitsandbytes (>=0.45.2,<1.0) ; platform_system != \"Darwin\"", "deepspeed (>=0.15.0,<0.17.0) ; platform_system != \"Windows\" and platform_system != \"Darwin\""]
+test = ["click (==8.1.8) ; python_version < \"3.11\"", "click (==8.3.1) ; python_version > \"3.10\"", "cloudpickle (>=1.3,<4.0)", "coverage (==7.10.7) ; python_version < \"3.10\"", "coverage (==7.13.1) ; python_version >= \"3.10\"", "fastapi", "huggingface-hub", "numpy (>1.21.0,<2.0) ; python_version < \"3.12\"", "numpy (>2.1.0,<3.0) ; python_version >= \"3.12\"", "onnx (>1.12.0,<2.0)", "onnxruntime (>=1.12.0,<2.0)", "onnxscript (>=0.1.0,<1.0)", "pandas (>2.0,<3.0)", "psutil (<8.0)", "pytest (==9.0.2)", "pytest-cov (==7.0.0)", "pytest-random-order (==1.2.0)", "pytest-rerunfailures (==16.0.1) ; python_version < \"3.10\"", "pytest-rerunfailures (==16.1) ; python_version >= \"3.10\"", "pytest-timeout (==2.4.0)", "scikit-learn (>0.22.1,<2.0)", "tensorboard (>=2.11,<3.0)", "tensorboardX (>=2.6,<3.0)", "torch-tensorrt ; platform_system != \"Darwin\" and python_version >= \"3.12\"", "uvicorn"]
+
+[[package]]
+name = "lightning-utilities"
+version = "0.15.2"
+description = "Lightning toolbox for across the our ecosystem."
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "lightning_utilities-0.15.2-py3-none-any.whl", hash = "sha256:ad3ab1703775044bbf880dbf7ddaaac899396c96315f3aa1779cec9d618a9841"},
+    {file = "lightning_utilities-0.15.2.tar.gz", hash = "sha256:cdf12f530214a63dacefd713f180d1ecf5d165338101617b4742e8f22c032e24"},
+]
+
+[package.dependencies]
+packaging = ">=17.1"
+setuptools = "*"
+typing_extensions = "*"
+
+[package.extras]
+cli = ["jsonargparse[signatures] (>=4.38.0)", "tomlkit"]
+docs = ["requests (>=2.0.0)"]
+typing = ["mypy (>=1.0.0)", "types-setuptools"]
+
+[[package]]
+name = "markupsafe"
+version = "3.0.3"
+description = "Safely add untrusted strings to HTML/XML markup."
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "markupsafe-3.0.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:2f981d352f04553a7171b8e44369f2af4055f888dfb147d55e42d29e29e74559"},
+    {file = "markupsafe-3.0.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:e1c1493fb6e50ab01d20a22826e57520f1284df32f2d8601fdd90b6304601419"},
+    {file = "markupsafe-3.0.3-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1ba88449deb3de88bd40044603fafffb7bc2b055d626a330323a9ed736661695"},
+    {file = "markupsafe-3.0.3-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f42d0984e947b8adf7dd6dde396e720934d12c506ce84eea8476409563607591"},
+    {file = "markupsafe-3.0.3-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c0c0b3ade1c0b13b936d7970b1d37a57acde9199dc2aecc4c336773e1d86049c"},
+    {file = "markupsafe-3.0.3-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:0303439a41979d9e74d18ff5e2dd8c43ed6c6001fd40e5bf2e43f7bd9bbc523f"},
+    {file = "markupsafe-3.0.3-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:d2ee202e79d8ed691ceebae8e0486bd9a2cd4794cec4824e1c99b6f5009502f6"},
+    {file = "markupsafe-3.0.3-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:177b5253b2834fe3678cb4a5f0059808258584c559193998be2601324fdeafb1"},
+    {file = "markupsafe-3.0.3-cp310-cp310-win32.whl", hash = "sha256:2a15a08b17dd94c53a1da0438822d70ebcd13f8c3a95abe3a9ef9f11a94830aa"},
+    {file = "markupsafe-3.0.3-cp310-cp310-win_amd64.whl", hash = "sha256:c4ffb7ebf07cfe8931028e3e4c85f0357459a3f9f9490886198848f4fa002ec8"},
+    {file = "markupsafe-3.0.3-cp310-cp310-win_arm64.whl", hash = "sha256:e2103a929dfa2fcaf9bb4e7c091983a49c9ac3b19c9061b6d5427dd7d14d81a1"},
+    {file = "markupsafe-3.0.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:1cc7ea17a6824959616c525620e387f6dd30fec8cb44f649e31712db02123dad"},
+    {file = "markupsafe-3.0.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4bd4cd07944443f5a265608cc6aab442e4f74dff8088b0dfc8238647b8f6ae9a"},
+    {file = "markupsafe-3.0.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6b5420a1d9450023228968e7e6a9ce57f65d148ab56d2313fcd589eee96a7a50"},
+    {file = "markupsafe-3.0.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0bf2a864d67e76e5c9a34dc26ec616a66b9888e25e7b9460e1c76d3293bd9dbf"},
+    {file = "markupsafe-3.0.3-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:bc51efed119bc9cfdf792cdeaa4d67e8f6fcccab66ed4bfdd6bde3e59bfcbb2f"},
+    {file = "markupsafe-3.0.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:068f375c472b3e7acbe2d5318dea141359e6900156b5b2ba06a30b169086b91a"},
+    {file = "markupsafe-3.0.3-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:7be7b61bb172e1ed687f1754f8e7484f1c8019780f6f6b0786e76bb01c2ae115"},
+    {file = "markupsafe-3.0.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:f9e130248f4462aaa8e2552d547f36ddadbeaa573879158d721bbd33dfe4743a"},
+    {file = "markupsafe-3.0.3-cp311-cp311-win32.whl", hash = "sha256:0db14f5dafddbb6d9208827849fad01f1a2609380add406671a26386cdf15a19"},
+    {file = "markupsafe-3.0.3-cp311-cp311-win_amd64.whl", hash = "sha256:de8a88e63464af587c950061a5e6a67d3632e36df62b986892331d4620a35c01"},
+    {file = "markupsafe-3.0.3-cp311-cp311-win_arm64.whl", hash = "sha256:3b562dd9e9ea93f13d53989d23a7e775fdfd1066c33494ff43f5418bc8c58a5c"},
+    {file = "markupsafe-3.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:d53197da72cc091b024dd97249dfc7794d6a56530370992a5e1a08983ad9230e"},
+    {file = "markupsafe-3.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1872df69a4de6aead3491198eaf13810b565bdbeec3ae2dc8780f14458ec73ce"},
+    {file = "markupsafe-3.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3a7e8ae81ae39e62a41ec302f972ba6ae23a5c5396c8e60113e9066ef893da0d"},
+    {file = "markupsafe-3.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d6dd0be5b5b189d31db7cda48b91d7e0a9795f31430b7f271219ab30f1d3ac9d"},
+    {file = "markupsafe-3.0.3-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:94c6f0bb423f739146aec64595853541634bde58b2135f27f61c1ffd1cd4d16a"},
+    {file = "markupsafe-3.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:be8813b57049a7dc738189df53d69395eba14fb99345e0a5994914a3864c8a4b"},
+    {file = "markupsafe-3.0.3-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:83891d0e9fb81a825d9a6d61e3f07550ca70a076484292a70fde82c4b807286f"},
+    {file = "markupsafe-3.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:77f0643abe7495da77fb436f50f8dab76dbc6e5fd25d39589a0f1fe6548bfa2b"},
+    {file = "markupsafe-3.0.3-cp312-cp312-win32.whl", hash = "sha256:d88b440e37a16e651bda4c7c2b930eb586fd15ca7406cb39e211fcff3bf3017d"},
+    {file = "markupsafe-3.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:26a5784ded40c9e318cfc2bdb30fe164bdb8665ded9cd64d500a34fb42067b1c"},
+    {file = "markupsafe-3.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:35add3b638a5d900e807944a078b51922212fb3dedb01633a8defc4b01a3c85f"},
+    {file = "markupsafe-3.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:e1cf1972137e83c5d4c136c43ced9ac51d0e124706ee1c8aa8532c1287fa8795"},
+    {file = "markupsafe-3.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:116bb52f642a37c115f517494ea5feb03889e04df47eeff5b130b1808ce7c219"},
+    {file = "markupsafe-3.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:133a43e73a802c5562be9bbcd03d090aa5a1fe899db609c29e8c8d815c5f6de6"},
+    {file = "markupsafe-3.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ccfcd093f13f0f0b7fdd0f198b90053bf7b2f02a3927a30e63f3ccc9df56b676"},
+    {file = "markupsafe-3.0.3-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:509fa21c6deb7a7a273d629cf5ec029bc209d1a51178615ddf718f5918992ab9"},
+    {file = "markupsafe-3.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a4afe79fb3de0b7097d81da19090f4df4f8d3a2b3adaa8764138aac2e44f3af1"},
+    {file = "markupsafe-3.0.3-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:795e7751525cae078558e679d646ae45574b47ed6e7771863fcc079a6171a0fc"},
+    {file = "markupsafe-3.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8485f406a96febb5140bfeca44a73e3ce5116b2501ac54fe953e488fb1d03b12"},
+    {file = "markupsafe-3.0.3-cp313-cp313-win32.whl", hash = "sha256:bdd37121970bfd8be76c5fb069c7751683bdf373db1ed6c010162b2a130248ed"},
+    {file = "markupsafe-3.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:9a1abfdc021a164803f4d485104931fb8f8c1efd55bc6b748d2f5774e78b62c5"},
+    {file = "markupsafe-3.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:7e68f88e5b8799aa49c85cd116c932a1ac15caaa3f5db09087854d218359e485"},
+    {file = "markupsafe-3.0.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:218551f6df4868a8d527e3062d0fb968682fe92054e89978594c28e642c43a73"},
+    {file = "markupsafe-3.0.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:3524b778fe5cfb3452a09d31e7b5adefeea8c5be1d43c4f810ba09f2ceb29d37"},
+    {file = "markupsafe-3.0.3-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4e885a3d1efa2eadc93c894a21770e4bc67899e3543680313b09f139e149ab19"},
+    {file = "markupsafe-3.0.3-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8709b08f4a89aa7586de0aadc8da56180242ee0ada3999749b183aa23df95025"},
+    {file = "markupsafe-3.0.3-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b8512a91625c9b3da6f127803b166b629725e68af71f8184ae7e7d54686a56d6"},
+    {file = "markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9b79b7a16f7fedff2495d684f2b59b0457c3b493778c9eed31111be64d58279f"},
+    {file = "markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:12c63dfb4a98206f045aa9563db46507995f7ef6d83b2f68eda65c307c6829eb"},
+    {file = "markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:8f71bc33915be5186016f675cd83a1e08523649b0e33efdb898db577ef5bb009"},
+    {file = "markupsafe-3.0.3-cp313-cp313t-win32.whl", hash = "sha256:69c0b73548bc525c8cb9a251cddf1931d1db4d2258e9599c28c07ef3580ef354"},
+    {file = "markupsafe-3.0.3-cp313-cp313t-win_amd64.whl", hash = "sha256:1b4b79e8ebf6b55351f0d91fe80f893b4743f104bff22e90697db1590e47a218"},
+    {file = "markupsafe-3.0.3-cp313-cp313t-win_arm64.whl", hash = "sha256:ad2cf8aa28b8c020ab2fc8287b0f823d0a7d8630784c31e9ee5edea20f406287"},
+    {file = "markupsafe-3.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:eaa9599de571d72e2daf60164784109f19978b327a3910d3e9de8c97b5b70cfe"},
+    {file = "markupsafe-3.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c47a551199eb8eb2121d4f0f15ae0f923d31350ab9280078d1e5f12b249e0026"},
+    {file = "markupsafe-3.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f34c41761022dd093b4b6896d4810782ffbabe30f2d443ff5f083e0cbbb8c737"},
+    {file = "markupsafe-3.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:457a69a9577064c05a97c41f4e65148652db078a3a509039e64d3467b9e7ef97"},
+    {file = "markupsafe-3.0.3-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e8afc3f2ccfa24215f8cb28dcf43f0113ac3c37c2f0f0806d8c70e4228c5cf4d"},
+    {file = "markupsafe-3.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ec15a59cf5af7be74194f7ab02d0f59a62bdcf1a537677ce67a2537c9b87fcda"},
+    {file = "markupsafe-3.0.3-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:0eb9ff8191e8498cca014656ae6b8d61f39da5f95b488805da4bb029cccbfbaf"},
+    {file = "markupsafe-3.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2713baf880df847f2bece4230d4d094280f4e67b1e813eec43b4c0e144a34ffe"},
+    {file = "markupsafe-3.0.3-cp314-cp314-win32.whl", hash = "sha256:729586769a26dbceff69f7a7dbbf59ab6572b99d94576a5592625d5b411576b9"},
+    {file = "markupsafe-3.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:bdc919ead48f234740ad807933cdf545180bfbe9342c2bb451556db2ed958581"},
+    {file = "markupsafe-3.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:5a7d5dc5140555cf21a6fefbdbf8723f06fcd2f63ef108f2854de715e4422cb4"},
+    {file = "markupsafe-3.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:1353ef0c1b138e1907ae78e2f6c63ff67501122006b0f9abad68fda5f4ffc6ab"},
+    {file = "markupsafe-3.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1085e7fbddd3be5f89cc898938f42c0b3c711fdcb37d75221de2666af647c175"},
+    {file = "markupsafe-3.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1b52b4fb9df4eb9ae465f8d0c228a00624de2334f216f178a995ccdcf82c4634"},
+    {file = "markupsafe-3.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fed51ac40f757d41b7c48425901843666a6677e3e8eb0abcff09e4ba6e664f50"},
+    {file = "markupsafe-3.0.3-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f190daf01f13c72eac4efd5c430a8de82489d9cff23c364c3ea822545032993e"},
+    {file = "markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e56b7d45a839a697b5eb268c82a71bd8c7f6c94d6fd50c3d577fa39a9f1409f5"},
+    {file = "markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:f3e98bb3798ead92273dc0e5fd0f31ade220f59a266ffd8a4f6065e0a3ce0523"},
+    {file = "markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5678211cb9333a6468fb8d8be0305520aa073f50d17f089b5b4b477ea6e67fdc"},
+    {file = "markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d"},
+    {file = "markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9"},
+    {file = "markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa"},
+    {file = "markupsafe-3.0.3-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:15d939a21d546304880945ca1ecb8a039db6b4dc49b2c5a400387cdae6a62e26"},
+    {file = "markupsafe-3.0.3-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:f71a396b3bf33ecaa1626c255855702aca4d3d9fea5e051b41ac59a9c1c41edc"},
+    {file = "markupsafe-3.0.3-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0f4b68347f8c5eab4a13419215bdfd7f8c9b19f2b25520968adfad23eb0ce60c"},
+    {file = "markupsafe-3.0.3-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e8fc20152abba6b83724d7ff268c249fa196d8259ff481f3b1476383f8f24e42"},
+    {file = "markupsafe-3.0.3-cp39-cp39-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:949b8d66bc381ee8b007cd945914c721d9aba8e27f71959d750a46f7c282b20b"},
+    {file = "markupsafe-3.0.3-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:3537e01efc9d4dccdf77221fb1cb3b8e1a38d5428920e0657ce299b20324d758"},
+    {file = "markupsafe-3.0.3-cp39-cp39-musllinux_1_2_riscv64.whl", hash = "sha256:591ae9f2a647529ca990bc681daebdd52c8791ff06c2bfa05b65163e28102ef2"},
+    {file = "markupsafe-3.0.3-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:a320721ab5a1aba0a233739394eb907f8c8da5c98c9181d1161e77a0c8e36f2d"},
+    {file = "markupsafe-3.0.3-cp39-cp39-win32.whl", hash = "sha256:df2449253ef108a379b8b5d6b43f4b1a8e81a061d6537becd5582fba5f9196d7"},
+    {file = "markupsafe-3.0.3-cp39-cp39-win_amd64.whl", hash = "sha256:7c3fb7d25180895632e5d3148dbdc29ea38ccb7fd210aa27acbd1201a1902c6e"},
+    {file = "markupsafe-3.0.3-cp39-cp39-win_arm64.whl", hash = "sha256:38664109c14ffc9e7437e86b4dceb442b0096dfe3541d7864d9cbe1da4cf36c8"},
+    {file = "markupsafe-3.0.3.tar.gz", hash = "sha256:722695808f4b6457b320fdc131280796bdceb04ab50fe1795cd540799ebe1698"},
+]
+
+[[package]]
+name = "mpmath"
+version = "1.3.0"
+description = "Python library for arbitrary-precision floating-point arithmetic"
+optional = false
+python-versions = "*"
+groups = ["main"]
+files = [
+    {file = "mpmath-1.3.0-py3-none-any.whl", hash = "sha256:a0b2b9fe80bbcd81a6647ff13108738cfb482d481d826cc0e02f5b35e5c88d2c"},
+    {file = "mpmath-1.3.0.tar.gz", hash = "sha256:7a28eb2a9774d00c7bc92411c19a89209d5da7c4c9a9e227be8330a23a25b91f"},
+]
+
+[package.extras]
+develop = ["codecov", "pycodestyle", "pytest (>=4.6)", "pytest-cov", "wheel"]
+docs = ["sphinx"]
+gmpy = ["gmpy2 (>=2.1.0a4) ; platform_python_implementation != \"PyPy\""]
+tests = ["pytest (>=4.6)"]
 
 [[package]]
 name = "msgpack"
@@ -889,6 +1470,185 @@ pyopengl = "*"
 usd = ["pillow", "usd-core"]
 
 [[package]]
+name = "multidict"
+version = "6.7.1"
+description = "multidict implementation"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "multidict-6.7.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:c93c3db7ea657dd4637d57e74ab73de31bccefe144d3d4ce370052035bc85fb5"},
+    {file = "multidict-6.7.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:974e72a2474600827abaeda71af0c53d9ebbc3c2eb7da37b37d7829ae31232d8"},
+    {file = "multidict-6.7.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:cdea2e7b2456cfb6694fb113066fd0ec7ea4d67e3a35e1f4cbeea0b448bf5872"},
+    {file = "multidict-6.7.1-cp310-cp310-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:17207077e29342fdc2c9a82e4b306f1127bf1ea91f8b71e02d4798a70bb99991"},
+    {file = "multidict-6.7.1-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d4f49cb5661344764e4c7c7973e92a47a59b8fc19b6523649ec9dc4960e58a03"},
+    {file = "multidict-6.7.1-cp310-cp310-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:a9fc4caa29e2e6ae408d1c450ac8bf19892c5fca83ee634ecd88a53332c59981"},
+    {file = "multidict-6.7.1-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c5f0c21549ab432b57dcc82130f388d84ad8179824cc3f223d5e7cfbfd4143f6"},
+    {file = "multidict-6.7.1-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:7dfb78d966b2c906ae1d28ccf6e6712a3cd04407ee5088cd276fe8cb42186190"},
+    {file = "multidict-6.7.1-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9b0d9b91d1aa44db9c1f1ecd0d9d2ae610b2f4f856448664e01a3b35899f3f92"},
+    {file = "multidict-6.7.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:dd96c01a9dcd4889dcfcf9eb5544ca0c77603f239e3ffab0524ec17aea9a93ee"},
+    {file = "multidict-6.7.1-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:067343c68cd6612d375710f895337b3a98a033c94f14b9a99eff902f205424e2"},
+    {file = "multidict-6.7.1-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:5884a04f4ff56c6120f6ccf703bdeb8b5079d808ba604d4d53aec0d55dc33568"},
+    {file = "multidict-6.7.1-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:8affcf1c98b82bc901702eb73b6947a1bfa170823c153fe8a47b5f5f02e48e40"},
+    {file = "multidict-6.7.1-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:0d17522c37d03e85c8098ec8431636309b2682cf12e58f4dbc76121fb50e4962"},
+    {file = "multidict-6.7.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:24c0cf81544ca5e17cfcb6e482e7a82cd475925242b308b890c9452a074d4505"},
+    {file = "multidict-6.7.1-cp310-cp310-win32.whl", hash = "sha256:d82dd730a95e6643802f4454b8fdecdf08667881a9c5670db85bc5a56693f122"},
+    {file = "multidict-6.7.1-cp310-cp310-win_amd64.whl", hash = "sha256:cf37cbe5ced48d417ba045aca1b21bafca67489452debcde94778a576666a1df"},
+    {file = "multidict-6.7.1-cp310-cp310-win_arm64.whl", hash = "sha256:59bc83d3f66b41dac1e7460aac1d196edc70c9ba3094965c467715a70ecb46db"},
+    {file = "multidict-6.7.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:7ff981b266af91d7b4b3793ca3382e53229088d193a85dfad6f5f4c27fc73e5d"},
+    {file = "multidict-6.7.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:844c5bca0b5444adb44a623fb0a1310c2f4cd41f402126bb269cd44c9b3f3e1e"},
+    {file = "multidict-6.7.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:f2a0a924d4c2e9afcd7ec64f9de35fcd96915149b2216e1cb2c10a56df483855"},
+    {file = "multidict-6.7.1-cp311-cp311-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:8be1802715a8e892c784c0197c2ace276ea52702a0ede98b6310c8f255a5afb3"},
+    {file = "multidict-6.7.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2e2d2ed645ea29f31c4c7ea1552fcfd7cb7ba656e1eafd4134a6620c9f5fdd9e"},
+    {file = "multidict-6.7.1-cp311-cp311-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:95922cee9a778659e91db6497596435777bd25ed116701a4c034f8e46544955a"},
+    {file = "multidict-6.7.1-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:6b83cabdc375ffaaa15edd97eb7c0c672ad788e2687004990074d7d6c9b140c8"},
+    {file = "multidict-6.7.1-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:38fb49540705369bab8484db0689d86c0a33a0a9f2c1b197f506b71b4b6c19b0"},
+    {file = "multidict-6.7.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:439cbebd499f92e9aa6793016a8acaa161dfa749ae86d20960189f5398a19144"},
+    {file = "multidict-6.7.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:6d3bc717b6fe763b8be3f2bee2701d3c8eb1b2a8ae9f60910f1b2860c82b6c49"},
+    {file = "multidict-6.7.1-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:619e5a1ac57986dbfec9f0b301d865dddf763696435e2962f6d9cf2fdff2bb71"},
+    {file = "multidict-6.7.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:0b38ebffd9be37c1170d33bc0f36f4f262e0a09bc1aac1c34c7aa51a7293f0b3"},
+    {file = "multidict-6.7.1-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:10ae39c9cfe6adedcdb764f5e8411d4a92b055e35573a2eaa88d3323289ef93c"},
+    {file = "multidict-6.7.1-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:25167cc263257660290fba06b9318d2026e3c910be240a146e1f66dd114af2b0"},
+    {file = "multidict-6.7.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:128441d052254f42989ef98b7b6a6ecb1e6f708aa962c7984235316db59f50fa"},
+    {file = "multidict-6.7.1-cp311-cp311-win32.whl", hash = "sha256:d62b7f64ffde3b99d06b707a280db04fb3855b55f5a06df387236051d0668f4a"},
+    {file = "multidict-6.7.1-cp311-cp311-win_amd64.whl", hash = "sha256:bdbf9f3b332abd0cdb306e7c2113818ab1e922dc84b8f8fd06ec89ed2a19ab8b"},
+    {file = "multidict-6.7.1-cp311-cp311-win_arm64.whl", hash = "sha256:b8c990b037d2fff2f4e33d3f21b9b531c5745b33a49a7d6dbe7a177266af44f6"},
+    {file = "multidict-6.7.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:a90f75c956e32891a4eda3639ce6dd86e87105271f43d43442a3aedf3cddf172"},
+    {file = "multidict-6.7.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:3fccb473e87eaa1382689053e4a4618e7ba7b9b9b8d6adf2027ee474597128cd"},
+    {file = "multidict-6.7.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:b0fa96985700739c4c7853a43c0b3e169360d6855780021bfc6d0f1ce7c123e7"},
+    {file = "multidict-6.7.1-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:cb2a55f408c3043e42b40cc8eecd575afa27b7e0b956dfb190de0f8499a57a53"},
+    {file = "multidict-6.7.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:eb0ce7b2a32d09892b3dd6cc44877a0d02a33241fafca5f25c8b6b62374f8b75"},
+    {file = "multidict-6.7.1-cp312-cp312-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:c3a32d23520ee37bf327d1e1a656fec76a2edd5c038bf43eddfa0572ec49c60b"},
+    {file = "multidict-6.7.1-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:9c90fed18bffc0189ba814749fdcc102b536e83a9f738a9003e569acd540a733"},
+    {file = "multidict-6.7.1-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:da62917e6076f512daccfbbde27f46fed1c98fee202f0559adec8ee0de67f71a"},
+    {file = "multidict-6.7.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bfde23ef6ed9db7eaee6c37dcec08524cb43903c60b285b172b6c094711b3961"},
+    {file = "multidict-6.7.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3758692429e4e32f1ba0df23219cd0b4fc0a52f476726fff9337d1a57676a582"},
+    {file = "multidict-6.7.1-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:398c1478926eca669f2fd6a5856b6de9c0acf23a2cb59a14c0ba5844fa38077e"},
+    {file = "multidict-6.7.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:c102791b1c4f3ab36ce4101154549105a53dc828f016356b3e3bcae2e3a039d3"},
+    {file = "multidict-6.7.1-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:a088b62bd733e2ad12c50dad01b7d0166c30287c166e137433d3b410add807a6"},
+    {file = "multidict-6.7.1-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:3d51ff4785d58d3f6c91bdbffcb5e1f7ddfda557727043aa20d20ec4f65e324a"},
+    {file = "multidict-6.7.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fc5907494fccf3e7d3f94f95c91d6336b092b5fc83811720fae5e2765890dfba"},
+    {file = "multidict-6.7.1-cp312-cp312-win32.whl", hash = "sha256:28ca5ce2fd9716631133d0e9a9b9a745ad7f60bac2bccafb56aa380fc0b6c511"},
+    {file = "multidict-6.7.1-cp312-cp312-win_amd64.whl", hash = "sha256:fcee94dfbd638784645b066074b338bc9cc155d4b4bffa4adce1615c5a426c19"},
+    {file = "multidict-6.7.1-cp312-cp312-win_arm64.whl", hash = "sha256:ba0a9fb644d0c1a2194cf7ffb043bd852cea63a57f66fbd33959f7dae18517bf"},
+    {file = "multidict-6.7.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:2b41f5fed0ed563624f1c17630cb9941cf2309d4df00e494b551b5f3e3d67a23"},
+    {file = "multidict-6.7.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:84e61e3af5463c19b67ced91f6c634effb89ef8bfc5ca0267f954451ed4bb6a2"},
+    {file = "multidict-6.7.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:935434b9853c7c112eee7ac891bc4cb86455aa631269ae35442cb316790c1445"},
+    {file = "multidict-6.7.1-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:432feb25a1cb67fe82a9680b4d65fb542e4635cb3166cd9c01560651ad60f177"},
+    {file = "multidict-6.7.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e82d14e3c948952a1a85503817e038cba5905a3352de76b9a465075d072fba23"},
+    {file = "multidict-6.7.1-cp313-cp313-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:4cfb48c6ea66c83bcaaf7e4dfa7ec1b6bbcf751b7db85a328902796dfde4c060"},
+    {file = "multidict-6.7.1-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:1d540e51b7e8e170174555edecddbd5538105443754539193e3e1061864d444d"},
+    {file = "multidict-6.7.1-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:273d23f4b40f3dce4d6c8a821c741a86dec62cded82e1175ba3d99be128147ed"},
+    {file = "multidict-6.7.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9d624335fd4fa1c08a53f8b4be7676ebde19cd092b3895c421045ca87895b429"},
+    {file = "multidict-6.7.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:12fad252f8b267cc75b66e8fc51b3079604e8d43a75428ffe193cd9e2195dfd6"},
+    {file = "multidict-6.7.1-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:03ede2a6ffbe8ef936b92cb4529f27f42be7f56afcdab5ab739cd5f27fb1cbf9"},
+    {file = "multidict-6.7.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:90efbcf47dbe33dcf643a1e400d67d59abeac5db07dc3f27d6bdeae497a2198c"},
+    {file = "multidict-6.7.1-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:5c4b9bfc148f5a91be9244d6264c53035c8a0dcd2f51f1c3c6e30e30ebaa1c84"},
+    {file = "multidict-6.7.1-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:401c5a650f3add2472d1d288c26deebc540f99e2fb83e9525007a74cd2116f1d"},
+    {file = "multidict-6.7.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:97891f3b1b3ffbded884e2916cacf3c6fc87b66bb0dde46f7357404750559f33"},
+    {file = "multidict-6.7.1-cp313-cp313-win32.whl", hash = "sha256:e1c5988359516095535c4301af38d8a8838534158f649c05dd1050222321bcb3"},
+    {file = "multidict-6.7.1-cp313-cp313-win_amd64.whl", hash = "sha256:960c83bf01a95b12b08fd54324a4eb1d5b52c88932b5cba5d6e712bb3ed12eb5"},
+    {file = "multidict-6.7.1-cp313-cp313-win_arm64.whl", hash = "sha256:563fe25c678aaba333d5399408f5ec3c383ca5b663e7f774dd179a520b8144df"},
+    {file = "multidict-6.7.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:c76c4bec1538375dad9d452d246ca5368ad6e1c9039dadcf007ae59c70619ea1"},
+    {file = "multidict-6.7.1-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:57b46b24b5d5ebcc978da4ec23a819a9402b4228b8a90d9c656422b4bdd8a963"},
+    {file = "multidict-6.7.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e954b24433c768ce78ab7929e84ccf3422e46deb45a4dc9f93438f8217fa2d34"},
+    {file = "multidict-6.7.1-cp313-cp313t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:3bd231490fa7217cc832528e1cd8752a96f0125ddd2b5749390f7c3ec8721b65"},
+    {file = "multidict-6.7.1-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:253282d70d67885a15c8a7716f3a73edf2d635793ceda8173b9ecc21f2fb8292"},
+    {file = "multidict-6.7.1-cp313-cp313t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:0b4c48648d7649c9335cf1927a8b87fa692de3dcb15faa676c6a6f1f1aabda43"},
+    {file = "multidict-6.7.1-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:98bc624954ec4d2c7cb074b8eefc2b5d0ce7d482e410df446414355d158fe4ca"},
+    {file = "multidict-6.7.1-cp313-cp313t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:1b99af4d9eec0b49927b4402bcbb58dea89d3e0db8806a4086117019939ad3dd"},
+    {file = "multidict-6.7.1-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6aac4f16b472d5b7dc6f66a0d49dd57b0e0902090be16594dc9ebfd3d17c47e7"},
+    {file = "multidict-6.7.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:21f830fe223215dffd51f538e78c172ed7c7f60c9b96a2bf05c4848ad49921c3"},
+    {file = "multidict-6.7.1-cp313-cp313t-musllinux_1_2_armv7l.whl", hash = "sha256:f5dd81c45b05518b9aa4da4aa74e1c93d715efa234fd3e8a179df611cc85e5f4"},
+    {file = "multidict-6.7.1-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:eb304767bca2bb92fb9c5bd33cedc95baee5bb5f6c88e63706533a1c06ad08c8"},
+    {file = "multidict-6.7.1-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:c9035dde0f916702850ef66460bc4239d89d08df4d02023a5926e7446724212c"},
+    {file = "multidict-6.7.1-cp313-cp313t-musllinux_1_2_s390x.whl", hash = "sha256:af959b9beeb66c822380f222f0e0a1889331597e81f1ded7f374f3ecb0fd6c52"},
+    {file = "multidict-6.7.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:41f2952231456154ee479651491e94118229844dd7226541788be783be2b5108"},
+    {file = "multidict-6.7.1-cp313-cp313t-win32.whl", hash = "sha256:df9f19c28adcb40b6aae30bbaa1478c389efd50c28d541d76760199fc1037c32"},
+    {file = "multidict-6.7.1-cp313-cp313t-win_amd64.whl", hash = "sha256:d54ecf9f301853f2c5e802da559604b3e95bb7a3b01a9c295c6ee591b9882de8"},
+    {file = "multidict-6.7.1-cp313-cp313t-win_arm64.whl", hash = "sha256:5a37ca18e360377cfda1d62f5f382ff41f2b8c4ccb329ed974cc2e1643440118"},
+    {file = "multidict-6.7.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:8f333ec9c5eb1b7105e3b84b53141e66ca05a19a605368c55450b6ba208cb9ee"},
+    {file = "multidict-6.7.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:a407f13c188f804c759fc6a9f88286a565c242a76b27626594c133b82883b5c2"},
+    {file = "multidict-6.7.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:0e161ddf326db5577c3a4cc2d8648f81456e8a20d40415541587a71620d7a7d1"},
+    {file = "multidict-6.7.1-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:1e3a8bb24342a8201d178c3b4984c26ba81a577c80d4d525727427460a50c22d"},
+    {file = "multidict-6.7.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:97231140a50f5d447d3164f994b86a0bed7cd016e2682f8650d6a9158e14fd31"},
+    {file = "multidict-6.7.1-cp314-cp314-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:6b10359683bd8806a200fd2909e7c8ca3a7b24ec1d8132e483d58e791d881048"},
+    {file = "multidict-6.7.1-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:283ddac99f7ac25a4acadbf004cb5ae34480bbeb063520f70ce397b281859362"},
+    {file = "multidict-6.7.1-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:538cec1e18c067d0e6103aa9a74f9e832904c957adc260e61cd9d8cf0c3b3d37"},
+    {file = "multidict-6.7.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7eee46ccb30ff48a1e35bb818cc90846c6be2b68240e42a78599166722cea709"},
+    {file = "multidict-6.7.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:fa263a02f4f2dd2d11a7b1bb4362aa7cb1049f84a9235d31adf63f30143469a0"},
+    {file = "multidict-6.7.1-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:2e1425e2f99ec5bd36c15a01b690a1a2456209c5deed58f95469ffb46039ccbb"},
+    {file = "multidict-6.7.1-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:497394b3239fc6f0e13a78a3e1b61296e72bf1c5f94b4c4eb80b265c37a131cd"},
+    {file = "multidict-6.7.1-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:233b398c29d3f1b9676b4b6f75c518a06fcb2ea0b925119fb2c1bc35c05e1601"},
+    {file = "multidict-6.7.1-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:93b1818e4a6e0930454f0f2af7dfce69307ca03cdcfb3739bf4d91241967b6c1"},
+    {file = "multidict-6.7.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:f33dc2a3abe9249ea5d8360f969ec7f4142e7ac45ee7014d8f8d5acddf178b7b"},
+    {file = "multidict-6.7.1-cp314-cp314-win32.whl", hash = "sha256:3ab8b9d8b75aef9df299595d5388b14530839f6422333357af1339443cff777d"},
+    {file = "multidict-6.7.1-cp314-cp314-win_amd64.whl", hash = "sha256:5e01429a929600e7dab7b166062d9bb54a5eed752384c7384c968c2afab8f50f"},
+    {file = "multidict-6.7.1-cp314-cp314-win_arm64.whl", hash = "sha256:4885cb0e817aef5d00a2e8451d4665c1808378dc27c2705f1bf4ef8505c0d2e5"},
+    {file = "multidict-6.7.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:0458c978acd8e6ea53c81eefaddbbee9c6c5e591f41b3f5e8e194780fe026581"},
+    {file = "multidict-6.7.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:c0abd12629b0af3cf590982c0b413b1e7395cd4ec026f30986818ab95bfaa94a"},
+    {file = "multidict-6.7.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:14525a5f61d7d0c94b368a42cff4c9a4e7ba2d52e2672a7b23d84dc86fb02b0c"},
+    {file = "multidict-6.7.1-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:17307b22c217b4cf05033dabefe68255a534d637c6c9b0cc8382718f87be4262"},
+    {file = "multidict-6.7.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7a7e590ff876a3eaf1c02a4dfe0724b6e69a9e9de6d8f556816f29c496046e59"},
+    {file = "multidict-6.7.1-cp314-cp314t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:5fa6a95dfee63893d80a34758cd0e0c118a30b8dcb46372bf75106c591b77889"},
+    {file = "multidict-6.7.1-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a0543217a6a017692aa6ae5cc39adb75e587af0f3a82288b1492eb73dd6cc2a4"},
+    {file = "multidict-6.7.1-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:f99fe611c312b3c1c0ace793f92464d8cd263cc3b26b5721950d977b006b6c4d"},
+    {file = "multidict-6.7.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9004d8386d133b7e6135679424c91b0b854d2d164af6ea3f289f8f2761064609"},
+    {file = "multidict-6.7.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e628ef0e6859ffd8273c69412a2465c4be4a9517d07261b33334b5ec6f3c7489"},
+    {file = "multidict-6.7.1-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:841189848ba629c3552035a6a7f5bf3b02eb304e9fea7492ca220a8eda6b0e5c"},
+    {file = "multidict-6.7.1-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:ce1bbd7d780bb5a0da032e095c951f7014d6b0a205f8318308140f1a6aba159e"},
+    {file = "multidict-6.7.1-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:b26684587228afed0d50cf804cc71062cc9c1cdf55051c4c6345d372947b268c"},
+    {file = "multidict-6.7.1-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:9f9af11306994335398293f9958071019e3ab95e9a707dc1383a35613f6abcb9"},
+    {file = "multidict-6.7.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:b4938326284c4f1224178a560987b6cf8b4d38458b113d9b8c1db1a836e640a2"},
+    {file = "multidict-6.7.1-cp314-cp314t-win32.whl", hash = "sha256:98655c737850c064a65e006a3df7c997cd3b220be4ec8fe26215760b9697d4d7"},
+    {file = "multidict-6.7.1-cp314-cp314t-win_amd64.whl", hash = "sha256:497bde6223c212ba11d462853cfa4f0ae6ef97465033e7dc9940cdb3ab5b48e5"},
+    {file = "multidict-6.7.1-cp314-cp314t-win_arm64.whl", hash = "sha256:2bbd113e0d4af5db41d5ebfe9ccaff89de2120578164f86a5d17d5a576d1e5b2"},
+    {file = "multidict-6.7.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:65573858d27cdeaca41893185677dc82395159aa28875a8867af66532d413a8f"},
+    {file = "multidict-6.7.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:c524c6fb8fc342793708ab111c4dbc90ff9abd568de220432500e47e990c0358"},
+    {file = "multidict-6.7.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:aa23b001d968faef416ff70dc0f1ab045517b9b42a90edd3e9bcdb06479e31d5"},
+    {file = "multidict-6.7.1-cp39-cp39-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:6704fa2b7453b2fb121740555fa1ee20cd98c4d011120caf4d2b8d4e7c76eec0"},
+    {file = "multidict-6.7.1-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:121a34e5bfa410cdf2c8c49716de160de3b1dbcd86b49656f5681e4543bcd1a8"},
+    {file = "multidict-6.7.1-cp39-cp39-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:026d264228bcd637d4e060844e39cdc60f86c479e463d49075dedc21b18fbbe0"},
+    {file = "multidict-6.7.1-cp39-cp39-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:0e697826df7eb63418ee190fd06ce9f1803593bb4b9517d08c60d9b9a7f69d8f"},
+    {file = "multidict-6.7.1-cp39-cp39-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:bb08271280173720e9fea9ede98e5231defcbad90f1624bea26f32ec8a956e2f"},
+    {file = "multidict-6.7.1-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c6b3228e1d80af737b72925ce5fb4daf5a335e49cd7ab77ed7b9fdfbf58c526e"},
+    {file = "multidict-6.7.1-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:3943debf0fbb57bdde5901695c11094a9a36723e5c03875f87718ee15ca2f4d2"},
+    {file = "multidict-6.7.1-cp39-cp39-musllinux_1_2_armv7l.whl", hash = "sha256:98c5787b0a0d9a41d9311eae44c3b76e6753def8d8870ab501320efe75a6a5f8"},
+    {file = "multidict-6.7.1-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:08ccb2a6dc72009093ebe7f3f073e5ec5964cba9a706fa94b1a1484039b87941"},
+    {file = "multidict-6.7.1-cp39-cp39-musllinux_1_2_ppc64le.whl", hash = "sha256:eb351f72c26dc9abe338ca7294661aa22969ad8ffe7ef7d5541d19f368dc854a"},
+    {file = "multidict-6.7.1-cp39-cp39-musllinux_1_2_s390x.whl", hash = "sha256:ac1c665bad8b5d762f5f85ebe4d94130c26965f11de70c708c75671297c776de"},
+    {file = "multidict-6.7.1-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:1fa6609d0364f4f6f58351b4659a1f3e0e898ba2a8c5cac04cb2c7bc556b0bc5"},
+    {file = "multidict-6.7.1-cp39-cp39-win32.whl", hash = "sha256:6f77ce314a29263e67adadc7e7c1bc699fcb3a305059ab973d038f87caa42ed0"},
+    {file = "multidict-6.7.1-cp39-cp39-win_amd64.whl", hash = "sha256:f537b55778cd3cbee430abe3131255d3a78202e0f9ea7ffc6ada893a4bcaeea4"},
+    {file = "multidict-6.7.1-cp39-cp39-win_arm64.whl", hash = "sha256:749aa54f578f2e5f439538706a475aa844bfa8ef75854b1401e6e528e4937cf9"},
+    {file = "multidict-6.7.1-py3-none-any.whl", hash = "sha256:55d97cc6dae627efa6a6e548885712d4864b81110ac76fa4e534c03819fa4a56"},
+    {file = "multidict-6.7.1.tar.gz", hash = "sha256:ec6652a1bee61c53a3e5776b6049172c53b6aaba34f18c9ad04f82712bac623d"},
+]
+
+[package.dependencies]
+typing-extensions = {version = ">=4.1.0", markers = "python_version < \"3.11\""}
+
+[[package]]
+name = "networkx"
+version = "3.4.2"
+description = "Python package for creating and manipulating graphs and networks"
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+files = [
+    {file = "networkx-3.4.2-py3-none-any.whl", hash = "sha256:df5d4365b724cf81b8c6a7312509d0c22386097011ad1abe274afd5e9d3bbc5f"},
+    {file = "networkx-3.4.2.tar.gz", hash = "sha256:307c3669428c5362aab27c8a1260aa8f47c4e91d3891f48be0141738d8d053e1"},
+]
+
+[package.extras]
+default = ["matplotlib (>=3.7)", "numpy (>=1.24)", "pandas (>=2.0)", "scipy (>=1.10,!=1.11.0,!=1.11.1)"]
+developer = ["changelist (==0.5)", "mypy (>=1.1)", "pre-commit (>=3.2)", "rtoml"]
+doc = ["intersphinx-registry", "myst-nb (>=1.1)", "numpydoc (>=1.8.0)", "pillow (>=9.4)", "pydata-sphinx-theme (>=0.15)", "sphinx (>=7.3)", "sphinx-gallery (>=0.16)", "texext (>=0.6.7)"]
+example = ["cairocffi (>=1.7)", "contextily (>=1.6)", "igraph (>=0.11)", "momepy (>=0.7.2)", "osmnx (>=1.9)", "scikit-learn (>=1.5)", "seaborn (>=0.13)"]
+extra = ["lxml (>=4.6)", "pydot (>=3.0.1)", "pygraphviz (>=1.14)", "sympy (>=1.10)"]
+test = ["pytest (>=7.2)", "pytest-cov (>=4.0)"]
+
+[[package]]
 name = "nodeenv"
 version = "1.9.1"
 description = "Node.js virtual environment builder"
@@ -963,6 +1723,227 @@ files = [
     {file = "numpy-2.2.6-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ce47521a4754c8f4593837384bd3424880629f718d87c5d44f8ed763edd63543"},
     {file = "numpy-2.2.6-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:d042d24c90c41b54fd506da306759e06e568864df8ec17ccc17e9e884634fd00"},
     {file = "numpy-2.2.6.tar.gz", hash = "sha256:e29554e2bef54a90aa5cc07da6ce955accb83f21ab5de01a62c8478897b264fd"},
+]
+
+[[package]]
+name = "nvidia-cublas-cu12"
+version = "12.8.4.1"
+description = "CUBLAS native runtime libraries"
+optional = false
+python-versions = ">=3"
+groups = ["main"]
+markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""
+files = [
+    {file = "nvidia_cublas_cu12-12.8.4.1-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:b86f6dd8935884615a0683b663891d43781b819ac4f2ba2b0c9604676af346d0"},
+    {file = "nvidia_cublas_cu12-12.8.4.1-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:8ac4e771d5a348c551b2a426eda6193c19aa630236b418086020df5ba9667142"},
+    {file = "nvidia_cublas_cu12-12.8.4.1-py3-none-win_amd64.whl", hash = "sha256:47e9b82132fa8d2b4944e708049229601448aaad7e6f296f630f2d1a32de35af"},
+]
+
+[[package]]
+name = "nvidia-cuda-cupti-cu12"
+version = "12.8.90"
+description = "CUDA profiling tools runtime libs."
+optional = false
+python-versions = ">=3"
+groups = ["main"]
+markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""
+files = [
+    {file = "nvidia_cuda_cupti_cu12-12.8.90-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:4412396548808ddfed3f17a467b104ba7751e6b58678a4b840675c56d21cf7ed"},
+    {file = "nvidia_cuda_cupti_cu12-12.8.90-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ea0cb07ebda26bb9b29ba82cda34849e73c166c18162d3913575b0c9db9a6182"},
+    {file = "nvidia_cuda_cupti_cu12-12.8.90-py3-none-win_amd64.whl", hash = "sha256:bb479dcdf7e6d4f8b0b01b115260399bf34154a1a2e9fe11c85c517d87efd98e"},
+]
+
+[[package]]
+name = "nvidia-cuda-nvrtc-cu12"
+version = "12.8.93"
+description = "NVRTC native runtime libraries"
+optional = false
+python-versions = ">=3"
+groups = ["main"]
+markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""
+files = [
+    {file = "nvidia_cuda_nvrtc_cu12-12.8.93-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:a7756528852ef889772a84c6cd89d41dfa74667e24cca16bb31f8f061e3e9994"},
+    {file = "nvidia_cuda_nvrtc_cu12-12.8.93-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:fc1fec1e1637854b4c0a65fb9a8346b51dd9ee69e61ebaccc82058441f15bce8"},
+    {file = "nvidia_cuda_nvrtc_cu12-12.8.93-py3-none-win_amd64.whl", hash = "sha256:7a4b6b2904850fe78e0bd179c4b655c404d4bb799ef03ddc60804247099ae909"},
+]
+
+[[package]]
+name = "nvidia-cuda-runtime-cu12"
+version = "12.8.90"
+description = "CUDA Runtime native Libraries"
+optional = false
+python-versions = ">=3"
+groups = ["main"]
+markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""
+files = [
+    {file = "nvidia_cuda_runtime_cu12-12.8.90-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:52bf7bbee900262ffefe5e9d5a2a69a30d97e2bc5bb6cc866688caa976966e3d"},
+    {file = "nvidia_cuda_runtime_cu12-12.8.90-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:adade8dcbd0edf427b7204d480d6066d33902cab2a4707dcfc48a2d0fd44ab90"},
+    {file = "nvidia_cuda_runtime_cu12-12.8.90-py3-none-win_amd64.whl", hash = "sha256:c0c6027f01505bfed6c3b21ec546f69c687689aad5f1a377554bc6ca4aa993a8"},
+]
+
+[[package]]
+name = "nvidia-cudnn-cu12"
+version = "9.10.2.21"
+description = "cuDNN runtime libraries"
+optional = false
+python-versions = ">=3"
+groups = ["main"]
+markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""
+files = [
+    {file = "nvidia_cudnn_cu12-9.10.2.21-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:c9132cc3f8958447b4910a1720036d9eff5928cc3179b0a51fb6d167c6cc87d8"},
+    {file = "nvidia_cudnn_cu12-9.10.2.21-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:949452be657fa16687d0930933f032835951ef0892b37d2d53824d1a84dc97a8"},
+    {file = "nvidia_cudnn_cu12-9.10.2.21-py3-none-win_amd64.whl", hash = "sha256:c6288de7d63e6cf62988f0923f96dc339cea362decb1bf5b3141883392a7d65e"},
+]
+
+[package.dependencies]
+nvidia-cublas-cu12 = "*"
+
+[[package]]
+name = "nvidia-cufft-cu12"
+version = "11.3.3.83"
+description = "CUFFT native runtime libraries"
+optional = false
+python-versions = ">=3"
+groups = ["main"]
+markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""
+files = [
+    {file = "nvidia_cufft_cu12-11.3.3.83-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:848ef7224d6305cdb2a4df928759dca7b1201874787083b6e7550dd6765ce69a"},
+    {file = "nvidia_cufft_cu12-11.3.3.83-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4d2dd21ec0b88cf61b62e6b43564355e5222e4a3fb394cac0db101f2dd0d4f74"},
+    {file = "nvidia_cufft_cu12-11.3.3.83-py3-none-win_amd64.whl", hash = "sha256:7a64a98ef2a7c47f905aaf8931b69a3a43f27c55530c698bb2ed7c75c0b42cb7"},
+]
+
+[package.dependencies]
+nvidia-nvjitlink-cu12 = "*"
+
+[[package]]
+name = "nvidia-cufile-cu12"
+version = "1.13.1.3"
+description = "cuFile GPUDirect libraries"
+optional = false
+python-versions = ">=3"
+groups = ["main"]
+markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""
+files = [
+    {file = "nvidia_cufile_cu12-1.13.1.3-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1d069003be650e131b21c932ec3d8969c1715379251f8d23a1860554b1cb24fc"},
+    {file = "nvidia_cufile_cu12-1.13.1.3-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:4beb6d4cce47c1a0f1013d72e02b0994730359e17801d395bdcbf20cfb3bb00a"},
+]
+
+[[package]]
+name = "nvidia-curand-cu12"
+version = "10.3.9.90"
+description = "CURAND native runtime libraries"
+optional = false
+python-versions = ">=3"
+groups = ["main"]
+markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""
+files = [
+    {file = "nvidia_curand_cu12-10.3.9.90-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:dfab99248034673b779bc6decafdc3404a8a6f502462201f2f31f11354204acd"},
+    {file = "nvidia_curand_cu12-10.3.9.90-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:b32331d4f4df5d6eefa0554c565b626c7216f87a06a4f56fab27c3b68a830ec9"},
+    {file = "nvidia_curand_cu12-10.3.9.90-py3-none-win_amd64.whl", hash = "sha256:f149a8ca457277da854f89cf282d6ef43176861926c7ac85b2a0fbd237c587ec"},
+]
+
+[[package]]
+name = "nvidia-cusolver-cu12"
+version = "11.7.3.90"
+description = "CUDA solver native runtime libraries"
+optional = false
+python-versions = ">=3"
+groups = ["main"]
+markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""
+files = [
+    {file = "nvidia_cusolver_cu12-11.7.3.90-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:db9ed69dbef9715071232caa9b69c52ac7de3a95773c2db65bdba85916e4e5c0"},
+    {file = "nvidia_cusolver_cu12-11.7.3.90-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:4376c11ad263152bd50ea295c05370360776f8c3427b30991df774f9fb26c450"},
+    {file = "nvidia_cusolver_cu12-11.7.3.90-py3-none-win_amd64.whl", hash = "sha256:4a550db115fcabc4d495eb7d39ac8b58d4ab5d8e63274d3754df1c0ad6a22d34"},
+]
+
+[package.dependencies]
+nvidia-cublas-cu12 = "*"
+nvidia-cusparse-cu12 = "*"
+nvidia-nvjitlink-cu12 = "*"
+
+[[package]]
+name = "nvidia-cusparse-cu12"
+version = "12.5.8.93"
+description = "CUSPARSE native runtime libraries"
+optional = false
+python-versions = ">=3"
+groups = ["main"]
+markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""
+files = [
+    {file = "nvidia_cusparse_cu12-12.5.8.93-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:9b6c161cb130be1a07a27ea6923df8141f3c295852f4b260c65f18f3e0a091dc"},
+    {file = "nvidia_cusparse_cu12-12.5.8.93-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1ec05d76bbbd8b61b06a80e1eaf8cf4959c3d4ce8e711b65ebd0443bb0ebb13b"},
+    {file = "nvidia_cusparse_cu12-12.5.8.93-py3-none-win_amd64.whl", hash = "sha256:9a33604331cb2cac199f2e7f5104dfbb8a5a898c367a53dfda9ff2acb6b6b4dd"},
+]
+
+[package.dependencies]
+nvidia-nvjitlink-cu12 = "*"
+
+[[package]]
+name = "nvidia-cusparselt-cu12"
+version = "0.7.1"
+description = "NVIDIA cuSPARSELt"
+optional = false
+python-versions = "*"
+groups = ["main"]
+markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""
+files = [
+    {file = "nvidia_cusparselt_cu12-0.7.1-py3-none-manylinux2014_aarch64.whl", hash = "sha256:8878dce784d0fac90131b6817b607e803c36e629ba34dc5b433471382196b6a5"},
+    {file = "nvidia_cusparselt_cu12-0.7.1-py3-none-manylinux2014_x86_64.whl", hash = "sha256:f1bb701d6b930d5a7cea44c19ceb973311500847f81b634d802b7b539dc55623"},
+    {file = "nvidia_cusparselt_cu12-0.7.1-py3-none-win_amd64.whl", hash = "sha256:f67fbb5831940ec829c9117b7f33807db9f9678dc2a617fbe781cac17b4e1075"},
+]
+
+[[package]]
+name = "nvidia-nccl-cu12"
+version = "2.27.5"
+description = "NVIDIA Collective Communication Library (NCCL) Runtime"
+optional = false
+python-versions = ">=3"
+groups = ["main"]
+markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""
+files = [
+    {file = "nvidia_nccl_cu12-2.27.5-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:31432ad4d1fb1004eb0c56203dc9bc2178a1ba69d1d9e02d64a6938ab5e40e7a"},
+    {file = "nvidia_nccl_cu12-2.27.5-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ad730cf15cb5d25fe849c6e6ca9eb5b76db16a80f13f425ac68d8e2e55624457"},
+]
+
+[[package]]
+name = "nvidia-nvjitlink-cu12"
+version = "12.8.93"
+description = "Nvidia JIT LTO Library"
+optional = false
+python-versions = ">=3"
+groups = ["main"]
+markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""
+files = [
+    {file = "nvidia_nvjitlink_cu12-12.8.93-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:81ff63371a7ebd6e6451970684f916be2eab07321b73c9d244dc2b4da7f73b88"},
+    {file = "nvidia_nvjitlink_cu12-12.8.93-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:adccd7161ace7261e01bb91e44e88da350895c270d23f744f0820c818b7229e7"},
+    {file = "nvidia_nvjitlink_cu12-12.8.93-py3-none-win_amd64.whl", hash = "sha256:bd93fbeeee850917903583587f4fc3a4eafa022e34572251368238ab5e6bd67f"},
+]
+
+[[package]]
+name = "nvidia-nvshmem-cu12"
+version = "3.4.5"
+description = "NVSHMEM creates a global address space that provides efficient and scalable communication for NVIDIA GPU clusters."
+optional = false
+python-versions = ">=3"
+groups = ["main"]
+markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""
+files = [
+    {file = "nvidia_nvshmem_cu12-3.4.5-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:0b48363fc6964dede448029434c6abed6c5e37f823cb43c3bcde7ecfc0457e15"},
+    {file = "nvidia_nvshmem_cu12-3.4.5-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:042f2500f24c021db8a06c5eec2539027d57460e1c1a762055a6554f72c369bd"},
+]
+
+[[package]]
+name = "nvidia-nvtx-cu12"
+version = "12.8.90"
+description = "NVIDIA Tools Extension"
+optional = false
+python-versions = ">=3"
+groups = ["main"]
+markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""
+files = [
+    {file = "nvidia_nvtx_cu12-12.8.90-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d7ad891da111ebafbf7e015d34879f7112832fc239ff0d7d776b6cb685274615"},
+    {file = "nvidia_nvtx_cu12-12.8.90-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5b17e2001cc0d751a5bc2c6ec6d26ad95913324a4adb86788c944f8ce9ba441f"},
+    {file = "nvidia_nvtx_cu12-12.8.90-py3-none-win_amd64.whl", hash = "sha256:619c8304aedc69f02ea82dd244541a83c3d9d40993381b3b590f1adaed3db41e"},
 ]
 
 [[package]]
@@ -1139,6 +2120,138 @@ pyyaml = ">=5.1"
 virtualenv = ">=20.10.0"
 
 [[package]]
+name = "propcache"
+version = "0.4.1"
+description = "Accelerated property cache"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "propcache-0.4.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:7c2d1fa3201efaf55d730400d945b5b3ab6e672e100ba0f9a409d950ab25d7db"},
+    {file = "propcache-0.4.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:1eb2994229cc8ce7fe9b3db88f5465f5fd8651672840b2e426b88cdb1a30aac8"},
+    {file = "propcache-0.4.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:66c1f011f45a3b33d7bcb22daed4b29c0c9e2224758b6be00686731e1b46f925"},
+    {file = "propcache-0.4.1-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9a52009f2adffe195d0b605c25ec929d26b36ef986ba85244891dee3b294df21"},
+    {file = "propcache-0.4.1-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:5d4e2366a9c7b837555cf02fb9be2e3167d333aff716332ef1b7c3a142ec40c5"},
+    {file = "propcache-0.4.1-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:9d2b6caef873b4f09e26ea7e33d65f42b944837563a47a94719cc3544319a0db"},
+    {file = "propcache-0.4.1-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2b16ec437a8c8a965ecf95739448dd938b5c7f56e67ea009f4300d8df05f32b7"},
+    {file = "propcache-0.4.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:296f4c8ed03ca7476813fe666c9ea97869a8d7aec972618671b33a38a5182ef4"},
+    {file = "propcache-0.4.1-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:1f0978529a418ebd1f49dad413a2b68af33f85d5c5ca5c6ca2a3bed375a7ac60"},
+    {file = "propcache-0.4.1-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:fd138803047fb4c062b1c1dd95462f5209456bfab55c734458f15d11da288f8f"},
+    {file = "propcache-0.4.1-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:8c9b3cbe4584636d72ff556d9036e0c9317fa27b3ac1f0f558e7e84d1c9c5900"},
+    {file = "propcache-0.4.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:f93243fdc5657247533273ac4f86ae106cc6445a0efacb9a1bfe982fcfefd90c"},
+    {file = "propcache-0.4.1-cp310-cp310-win32.whl", hash = "sha256:a0ee98db9c5f80785b266eb805016e36058ac72c51a064040f2bc43b61101cdb"},
+    {file = "propcache-0.4.1-cp310-cp310-win_amd64.whl", hash = "sha256:1cdb7988c4e5ac7f6d175a28a9aa0c94cb6f2ebe52756a3c0cda98d2809a9e37"},
+    {file = "propcache-0.4.1-cp310-cp310-win_arm64.whl", hash = "sha256:d82ad62b19645419fe79dd63b3f9253e15b30e955c0170e5cebc350c1844e581"},
+    {file = "propcache-0.4.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:60a8fda9644b7dfd5dece8c61d8a85e271cb958075bfc4e01083c148b61a7caf"},
+    {file = "propcache-0.4.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:c30b53e7e6bda1d547cabb47c825f3843a0a1a42b0496087bb58d8fedf9f41b5"},
+    {file = "propcache-0.4.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:6918ecbd897443087a3b7cd978d56546a812517dcaaca51b49526720571fa93e"},
+    {file = "propcache-0.4.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3d902a36df4e5989763425a8ab9e98cd8ad5c52c823b34ee7ef307fd50582566"},
+    {file = "propcache-0.4.1-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a9695397f85973bb40427dedddf70d8dc4a44b22f1650dd4af9eedf443d45165"},
+    {file = "propcache-0.4.1-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:2bb07ffd7eaad486576430c89f9b215f9e4be68c4866a96e97db9e97fead85dc"},
+    {file = "propcache-0.4.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fd6f30fdcf9ae2a70abd34da54f18da086160e4d7d9251f81f3da0ff84fc5a48"},
+    {file = "propcache-0.4.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:fc38cba02d1acba4e2869eef1a57a43dfbd3d49a59bf90dda7444ec2be6a5570"},
+    {file = "propcache-0.4.1-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:67fad6162281e80e882fb3ec355398cf72864a54069d060321f6cd0ade95fe85"},
+    {file = "propcache-0.4.1-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:f10207adf04d08bec185bae14d9606a1444715bc99180f9331c9c02093e1959e"},
+    {file = "propcache-0.4.1-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:e9b0d8d0845bbc4cfcdcbcdbf5086886bc8157aa963c31c777ceff7846c77757"},
+    {file = "propcache-0.4.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:981333cb2f4c1896a12f4ab92a9cc8f09ea664e9b7dbdc4eff74627af3a11c0f"},
+    {file = "propcache-0.4.1-cp311-cp311-win32.whl", hash = "sha256:f1d2f90aeec838a52f1c1a32fe9a619fefd5e411721a9117fbf82aea638fe8a1"},
+    {file = "propcache-0.4.1-cp311-cp311-win_amd64.whl", hash = "sha256:364426a62660f3f699949ac8c621aad6977be7126c5807ce48c0aeb8e7333ea6"},
+    {file = "propcache-0.4.1-cp311-cp311-win_arm64.whl", hash = "sha256:e53f3a38d3510c11953f3e6a33f205c6d1b001129f972805ca9b42fc308bc239"},
+    {file = "propcache-0.4.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:e153e9cd40cc8945138822807139367f256f89c6810c2634a4f6902b52d3b4e2"},
+    {file = "propcache-0.4.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:cd547953428f7abb73c5ad82cbb32109566204260d98e41e5dfdc682eb7f8403"},
+    {file = "propcache-0.4.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f048da1b4f243fc44f205dfd320933a951b8d89e0afd4c7cacc762a8b9165207"},
+    {file = "propcache-0.4.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ec17c65562a827bba85e3872ead335f95405ea1674860d96483a02f5c698fa72"},
+    {file = "propcache-0.4.1-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:405aac25c6394ef275dee4c709be43745d36674b223ba4eb7144bf4d691b7367"},
+    {file = "propcache-0.4.1-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:0013cb6f8dde4b2a2f66903b8ba740bdfe378c943c4377a200551ceb27f379e4"},
+    {file = "propcache-0.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:15932ab57837c3368b024473a525e25d316d8353016e7cc0e5ba9eb343fbb1cf"},
+    {file = "propcache-0.4.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:031dce78b9dc099f4c29785d9cf5577a3faf9ebf74ecbd3c856a7b92768c3df3"},
+    {file = "propcache-0.4.1-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:ab08df6c9a035bee56e31af99be621526bd237bea9f32def431c656b29e41778"},
+    {file = "propcache-0.4.1-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:4d7af63f9f93fe593afbf104c21b3b15868efb2c21d07d8732c0c4287e66b6a6"},
+    {file = "propcache-0.4.1-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:cfc27c945f422e8b5071b6e93169679e4eb5bf73bbcbf1ba3ae3a83d2f78ebd9"},
+    {file = "propcache-0.4.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:35c3277624a080cc6ec6f847cbbbb5b49affa3598c4535a0a4682a697aaa5c75"},
+    {file = "propcache-0.4.1-cp312-cp312-win32.whl", hash = "sha256:671538c2262dadb5ba6395e26c1731e1d52534bfe9ae56d0b5573ce539266aa8"},
+    {file = "propcache-0.4.1-cp312-cp312-win_amd64.whl", hash = "sha256:cb2d222e72399fcf5890d1d5cc1060857b9b236adff2792ff48ca2dfd46c81db"},
+    {file = "propcache-0.4.1-cp312-cp312-win_arm64.whl", hash = "sha256:204483131fb222bdaaeeea9f9e6c6ed0cac32731f75dfc1d4a567fc1926477c1"},
+    {file = "propcache-0.4.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:43eedf29202c08550aac1d14e0ee619b0430aaef78f85864c1a892294fbc28cf"},
+    {file = "propcache-0.4.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:d62cdfcfd89ccb8de04e0eda998535c406bf5e060ffd56be6c586cbcc05b3311"},
+    {file = "propcache-0.4.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:cae65ad55793da34db5f54e4029b89d3b9b9490d8abe1b4c7ab5d4b8ec7ebf74"},
+    {file = "propcache-0.4.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:333ddb9031d2704a301ee3e506dc46b1fe5f294ec198ed6435ad5b6a085facfe"},
+    {file = "propcache-0.4.1-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:fd0858c20f078a32cf55f7e81473d96dcf3b93fd2ccdb3d40fdf54b8573df3af"},
+    {file = "propcache-0.4.1-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:678ae89ebc632c5c204c794f8dab2837c5f159aeb59e6ed0539500400577298c"},
+    {file = "propcache-0.4.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d472aeb4fbf9865e0c6d622d7f4d54a4e101a89715d8904282bb5f9a2f476c3f"},
+    {file = "propcache-0.4.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:4d3df5fa7e36b3225954fba85589da77a0fe6a53e3976de39caf04a0db4c36f1"},
+    {file = "propcache-0.4.1-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:ee17f18d2498f2673e432faaa71698032b0127ebf23ae5974eeaf806c279df24"},
+    {file = "propcache-0.4.1-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:580e97762b950f993ae618e167e7be9256b8353c2dcd8b99ec100eb50f5286aa"},
+    {file = "propcache-0.4.1-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:501d20b891688eb8e7aa903021f0b72d5a55db40ffaab27edefd1027caaafa61"},
+    {file = "propcache-0.4.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:9a0bd56e5b100aef69bd8562b74b46254e7c8812918d3baa700c8a8009b0af66"},
+    {file = "propcache-0.4.1-cp313-cp313-win32.whl", hash = "sha256:bcc9aaa5d80322bc2fb24bb7accb4a30f81e90ab8d6ba187aec0744bc302ad81"},
+    {file = "propcache-0.4.1-cp313-cp313-win_amd64.whl", hash = "sha256:381914df18634f5494334d201e98245c0596067504b9372d8cf93f4bb23e025e"},
+    {file = "propcache-0.4.1-cp313-cp313-win_arm64.whl", hash = "sha256:8873eb4460fd55333ea49b7d189749ecf6e55bf85080f11b1c4530ed3034cba1"},
+    {file = "propcache-0.4.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:92d1935ee1f8d7442da9c0c4fa7ac20d07e94064184811b685f5c4fada64553b"},
+    {file = "propcache-0.4.1-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:473c61b39e1460d386479b9b2f337da492042447c9b685f28be4f74d3529e566"},
+    {file = "propcache-0.4.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:c0ef0aaafc66fbd87842a3fe3902fd889825646bc21149eafe47be6072725835"},
+    {file = "propcache-0.4.1-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f95393b4d66bfae908c3ca8d169d5f79cd65636ae15b5e7a4f6e67af675adb0e"},
+    {file = "propcache-0.4.1-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c07fda85708bc48578467e85099645167a955ba093be0a2dcba962195676e859"},
+    {file = "propcache-0.4.1-cp313-cp313t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:af223b406d6d000830c6f65f1e6431783fc3f713ba3e6cc8c024d5ee96170a4b"},
+    {file = "propcache-0.4.1-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a78372c932c90ee474559c5ddfffd718238e8673c340dc21fe45c5b8b54559a0"},
+    {file = "propcache-0.4.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:564d9f0d4d9509e1a870c920a89b2fec951b44bf5ba7d537a9e7c1ccec2c18af"},
+    {file = "propcache-0.4.1-cp313-cp313t-musllinux_1_2_armv7l.whl", hash = "sha256:17612831fda0138059cc5546f4d12a2aacfb9e47068c06af35c400ba58ba7393"},
+    {file = "propcache-0.4.1-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:41a89040cb10bd345b3c1a873b2bf36413d48da1def52f268a055f7398514874"},
+    {file = "propcache-0.4.1-cp313-cp313t-musllinux_1_2_s390x.whl", hash = "sha256:e35b88984e7fa64aacecea39236cee32dd9bd8c55f57ba8a75cf2399553f9bd7"},
+    {file = "propcache-0.4.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:6f8b465489f927b0df505cbe26ffbeed4d6d8a2bbc61ce90eb074ff129ef0ab1"},
+    {file = "propcache-0.4.1-cp313-cp313t-win32.whl", hash = "sha256:2ad890caa1d928c7c2965b48f3a3815c853180831d0e5503d35cf00c472f4717"},
+    {file = "propcache-0.4.1-cp313-cp313t-win_amd64.whl", hash = "sha256:f7ee0e597f495cf415bcbd3da3caa3bd7e816b74d0d52b8145954c5e6fd3ff37"},
+    {file = "propcache-0.4.1-cp313-cp313t-win_arm64.whl", hash = "sha256:929d7cbe1f01bb7baffb33dc14eb5691c95831450a26354cd210a8155170c93a"},
+    {file = "propcache-0.4.1-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:3f7124c9d820ba5548d431afb4632301acf965db49e666aa21c305cbe8c6de12"},
+    {file = "propcache-0.4.1-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:c0d4b719b7da33599dfe3b22d3db1ef789210a0597bc650b7cee9c77c2be8c5c"},
+    {file = "propcache-0.4.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:9f302f4783709a78240ebc311b793f123328716a60911d667e0c036bc5dcbded"},
+    {file = "propcache-0.4.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c80ee5802e3fb9ea37938e7eecc307fb984837091d5fd262bb37238b1ae97641"},
+    {file = "propcache-0.4.1-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ed5a841e8bb29a55fb8159ed526b26adc5bdd7e8bd7bf793ce647cb08656cdf4"},
+    {file = "propcache-0.4.1-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:55c72fd6ea2da4c318e74ffdf93c4fe4e926051133657459131a95c846d16d44"},
+    {file = "propcache-0.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8326e144341460402713f91df60ade3c999d601e7eb5ff8f6f7862d54de0610d"},
+    {file = "propcache-0.4.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:060b16ae65bc098da7f6d25bf359f1f31f688384858204fe5d652979e0015e5b"},
+    {file = "propcache-0.4.1-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:89eb3fa9524f7bec9de6e83cf3faed9d79bffa560672c118a96a171a6f55831e"},
+    {file = "propcache-0.4.1-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:dee69d7015dc235f526fe80a9c90d65eb0039103fe565776250881731f06349f"},
+    {file = "propcache-0.4.1-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:5558992a00dfd54ccbc64a32726a3357ec93825a418a401f5cc67df0ac5d9e49"},
+    {file = "propcache-0.4.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:c9b822a577f560fbd9554812526831712c1436d2c046cedee4c3796d3543b144"},
+    {file = "propcache-0.4.1-cp314-cp314-win32.whl", hash = "sha256:ab4c29b49d560fe48b696cdcb127dd36e0bc2472548f3bf56cc5cb3da2b2984f"},
+    {file = "propcache-0.4.1-cp314-cp314-win_amd64.whl", hash = "sha256:5a103c3eb905fcea0ab98be99c3a9a5ab2de60228aa5aceedc614c0281cf6153"},
+    {file = "propcache-0.4.1-cp314-cp314-win_arm64.whl", hash = "sha256:74c1fb26515153e482e00177a1ad654721bf9207da8a494a0c05e797ad27b992"},
+    {file = "propcache-0.4.1-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:824e908bce90fb2743bd6b59db36eb4f45cd350a39637c9f73b1c1ea66f5b75f"},
+    {file = "propcache-0.4.1-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:c2b5e7db5328427c57c8e8831abda175421b709672f6cfc3d630c3b7e2146393"},
+    {file = "propcache-0.4.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:6f6ff873ed40292cd4969ef5310179afd5db59fdf055897e282485043fc80ad0"},
+    {file = "propcache-0.4.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:49a2dc67c154db2c1463013594c458881a069fcf98940e61a0569016a583020a"},
+    {file = "propcache-0.4.1-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:005f08e6a0529984491e37d8dbc3dd86f84bd78a8ceb5fa9a021f4c48d4984be"},
+    {file = "propcache-0.4.1-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5c3310452e0d31390da9035c348633b43d7e7feb2e37be252be6da45abd1abcc"},
+    {file = "propcache-0.4.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4c3c70630930447f9ef1caac7728c8ad1c56bc5015338b20fed0d08ea2480b3a"},
+    {file = "propcache-0.4.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8e57061305815dfc910a3634dcf584f08168a8836e6999983569f51a8544cd89"},
+    {file = "propcache-0.4.1-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:521a463429ef54143092c11a77e04056dd00636f72e8c45b70aaa3140d639726"},
+    {file = "propcache-0.4.1-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:120c964da3fdc75e3731aa392527136d4ad35868cc556fd09bb6d09172d9a367"},
+    {file = "propcache-0.4.1-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:d8f353eb14ee3441ee844ade4277d560cdd68288838673273b978e3d6d2c8f36"},
+    {file = "propcache-0.4.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ab2943be7c652f09638800905ee1bab2c544e537edb57d527997a24c13dc1455"},
+    {file = "propcache-0.4.1-cp314-cp314t-win32.whl", hash = "sha256:05674a162469f31358c30bcaa8883cb7829fa3110bf9c0991fe27d7896c42d85"},
+    {file = "propcache-0.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:990f6b3e2a27d683cb7602ed6c86f15ee6b43b1194736f9baaeb93d0016633b1"},
+    {file = "propcache-0.4.1-cp314-cp314t-win_arm64.whl", hash = "sha256:ecef2343af4cc68e05131e45024ba34f6095821988a9d0a02aa7c73fcc448aa9"},
+    {file = "propcache-0.4.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:3d233076ccf9e450c8b3bc6720af226b898ef5d051a2d145f7d765e6e9f9bcff"},
+    {file = "propcache-0.4.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:357f5bb5c377a82e105e44bd3d52ba22b616f7b9773714bff93573988ef0a5fb"},
+    {file = "propcache-0.4.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:cbc3b6dfc728105b2a57c06791eb07a94229202ea75c59db644d7d496b698cac"},
+    {file = "propcache-0.4.1-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:182b51b421f0501952d938dc0b0eb45246a5b5153c50d42b495ad5fb7517c888"},
+    {file = "propcache-0.4.1-cp39-cp39-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:4b536b39c5199b96fc6245eb5fb796c497381d3942f169e44e8e392b29c9ebcc"},
+    {file = "propcache-0.4.1-cp39-cp39-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:db65d2af507bbfbdcedb254a11149f894169d90488dd3e7190f7cdcb2d6cd57a"},
+    {file = "propcache-0.4.1-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fd2dbc472da1f772a4dae4fa24be938a6c544671a912e30529984dd80400cd88"},
+    {file = "propcache-0.4.1-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:daede9cd44e0f8bdd9e6cc9a607fc81feb80fae7a5fc6cecaff0e0bb32e42d00"},
+    {file = "propcache-0.4.1-cp39-cp39-musllinux_1_2_armv7l.whl", hash = "sha256:71b749281b816793678ae7f3d0d84bd36e694953822eaad408d682efc5ca18e0"},
+    {file = "propcache-0.4.1-cp39-cp39-musllinux_1_2_ppc64le.whl", hash = "sha256:0002004213ee1f36cfb3f9a42b5066100c44276b9b72b4e1504cddd3d692e86e"},
+    {file = "propcache-0.4.1-cp39-cp39-musllinux_1_2_s390x.whl", hash = "sha256:fe49d0a85038f36ba9e3ffafa1103e61170b28e95b16622e11be0a0ea07c6781"},
+    {file = "propcache-0.4.1-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:99d43339c83aaf4d32bda60928231848eee470c6bda8d02599cc4cebe872d183"},
+    {file = "propcache-0.4.1-cp39-cp39-win32.whl", hash = "sha256:a129e76735bc792794d5177069691c3217898b9f5cee2b2661471e52ffe13f19"},
+    {file = "propcache-0.4.1-cp39-cp39-win_amd64.whl", hash = "sha256:948dab269721ae9a87fd16c514a0a2c2a1bdb23a9a61b969b0f9d9ee2968546f"},
+    {file = "propcache-0.4.1-cp39-cp39-win_arm64.whl", hash = "sha256:5fd37c406dd6dc85aa743e214cef35dc54bbdd1419baac4f6ae5e5b1a2976938"},
+    {file = "propcache-0.4.1-py3-none-any.whl", hash = "sha256:af2a6052aeb6cf17d3e46ee169099044fd8224cbaf75c76a2ef596e8163e2237"},
+    {file = "propcache-0.4.1.tar.gz", hash = "sha256:f48107a8c637e80362555f37ecf49abe20370e557cc4ab374f04ec4423c97c3d"},
+]
+
+[[package]]
 name = "protobuf"
 version = "3.20.3"
 description = "Protocol Buffers"
@@ -1305,6 +2418,37 @@ termcolor = ">=2.1.0"
 
 [package.extras]
 dev = ["black", "flake8", "pre-commit"]
+
+[[package]]
+name = "pytorch-lightning"
+version = "2.6.1"
+description = "PyTorch Lightning is the lightweight PyTorch wrapper for ML researchers. Scale your models. Write less boilerplate."
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+files = [
+    {file = "pytorch_lightning-2.6.1-py3-none-any.whl", hash = "sha256:1f8118567ec829e3055f16cf1aa320883a86a47c836951bfd9dcfa34ec7ffd59"},
+    {file = "pytorch_lightning-2.6.1.tar.gz", hash = "sha256:ba08f8901cf226fcca473046ad9346f414e99117762dc869c76e650d5b3d7bdc"},
+]
+
+[package.dependencies]
+fsspec = {version = ">=2022.5.0", extras = ["http"]}
+lightning-utilities = ">=0.10.0"
+packaging = ">=23.0"
+PyYAML = ">5.4"
+torch = ">=2.1.0"
+torchmetrics = ">0.7.0"
+tqdm = ">=4.57.0"
+typing-extensions = ">4.5.0"
+
+[package.extras]
+all = ["bitsandbytes (>=0.45.2) ; platform_system != \"Darwin\"", "deepspeed (>=0.15.0,<0.17.0) ; platform_system != \"Windows\" and platform_system != \"Darwin\"", "hydra-core (>=1.2.0)", "ipython[all] (>=8.0.0)", "jsonargparse[jsonnet,signatures] (>=4.39.0)", "matplotlib (>3.1)", "omegaconf (>=2.2.3)", "requests (<2.33.0)", "rich (>=12.3.0)", "tensorboardX (>=2.2)", "torchmetrics (>=0.10.0)", "torchvision (>=0.16.0)"]
+deepspeed = ["deepspeed (>=0.15.0,<0.17.0) ; platform_system != \"Windows\" and platform_system != \"Darwin\""]
+dev = ["bitsandbytes (>=0.45.2) ; platform_system != \"Darwin\"", "cloudpickle (>=1.3)", "coverage (==7.10.7) ; python_version < \"3.10\"", "coverage (==7.13.1) ; python_version >= \"3.10\"", "deepspeed (>=0.15.0,<0.17.0) ; platform_system != \"Windows\" and platform_system != \"Darwin\"", "fastapi", "huggingface-hub", "hydra-core (>=1.2.0)", "ipython[all] (>=8.0.0)", "jsonargparse[jsonnet,signatures] (>=4.39.0)", "matplotlib (>3.1)", "numpy (>1.21.0) ; python_version < \"3.12\"", "numpy (>2.1.0) ; python_version >= \"3.12\"", "omegaconf (>=2.2.3)", "onnx (>1.12.0)", "onnxruntime (>=1.12.0)", "onnxscript (>=0.1.0)", "pandas (>2.0)", "psutil (<7.3.0)", "pytest (==9.0.2)", "pytest-cov (==7.0.0)", "pytest-random-order (==1.2.0)", "pytest-rerunfailures (==16.0.1) ; python_version < \"3.10\"", "pytest-rerunfailures (==16.1) ; python_version >= \"3.10\"", "pytest-timeout (==2.4.0)", "requests (<2.33.0)", "rich (>=12.3.0)", "scikit-learn (>0.22.1)", "tensorboard (>=2.11)", "tensorboardX (>=2.2)", "torch-tensorrt ; platform_system != \"Darwin\" and python_version >= \"3.12\"", "torchmetrics (>=0.10.0)", "torchvision (>=0.16.0)", "uvicorn"]
+examples = ["ipython[all] (>=8.0.0)", "requests (<2.33.0)", "torchmetrics (>=0.10.0)", "torchvision (>=0.16.0)"]
+extra = ["bitsandbytes (>=0.45.2) ; platform_system != \"Darwin\"", "hydra-core (>=1.2.0)", "jsonargparse[jsonnet,signatures] (>=4.39.0)", "matplotlib (>3.1)", "omegaconf (>=2.2.3)", "rich (>=12.3.0)", "tensorboardX (>=2.2)"]
+strategies = ["deepspeed (>=0.15.0,<0.17.0) ; platform_system != \"Windows\" and platform_system != \"Darwin\""]
+test = ["cloudpickle (>=1.3)", "coverage (==7.10.7) ; python_version < \"3.10\"", "coverage (==7.13.1) ; python_version >= \"3.10\"", "fastapi", "huggingface-hub", "numpy (>1.21.0) ; python_version < \"3.12\"", "numpy (>2.1.0) ; python_version >= \"3.12\"", "onnx (>1.12.0)", "onnxruntime (>=1.12.0)", "onnxscript (>=0.1.0)", "pandas (>2.0)", "psutil (<7.3.0)", "pytest (==9.0.2)", "pytest-cov (==7.0.0)", "pytest-random-order (==1.2.0)", "pytest-rerunfailures (==16.0.1) ; python_version < \"3.10\"", "pytest-rerunfailures (==16.1) ; python_version >= \"3.10\"", "pytest-timeout (==2.4.0)", "scikit-learn (>0.22.1)", "tensorboard (>=2.11)", "torch-tensorrt ; platform_system != \"Darwin\" and python_version >= \"3.12\"", "uvicorn"]
 
 [[package]]
 name = "pyyaml"
@@ -1681,6 +2825,27 @@ files = [
 ]
 
 [[package]]
+name = "setuptools"
+version = "81.0.0"
+description = "Easily download, build, install, upgrade, and uninstall Python packages"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "setuptools-81.0.0-py3-none-any.whl", hash = "sha256:fdd925d5c5d9f62e4b74b30d6dd7828ce236fd6ed998a08d81de62ce5a6310d6"},
+    {file = "setuptools-81.0.0.tar.gz", hash = "sha256:487b53915f52501f0a79ccfd0c02c165ffe06631443a886740b91af4b7a5845a"},
+]
+
+[package.extras]
+check = ["pytest-checkdocs (>=2.4)", "pytest-ruff (>=0.2.1) ; sys_platform != \"cygwin\"", "ruff (>=0.13.0) ; sys_platform != \"cygwin\""]
+core = ["importlib_metadata (>=6) ; python_version < \"3.10\"", "jaraco.functools (>=4)", "jaraco.text (>=3.7)", "more_itertools", "more_itertools (>=8.8)", "packaging (>=24.2)", "platformdirs (>=4.2.2)", "tomli (>=2.0.1) ; python_version < \"3.11\"", "wheel (>=0.43.0)"]
+cover = ["pytest-cov"]
+doc = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "pyproject-hooks (!=1.1)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-favicon", "sphinx-inline-tabs", "sphinx-lint", "sphinx-notfound-page (>=1,<2)", "sphinx-reredirects", "sphinxcontrib-towncrier", "towncrier (<24.7)"]
+enabler = ["pytest-enabler (>=2.2)"]
+test = ["build[virtualenv] (>=1.0.3)", "filelock (>=3.4.0)", "ini2toml[lite] (>=0.14)", "jaraco.develop (>=7.21) ; python_version >= \"3.9\" and sys_platform != \"cygwin\"", "jaraco.envs (>=2.2)", "jaraco.path (>=3.7.2)", "jaraco.test (>=5.5)", "packaging (>=24.2)", "pip (>=19.1)", "pyproject-hooks (!=1.1)", "pytest (>=6,!=8.1.*)", "pytest-home (>=0.5)", "pytest-perf ; sys_platform != \"cygwin\"", "pytest-subprocess", "pytest-timeout", "pytest-xdist (>=3)", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel (>=0.44.0)"]
+type = ["importlib_metadata (>=7.0.2) ; python_version < \"3.10\"", "jaraco.develop (>=7.21) ; sys_platform != \"cygwin\"", "mypy (==1.18.*)", "pytest-mypy"]
+
+[[package]]
 name = "six"
 version = "1.17.0"
 description = "Python 2 and 3 compatibility utilities"
@@ -1703,6 +2868,24 @@ files = [
     {file = "sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0"},
     {file = "sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88"},
 ]
+
+[[package]]
+name = "sympy"
+version = "1.14.0"
+description = "Computer algebra system (CAS) in Python"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "sympy-1.14.0-py3-none-any.whl", hash = "sha256:e091cc3e99d2141a0ba2847328f5479b05d94a6635cb96148ccb3f34671bd8f5"},
+    {file = "sympy-1.14.0.tar.gz", hash = "sha256:d3d3fe8df1e5a0b42f0e7bdf50541697dbe7d23746e894990c030e2b05e72517"},
+]
+
+[package.dependencies]
+mpmath = ">=1.1.0,<1.4"
+
+[package.extras]
+dev = ["hypothesis (>=6.70.0)", "pytest (>=7.1.0)"]
 
 [[package]]
 name = "termcolor"
@@ -1772,6 +2955,109 @@ files = [
 ]
 
 [[package]]
+name = "torch"
+version = "2.10.0"
+description = "Tensors and Dynamic neural networks in Python with strong GPU acceleration"
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+files = [
+    {file = "torch-2.10.0-1-cp310-none-macosx_11_0_arm64.whl", hash = "sha256:c37fc46eedd9175f9c81814cc47308f1b42cfe4987e532d4b423d23852f2bf63"},
+    {file = "torch-2.10.0-1-cp311-none-macosx_11_0_arm64.whl", hash = "sha256:f699f31a236a677b3118bc0a3ef3d89c0c29b5ec0b20f4c4bf0b110378487464"},
+    {file = "torch-2.10.0-1-cp312-none-macosx_11_0_arm64.whl", hash = "sha256:6abb224c2b6e9e27b592a1c0015c33a504b00a0e0938f1499f7f514e9b7bfb5c"},
+    {file = "torch-2.10.0-1-cp313-none-macosx_11_0_arm64.whl", hash = "sha256:7350f6652dfd761f11f9ecb590bfe95b573e2961f7a242eccb3c8e78348d26fe"},
+    {file = "torch-2.10.0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:5276fa790a666ee8becaffff8acb711922252521b28fbce5db7db5cf9cb2026d"},
+    {file = "torch-2.10.0-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:aaf663927bcd490ae971469a624c322202a2a1e68936eb952535ca4cd3b90444"},
+    {file = "torch-2.10.0-cp310-cp310-win_amd64.whl", hash = "sha256:a4be6a2a190b32ff5c8002a0977a25ea60e64f7ba46b1be37093c141d9c49aeb"},
+    {file = "torch-2.10.0-cp310-none-macosx_11_0_arm64.whl", hash = "sha256:35e407430795c8d3edb07a1d711c41cc1f9eaddc8b2f1cc0a165a6767a8fb73d"},
+    {file = "torch-2.10.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:3282d9febd1e4e476630a099692b44fdc214ee9bf8ee5377732d9d9dfe5712e4"},
+    {file = "torch-2.10.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:a2f9edd8dbc99f62bc4dfb78af7bf89499bca3d753423ac1b4e06592e467b763"},
+    {file = "torch-2.10.0-cp311-cp311-win_amd64.whl", hash = "sha256:29b7009dba4b7a1c960260fc8ac85022c784250af43af9fb0ebafc9883782ebd"},
+    {file = "torch-2.10.0-cp311-none-macosx_11_0_arm64.whl", hash = "sha256:b7bd80f3477b830dd166c707c5b0b82a898e7b16f59a7d9d42778dd058272e8b"},
+    {file = "torch-2.10.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:5fd4117d89ffd47e3dcc71e71a22efac24828ad781c7e46aaaf56bf7f2796acf"},
+    {file = "torch-2.10.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:787124e7db3b379d4f1ed54dd12ae7c741c16a4d29b49c0226a89bea50923ffb"},
+    {file = "torch-2.10.0-cp312-cp312-win_amd64.whl", hash = "sha256:2c66c61f44c5f903046cc696d088e21062644cbe541c7f1c4eaae88b2ad23547"},
+    {file = "torch-2.10.0-cp312-none-macosx_11_0_arm64.whl", hash = "sha256:6d3707a61863d1c4d6ebba7be4ca320f42b869ee657e9b2c21c736bf17000294"},
+    {file = "torch-2.10.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:5c4d217b14741e40776dd7074d9006fd28b8a97ef5654db959d8635b2fe5f29b"},
+    {file = "torch-2.10.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:6b71486353fce0f9714ca0c9ef1c850a2ae766b409808acd58e9678a3edb7738"},
+    {file = "torch-2.10.0-cp313-cp313-win_amd64.whl", hash = "sha256:c2ee399c644dc92ef7bc0d4f7e74b5360c37cdbe7c5ba11318dda49ffac2bc57"},
+    {file = "torch-2.10.0-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:3202429f58309b9fa96a614885eace4b7995729f44beb54d3e4a47773649d382"},
+    {file = "torch-2.10.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:aae1b29cd68e50a9397f5ee897b9c24742e9e306f88a807a27d617f07adb3bd8"},
+    {file = "torch-2.10.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:6021db85958db2f07ec94e1bc77212721ba4920c12a18dc552d2ae36a3eb163f"},
+    {file = "torch-2.10.0-cp313-cp313t-win_amd64.whl", hash = "sha256:ff43db38af76fda183156153983c9a096fc4c78d0cd1e07b14a2314c7f01c2c8"},
+    {file = "torch-2.10.0-cp313-none-macosx_11_0_arm64.whl", hash = "sha256:cdf2a523d699b70d613243211ecaac14fe9c5df8a0b0a9c02add60fb2a413e0f"},
+    {file = "torch-2.10.0-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:bf0d9ff448b0218e0433aeb198805192346c4fd659c852370d5cc245f602a06a"},
+    {file = "torch-2.10.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:233aed0659a2503b831d8a67e9da66a62c996204c0bba4f4c442ccc0c68a3f60"},
+    {file = "torch-2.10.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:682497e16bdfa6efeec8cde66531bc8d1fbbbb4d8788ec6173c089ed3cc2bfe5"},
+    {file = "torch-2.10.0-cp314-cp314-win_amd64.whl", hash = "sha256:6528f13d2a8593a1a412ea07a99812495bec07e9224c28b2a25c0a30c7da025c"},
+    {file = "torch-2.10.0-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:f5ab4ba32383061be0fb74bda772d470140a12c1c3b58a0cfbf3dae94d164c28"},
+    {file = "torch-2.10.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:716b01a176c2a5659c98f6b01bf868244abdd896526f1c692712ab36dbaf9b63"},
+    {file = "torch-2.10.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:d8f5912ba938233f86361e891789595ff35ca4b4e2ac8fe3670895e5976731d6"},
+    {file = "torch-2.10.0-cp314-cp314t-win_amd64.whl", hash = "sha256:71283a373f0ee2c89e0f0d5f446039bdabe8dbc3c9ccf35f0f784908b0acd185"},
+]
+
+[package.dependencies]
+cuda-bindings = {version = "12.9.4", markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""}
+filelock = "*"
+fsspec = ">=0.8.5"
+jinja2 = "*"
+networkx = ">=2.5.1"
+nvidia-cublas-cu12 = {version = "12.8.4.1", markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""}
+nvidia-cuda-cupti-cu12 = {version = "12.8.90", markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""}
+nvidia-cuda-nvrtc-cu12 = {version = "12.8.93", markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""}
+nvidia-cuda-runtime-cu12 = {version = "12.8.90", markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""}
+nvidia-cudnn-cu12 = {version = "9.10.2.21", markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""}
+nvidia-cufft-cu12 = {version = "11.3.3.83", markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""}
+nvidia-cufile-cu12 = {version = "1.13.1.3", markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""}
+nvidia-curand-cu12 = {version = "10.3.9.90", markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""}
+nvidia-cusolver-cu12 = {version = "11.7.3.90", markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""}
+nvidia-cusparse-cu12 = {version = "12.5.8.93", markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""}
+nvidia-cusparselt-cu12 = {version = "0.7.1", markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""}
+nvidia-nccl-cu12 = {version = "2.27.5", markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""}
+nvidia-nvjitlink-cu12 = {version = "12.8.93", markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""}
+nvidia-nvshmem-cu12 = {version = "3.4.5", markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""}
+nvidia-nvtx-cu12 = {version = "12.8.90", markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""}
+sympy = ">=1.13.3"
+triton = {version = "3.6.0", markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""}
+typing-extensions = ">=4.10.0"
+
+[package.extras]
+opt-einsum = ["opt-einsum (>=3.3)"]
+optree = ["optree (>=0.13.0)"]
+pyyaml = ["pyyaml"]
+
+[[package]]
+name = "torchmetrics"
+version = "1.8.2"
+description = "PyTorch native Metrics"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "torchmetrics-1.8.2-py3-none-any.whl", hash = "sha256:08382fd96b923e39e904c4d570f3d49e2cc71ccabd2a94e0f895d1f0dac86242"},
+    {file = "torchmetrics-1.8.2.tar.gz", hash = "sha256:cf64a901036bf107f17a524009eea7781c9c5315d130713aeca5747a686fe7a5"},
+]
+
+[package.dependencies]
+lightning-utilities = ">=0.8.0"
+numpy = ">1.20.0"
+packaging = ">17.1"
+torch = ">=2.0.0"
+
+[package.extras]
+all = ["SciencePlots (>=2.0.0)", "einops (>=0.7.0)", "einops (>=0.7.0)", "gammatone (>=1.0.0)", "ipadic (>=1.0.0)", "librosa (>=0.10.0)", "matplotlib (>=3.6.0)", "mecab-python3 (>=1.0.6)", "mypy (==1.17.1)", "nltk (>3.8.1)", "onnxruntime (>=1.12.0)", "pesq (>=0.0.4)", "piq (<=0.8.0)", "pycocotools (>2.0.0)", "pystoi (>=0.4.0)", "regex (>=2021.9.24)", "requests (>=2.19.0)", "scipy (>1.0.0)", "sentencepiece (>=0.2.0)", "timm (>=0.9.0)", "torch (==2.8.0)", "torch-fidelity (<=0.4.0)", "torch_linear_assignment (>=0.0.2)", "torchaudio (>=2.0.1)", "torchvision (>=0.15.1)", "torchvision (>=0.15.1)", "tqdm (<4.68.0)", "transformers (>=4.43.0)", "transformers (>=4.43.0)", "types-PyYAML", "types-emoji", "types-protobuf", "types-requests", "types-setuptools", "types-six", "types-tabulate", "vmaf-torch (>=1.1.0)"]
+audio = ["gammatone (>=1.0.0)", "librosa (>=0.10.0)", "onnxruntime (>=1.12.0)", "pesq (>=0.0.4)", "pystoi (>=0.4.0)", "requests (>=2.19.0)", "torchaudio (>=2.0.1)"]
+clustering = ["torch_linear_assignment (>=0.0.2)"]
+detection = ["pycocotools (>2.0.0)", "torchvision (>=0.15.1)"]
+dev = ["PyTDC (==0.4.1) ; python_version < \"3.10\" or platform_system == \"Windows\" and python_version < \"3.12\"", "SciencePlots (>=2.0.0)", "aeon (>=1.0.0) ; python_version > \"3.10\"", "bert_score (==0.3.13)", "dists-pytorch (==0.1)", "dython (==0.7.9)", "einops (>=0.7.0)", "einops (>=0.7.0)", "fairlearn", "fast-bss-eval (>=0.1.0)", "faster-coco-eval (>=1.6.3)", "gammatone (>=1.0.0)", "huggingface-hub (<0.35)", "ipadic (>=1.0.0)", "jiwer (>=2.3.0)", "kornia (>=0.6.7)", "librosa (>=0.10.0)", "lpips (<=0.1.4)", "matplotlib (>=3.6.0)", "mecab-ko (>=1.0.0,<1.1.0) ; python_version < \"3.12\"", "mecab-ko-dic (>=1.0.0) ; python_version < \"3.12\"", "mecab-python3 (>=1.0.6)", "mir-eval (>=0.6)", "monai (==1.4.0)", "mypy (==1.17.1)", "netcal (>1.0.0)", "nltk (>3.8.1)", "numpy (<2.4.0)", "onnxruntime (>=1.12.0)", "pandas (>1.4.0)", "permetrics (==2.0.0)", "pesq (>=0.0.4)", "piq (<=0.8.0)", "properscoring (==0.1)", "pycocotools (>2.0.0)", "pystoi (>=0.4.0)", "pytorch-msssim (==1.0.0)", "regex (>=2021.9.24)", "requests (>=2.19.0)", "rouge-score (>0.1.0)", "sacrebleu (>=2.3.0)", "scikit-image (>=0.19.0)", "scipy (>1.0.0)", "scipy (>1.0.0)", "sentencepiece (>=0.2.0)", "sewar (>=0.4.4)", "statsmodels (>0.13.5)", "timm (>=0.9.0)", "torch (==2.8.0)", "torch-fidelity (<=0.4.0)", "torch_complex (<0.5.0)", "torch_linear_assignment (>=0.0.2)", "torchaudio (>=2.0.1)", "torchvision (>=0.15.1)", "torchvision (>=0.15.1)", "tqdm (<4.68.0)", "transformers (>=4.43.0)", "transformers (>=4.43.0)", "types-PyYAML", "types-emoji", "types-protobuf", "types-requests", "types-setuptools", "types-six", "types-tabulate", "vmaf-torch (>=1.1.0)"]
+image = ["scipy (>1.0.0)", "torch-fidelity (<=0.4.0)", "torchvision (>=0.15.1)"]
+multimodal = ["einops (>=0.7.0)", "piq (<=0.8.0)", "timm (>=0.9.0)", "transformers (>=4.43.0)"]
+text = ["ipadic (>=1.0.0)", "mecab-python3 (>=1.0.6)", "nltk (>3.8.1)", "regex (>=2021.9.24)", "sentencepiece (>=0.2.0)", "tqdm (<4.68.0)", "transformers (>=4.43.0)"]
+typing = ["mypy (==1.17.1)", "torch (==2.8.0)", "types-PyYAML", "types-emoji", "types-protobuf", "types-requests", "types-setuptools", "types-six", "types-tabulate"]
+video = ["einops (>=0.7.0)", "vmaf-torch (>=1.1.0)"]
+visual = ["SciencePlots (>=2.0.0)", "matplotlib (>=3.6.0)"]
+
+[[package]]
 name = "tox"
 version = "3.28.0"
 description = "tox is a generic virtualenv management and test command line tool"
@@ -1796,6 +3082,58 @@ virtualenv = ">=16.0.0,<20.0.0 || >20.0.0,<20.0.1 || >20.0.1,<20.0.2 || >20.0.2,
 [package.extras]
 docs = ["pygments-github-lexers (>=0.0.5)", "sphinx (>=2.0.0)", "sphinxcontrib-autoprogram (>=0.1.5)", "towncrier (>=18.5.0)"]
 testing = ["flaky (>=3.4.0)", "freezegun (>=0.3.11)", "pathlib2 (>=2.3.3) ; python_version < \"3.4\"", "psutil (>=5.6.1) ; platform_python_implementation == \"cpython\"", "pytest (>=4.0.0)", "pytest-cov (>=2.5.1)", "pytest-mock (>=1.10.0)", "pytest-randomly (>=1.0.0)"]
+
+[[package]]
+name = "tqdm"
+version = "4.67.3"
+description = "Fast, Extensible Progress Meter"
+optional = false
+python-versions = ">=3.7"
+groups = ["main"]
+files = [
+    {file = "tqdm-4.67.3-py3-none-any.whl", hash = "sha256:ee1e4c0e59148062281c49d80b25b67771a127c85fc9676d3be5f243206826bf"},
+    {file = "tqdm-4.67.3.tar.gz", hash = "sha256:7d825f03f89244ef73f1d4ce193cb1774a8179fd96f31d7e1dcde62092b960bb"},
+]
+
+[package.dependencies]
+colorama = {version = "*", markers = "platform_system == \"Windows\""}
+
+[package.extras]
+dev = ["nbval", "pytest (>=6)", "pytest-asyncio (>=0.24)", "pytest-cov", "pytest-timeout"]
+discord = ["requests"]
+notebook = ["ipywidgets (>=6)"]
+slack = ["slack-sdk"]
+telegram = ["requests"]
+
+[[package]]
+name = "triton"
+version = "3.6.0"
+description = "A language and compiler for custom Deep Learning operations"
+optional = false
+python-versions = "<3.15,>=3.10"
+groups = ["main"]
+markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""
+files = [
+    {file = "triton-3.6.0-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6c723cfb12f6842a0ae94ac307dba7e7a44741d720a40cf0e270ed4a4e3be781"},
+    {file = "triton-3.6.0-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a6550fae429e0667e397e5de64b332d1e5695b73650ee75a6146e2e902770bea"},
+    {file = "triton-3.6.0-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:49df5ef37379c0c2b5c0012286f80174fcf0e073e5ade1ca9a86c36814553651"},
+    {file = "triton-3.6.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e8e323d608e3a9bfcc2d9efcc90ceefb764a82b99dea12a86d643c72539ad5d3"},
+    {file = "triton-3.6.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:374f52c11a711fd062b4bfbb201fd9ac0a5febd28a96fb41b4a0f51dde3157f4"},
+    {file = "triton-3.6.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:74caf5e34b66d9f3a429af689c1c7128daba1d8208df60e81106b115c00d6fca"},
+    {file = "triton-3.6.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:448e02fe6dc898e9e5aa89cf0ee5c371e99df5aa5e8ad976a80b93334f3494fd"},
+    {file = "triton-3.6.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:10c7f76c6e72d2ef08df639e3d0d30729112f47a56b0c81672edc05ee5116ac9"},
+    {file = "triton-3.6.0-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1722e172d34e32abc3eb7711d0025bb69d7959ebea84e3b7f7a341cd7ed694d6"},
+    {file = "triton-3.6.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d002e07d7180fd65e622134fbd980c9a3d4211fb85224b56a0a0efbd422ab72f"},
+    {file = "triton-3.6.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ef5523241e7d1abca00f1d240949eebdd7c673b005edbbce0aca95b8191f1d43"},
+    {file = "triton-3.6.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a17a5d5985f0ac494ed8a8e54568f092f7057ef60e1b0fa09d3fd1512064e803"},
+    {file = "triton-3.6.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0b3a97e8ed304dfa9bd23bb41ca04cdf6b2e617d5e782a8653d616037a5d537d"},
+    {file = "triton-3.6.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:46bd1c1af4b6704e554cad2eeb3b0a6513a980d470ccfa63189737340c7746a7"},
+]
+
+[package.extras]
+build = ["cmake (>=3.20,<4.0)", "lit"]
+tests = ["autopep8", "isort", "llnl-hatchet", "numpy", "pytest", "pytest-forked", "pytest-xdist", "scipy (>=1.7.1)"]
+tutorials = ["matplotlib", "pandas", "tabulate"]
 
 [[package]]
 name = "typing-extensions"
@@ -1850,6 +3188,151 @@ docs = ["furo (>=2023.7.26)", "proselint (>=0.13)", "sphinx (>=7.1.2,!=7.3)", "s
 test = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "coverage-enable-subprocess (>=1)", "flaky (>=3.7)", "packaging (>=23.1)", "pytest (>=7.4)", "pytest-env (>=0.8.2)", "pytest-freezer (>=0.4.8) ; platform_python_implementation == \"PyPy\" or platform_python_implementation == \"GraalVM\" or platform_python_implementation == \"CPython\" and sys_platform == \"win32\" and python_version >= \"3.13\"", "pytest-mock (>=3.11.1)", "pytest-randomly (>=3.12)", "pytest-timeout (>=2.1)", "setuptools (>=68)", "time-machine (>=2.10) ; platform_python_implementation == \"CPython\""]
 
 [[package]]
+name = "yarl"
+version = "1.22.0"
+description = "Yet another URL library"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "yarl-1.22.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:c7bd6683587567e5a49ee6e336e0612bec8329be1b7d4c8af5687dcdeb67ee1e"},
+    {file = "yarl-1.22.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:5cdac20da754f3a723cceea5b3448e1a2074866406adeb4ef35b469d089adb8f"},
+    {file = "yarl-1.22.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:07a524d84df0c10f41e3ee918846e1974aba4ec017f990dc735aad487a0bdfdf"},
+    {file = "yarl-1.22.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e1b329cb8146d7b736677a2440e422eadd775d1806a81db2d4cded80a48efc1a"},
+    {file = "yarl-1.22.0-cp310-cp310-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:75976c6945d85dbb9ee6308cd7ff7b1fb9409380c82d6119bd778d8fcfe2931c"},
+    {file = "yarl-1.22.0-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:80ddf7a5f8c86cb3eb4bc9028b07bbbf1f08a96c5c0bc1244be5e8fefcb94147"},
+    {file = "yarl-1.22.0-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:d332fc2e3c94dad927f2112395772a4e4fedbcf8f80efc21ed7cdfae4d574fdb"},
+    {file = "yarl-1.22.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0cf71bf877efeac18b38d3930594c0948c82b64547c1cf420ba48722fe5509f6"},
+    {file = "yarl-1.22.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:663e1cadaddae26be034a6ab6072449a8426ddb03d500f43daf952b74553bba0"},
+    {file = "yarl-1.22.0-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:6dcbb0829c671f305be48a7227918cfcd11276c2d637a8033a99a02b67bf9eda"},
+    {file = "yarl-1.22.0-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:f0d97c18dfd9a9af4490631905a3f131a8e4c9e80a39353919e2cfed8f00aedc"},
+    {file = "yarl-1.22.0-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:437840083abe022c978470b942ff832c3940b2ad3734d424b7eaffcd07f76737"},
+    {file = "yarl-1.22.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:a899cbd98dce6f5d8de1aad31cb712ec0a530abc0a86bd6edaa47c1090138467"},
+    {file = "yarl-1.22.0-cp310-cp310-win32.whl", hash = "sha256:595697f68bd1f0c1c159fcb97b661fc9c3f5db46498043555d04805430e79bea"},
+    {file = "yarl-1.22.0-cp310-cp310-win_amd64.whl", hash = "sha256:cb95a9b1adaa48e41815a55ae740cfda005758104049a640a398120bf02515ca"},
+    {file = "yarl-1.22.0-cp310-cp310-win_arm64.whl", hash = "sha256:b85b982afde6df99ecc996990d4ad7ccbdbb70e2a4ba4de0aecde5922ba98a0b"},
+    {file = "yarl-1.22.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:1ab72135b1f2db3fed3997d7e7dc1b80573c67138023852b6efb336a5eae6511"},
+    {file = "yarl-1.22.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:669930400e375570189492dc8d8341301578e8493aec04aebc20d4717f899dd6"},
+    {file = "yarl-1.22.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:792a2af6d58177ef7c19cbf0097aba92ca1b9cb3ffdd9c7470e156c8f9b5e028"},
+    {file = "yarl-1.22.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3ea66b1c11c9150f1372f69afb6b8116f2dd7286f38e14ea71a44eee9ec51b9d"},
+    {file = "yarl-1.22.0-cp311-cp311-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:3e2daa88dc91870215961e96a039ec73e4937da13cf77ce17f9cad0c18df3503"},
+    {file = "yarl-1.22.0-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ba440ae430c00eee41509353628600212112cd5018d5def7e9b05ea7ac34eb65"},
+    {file = "yarl-1.22.0-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:e6438cc8f23a9c1478633d216b16104a586b9761db62bfacb6425bac0a36679e"},
+    {file = "yarl-1.22.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4c52a6e78aef5cf47a98ef8e934755abf53953379b7d53e68b15ff4420e6683d"},
+    {file = "yarl-1.22.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:3b06bcadaac49c70f4c88af4ffcfbe3dc155aab3163e75777818092478bcbbe7"},
+    {file = "yarl-1.22.0-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:6944b2dc72c4d7f7052683487e3677456050ff77fcf5e6204e98caf785ad1967"},
+    {file = "yarl-1.22.0-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:d5372ca1df0f91a86b047d1277c2aaf1edb32d78bbcefffc81b40ffd18f027ed"},
+    {file = "yarl-1.22.0-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:51af598701f5299012b8416486b40fceef8c26fc87dc6d7d1f6fc30609ea0aa6"},
+    {file = "yarl-1.22.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:b266bd01fedeffeeac01a79ae181719ff848a5a13ce10075adbefc8f1daee70e"},
+    {file = "yarl-1.22.0-cp311-cp311-win32.whl", hash = "sha256:a9b1ba5610a4e20f655258d5a1fdc7ebe3d837bb0e45b581398b99eb98b1f5ca"},
+    {file = "yarl-1.22.0-cp311-cp311-win_amd64.whl", hash = "sha256:078278b9b0b11568937d9509b589ee83ef98ed6d561dfe2020e24a9fd08eaa2b"},
+    {file = "yarl-1.22.0-cp311-cp311-win_arm64.whl", hash = "sha256:b6a6f620cfe13ccec221fa312139135166e47ae169f8253f72a0abc0dae94376"},
+    {file = "yarl-1.22.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:e340382d1afa5d32b892b3ff062436d592ec3d692aeea3bef3a5cfe11bbf8c6f"},
+    {file = "yarl-1.22.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:f1e09112a2c31ffe8d80be1b0988fa6a18c5d5cad92a9ffbb1c04c91bfe52ad2"},
+    {file = "yarl-1.22.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:939fe60db294c786f6b7c2d2e121576628468f65453d86b0fe36cb52f987bd74"},
+    {file = "yarl-1.22.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e1651bf8e0398574646744c1885a41198eba53dc8a9312b954073f845c90a8df"},
+    {file = "yarl-1.22.0-cp312-cp312-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:b8a0588521a26bf92a57a1705b77b8b59044cdceccac7151bd8d229e66b8dedb"},
+    {file = "yarl-1.22.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:42188e6a615c1a75bcaa6e150c3fe8f3e8680471a6b10150c5f7e83f47cc34d2"},
+    {file = "yarl-1.22.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:f6d2cb59377d99718913ad9a151030d6f83ef420a2b8f521d94609ecc106ee82"},
+    {file = "yarl-1.22.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:50678a3b71c751d58d7908edc96d332af328839eea883bb554a43f539101277a"},
+    {file = "yarl-1.22.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:1e8fbaa7cec507aa24ea27a01456e8dd4b6fab829059b69844bd348f2d467124"},
+    {file = "yarl-1.22.0-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:433885ab5431bc3d3d4f2f9bd15bfa1614c522b0f1405d62c4f926ccd69d04fa"},
+    {file = "yarl-1.22.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:b790b39c7e9a4192dc2e201a282109ed2985a1ddbd5ac08dc56d0e121400a8f7"},
+    {file = "yarl-1.22.0-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:31f0b53913220599446872d757257be5898019c85e7971599065bc55065dc99d"},
+    {file = "yarl-1.22.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:a49370e8f711daec68d09b821a34e1167792ee2d24d405cbc2387be4f158b520"},
+    {file = "yarl-1.22.0-cp312-cp312-win32.whl", hash = "sha256:70dfd4f241c04bd9239d53b17f11e6ab672b9f1420364af63e8531198e3f5fe8"},
+    {file = "yarl-1.22.0-cp312-cp312-win_amd64.whl", hash = "sha256:8884d8b332a5e9b88e23f60bb166890009429391864c685e17bd73a9eda9105c"},
+    {file = "yarl-1.22.0-cp312-cp312-win_arm64.whl", hash = "sha256:ea70f61a47f3cc93bdf8b2f368ed359ef02a01ca6393916bc8ff877427181e74"},
+    {file = "yarl-1.22.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:8dee9c25c74997f6a750cd317b8ca63545169c098faee42c84aa5e506c819b53"},
+    {file = "yarl-1.22.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:01e73b85a5434f89fc4fe27dcda2aff08ddf35e4d47bbbea3bdcd25321af538a"},
+    {file = "yarl-1.22.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:22965c2af250d20c873cdbee8ff958fb809940aeb2e74ba5f20aaf6b7ac8c70c"},
+    {file = "yarl-1.22.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b4f15793aa49793ec8d1c708ab7f9eded1aa72edc5174cae703651555ed1b601"},
+    {file = "yarl-1.22.0-cp313-cp313-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:e5542339dcf2747135c5c85f68680353d5cb9ffd741c0f2e8d832d054d41f35a"},
+    {file = "yarl-1.22.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:5c401e05ad47a75869c3ab3e35137f8468b846770587e70d71e11de797d113df"},
+    {file = "yarl-1.22.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:243dda95d901c733f5b59214d28b0120893d91777cb8aa043e6ef059d3cddfe2"},
+    {file = "yarl-1.22.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bec03d0d388060058f5d291a813f21c011041938a441c593374da6077fe21b1b"},
+    {file = "yarl-1.22.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:b0748275abb8c1e1e09301ee3cf90c8a99678a4e92e4373705f2a2570d581273"},
+    {file = "yarl-1.22.0-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:47fdb18187e2a4e18fda2c25c05d8251a9e4a521edaed757fef033e7d8498d9a"},
+    {file = "yarl-1.22.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:c7044802eec4524fde550afc28edda0dd5784c4c45f0be151a2d3ba017daca7d"},
+    {file = "yarl-1.22.0-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:139718f35149ff544caba20fce6e8a2f71f1e39b92c700d8438a0b1d2a631a02"},
+    {file = "yarl-1.22.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:e1b51bebd221006d3d2f95fbe124b22b247136647ae5dcc8c7acafba66e5ee67"},
+    {file = "yarl-1.22.0-cp313-cp313-win32.whl", hash = "sha256:d3e32536234a95f513bd374e93d717cf6b2231a791758de6c509e3653f234c95"},
+    {file = "yarl-1.22.0-cp313-cp313-win_amd64.whl", hash = "sha256:47743b82b76d89a1d20b83e60d5c20314cbd5ba2befc9cda8f28300c4a08ed4d"},
+    {file = "yarl-1.22.0-cp313-cp313-win_arm64.whl", hash = "sha256:5d0fcda9608875f7d052eff120c7a5da474a6796fe4d83e152e0e4d42f6d1a9b"},
+    {file = "yarl-1.22.0-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:719ae08b6972befcba4310e49edb1161a88cdd331e3a694b84466bd938a6ab10"},
+    {file = "yarl-1.22.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:47d8a5c446df1c4db9d21b49619ffdba90e77c89ec6e283f453856c74b50b9e3"},
+    {file = "yarl-1.22.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:cfebc0ac8333520d2d0423cbbe43ae43c8838862ddb898f5ca68565e395516e9"},
+    {file = "yarl-1.22.0-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4398557cbf484207df000309235979c79c4356518fd5c99158c7d38203c4da4f"},
+    {file = "yarl-1.22.0-cp313-cp313t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:2ca6fd72a8cd803be290d42f2dec5cdcd5299eeb93c2d929bf060ad9efaf5de0"},
+    {file = "yarl-1.22.0-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ca1f59c4e1ab6e72f0a23c13fca5430f889634166be85dbf1013683e49e3278e"},
+    {file = "yarl-1.22.0-cp313-cp313t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:6c5010a52015e7c70f86eb967db0f37f3c8bd503a695a49f8d45700144667708"},
+    {file = "yarl-1.22.0-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9d7672ecf7557476642c88497c2f8d8542f8e36596e928e9bcba0e42e1e7d71f"},
+    {file = "yarl-1.22.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:3b7c88eeef021579d600e50363e0b6ee4f7f6f728cd3486b9d0f3ee7b946398d"},
+    {file = "yarl-1.22.0-cp313-cp313t-musllinux_1_2_armv7l.whl", hash = "sha256:f4afb5c34f2c6fecdcc182dfcfc6af6cccf1aa923eed4d6a12e9d96904e1a0d8"},
+    {file = "yarl-1.22.0-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:59c189e3e99a59cf8d83cbb31d4db02d66cda5a1a4374e8a012b51255341abf5"},
+    {file = "yarl-1.22.0-cp313-cp313t-musllinux_1_2_s390x.whl", hash = "sha256:5a3bf7f62a289fa90f1990422dc8dff5a458469ea71d1624585ec3a4c8d6960f"},
+    {file = "yarl-1.22.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:de6b9a04c606978fdfe72666fa216ffcf2d1a9f6a381058d4378f8d7b1e5de62"},
+    {file = "yarl-1.22.0-cp313-cp313t-win32.whl", hash = "sha256:1834bb90991cc2999f10f97f5f01317f99b143284766d197e43cd5b45eb18d03"},
+    {file = "yarl-1.22.0-cp313-cp313t-win_amd64.whl", hash = "sha256:ff86011bd159a9d2dfc89c34cfd8aff12875980e3bd6a39ff097887520e60249"},
+    {file = "yarl-1.22.0-cp313-cp313t-win_arm64.whl", hash = "sha256:7861058d0582b847bc4e3a4a4c46828a410bca738673f35a29ba3ca5db0b473b"},
+    {file = "yarl-1.22.0-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:34b36c2c57124530884d89d50ed2c1478697ad7473efd59cfd479945c95650e4"},
+    {file = "yarl-1.22.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:0dd9a702591ca2e543631c2a017e4a547e38a5c0f29eece37d9097e04a7ac683"},
+    {file = "yarl-1.22.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:594fcab1032e2d2cc3321bb2e51271e7cd2b516c7d9aee780ece81b07ff8244b"},
+    {file = "yarl-1.22.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f3d7a87a78d46a2e3d5b72587ac14b4c16952dd0887dbb051451eceac774411e"},
+    {file = "yarl-1.22.0-cp314-cp314-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:852863707010316c973162e703bddabec35e8757e67fcb8ad58829de1ebc8590"},
+    {file = "yarl-1.22.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:131a085a53bfe839a477c0845acf21efc77457ba2bcf5899618136d64f3303a2"},
+    {file = "yarl-1.22.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:078a8aefd263f4d4f923a9677b942b445a2be970ca24548a8102689a3a8ab8da"},
+    {file = "yarl-1.22.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bca03b91c323036913993ff5c738d0842fc9c60c4648e5c8d98331526df89784"},
+    {file = "yarl-1.22.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:68986a61557d37bb90d3051a45b91fa3d5c516d177dfc6dd6f2f436a07ff2b6b"},
+    {file = "yarl-1.22.0-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:4792b262d585ff0dff6bcb787f8492e40698443ec982a3568c2096433660c694"},
+    {file = "yarl-1.22.0-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:ebd4549b108d732dba1d4ace67614b9545b21ece30937a63a65dd34efa19732d"},
+    {file = "yarl-1.22.0-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:f87ac53513d22240c7d59203f25cc3beac1e574c6cd681bbfd321987b69f95fd"},
+    {file = "yarl-1.22.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:22b029f2881599e2f1b06f8f1db2ee63bd309e2293ba2d566e008ba12778b8da"},
+    {file = "yarl-1.22.0-cp314-cp314-win32.whl", hash = "sha256:6a635ea45ba4ea8238463b4f7d0e721bad669f80878b7bfd1f89266e2ae63da2"},
+    {file = "yarl-1.22.0-cp314-cp314-win_amd64.whl", hash = "sha256:0d6e6885777af0f110b0e5d7e5dda8b704efed3894da26220b7f3d887b839a79"},
+    {file = "yarl-1.22.0-cp314-cp314-win_arm64.whl", hash = "sha256:8218f4e98d3c10d683584cb40f0424f4b9fd6e95610232dd75e13743b070ee33"},
+    {file = "yarl-1.22.0-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:45c2842ff0e0d1b35a6bf1cd6c690939dacb617a70827f715232b2e0494d55d1"},
+    {file = "yarl-1.22.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:d947071e6ebcf2e2bee8fce76e10faca8f7a14808ca36a910263acaacef08eca"},
+    {file = "yarl-1.22.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:334b8721303e61b00019474cc103bdac3d7b1f65e91f0bfedeec2d56dfe74b53"},
+    {file = "yarl-1.22.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1e7ce67c34138a058fd092f67d07a72b8e31ff0c9236e751957465a24b28910c"},
+    {file = "yarl-1.22.0-cp314-cp314t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:d77e1b2c6d04711478cb1c4ab90db07f1609ccf06a287d5607fcd90dc9863acf"},
+    {file = "yarl-1.22.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c4647674b6150d2cae088fc07de2738a84b8bcedebef29802cf0b0a82ab6face"},
+    {file = "yarl-1.22.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:efb07073be061c8f79d03d04139a80ba33cbd390ca8f0297aae9cce6411e4c6b"},
+    {file = "yarl-1.22.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e51ac5435758ba97ad69617e13233da53908beccc6cfcd6c34bbed8dcbede486"},
+    {file = "yarl-1.22.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:33e32a0dd0c8205efa8e83d04fc9f19313772b78522d1bdc7d9aed706bfd6138"},
+    {file = "yarl-1.22.0-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:bf4a21e58b9cde0e401e683ebd00f6ed30a06d14e93f7c8fd059f8b6e8f87b6a"},
+    {file = "yarl-1.22.0-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:e4b582bab49ac33c8deb97e058cd67c2c50dac0dd134874106d9c774fd272529"},
+    {file = "yarl-1.22.0-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:0b5bcc1a9c4839e7e30b7b30dd47fe5e7e44fb7054ec29b5bb8d526aa1041093"},
+    {file = "yarl-1.22.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:c0232bce2170103ec23c454e54a57008a9a72b5d1c3105dc2496750da8cfa47c"},
+    {file = "yarl-1.22.0-cp314-cp314t-win32.whl", hash = "sha256:8009b3173bcd637be650922ac455946197d858b3630b6d8787aa9e5c4564533e"},
+    {file = "yarl-1.22.0-cp314-cp314t-win_amd64.whl", hash = "sha256:9fb17ea16e972c63d25d4a97f016d235c78dd2344820eb35bc034bc32012ee27"},
+    {file = "yarl-1.22.0-cp314-cp314t-win_arm64.whl", hash = "sha256:9f6d73c1436b934e3f01df1e1b21ff765cd1d28c77dfb9ace207f746d4610ee1"},
+    {file = "yarl-1.22.0-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:3aa27acb6de7a23785d81557577491f6c38a5209a254d1191519d07d8fe51748"},
+    {file = "yarl-1.22.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:af74f05666a5e531289cb1cc9c883d1de2088b8e5b4de48004e5ca8a830ac859"},
+    {file = "yarl-1.22.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:62441e55958977b8167b2709c164c91a6363e25da322d87ae6dd9c6019ceecf9"},
+    {file = "yarl-1.22.0-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b580e71cac3f8113d3135888770903eaf2f507e9421e5697d6ee6d8cd1c7f054"},
+    {file = "yarl-1.22.0-cp39-cp39-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:e81fda2fb4a07eda1a2252b216aa0df23ebcd4d584894e9612e80999a78fd95b"},
+    {file = "yarl-1.22.0-cp39-cp39-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:99b6fc1d55782461b78221e95fc357b47ad98b041e8e20f47c1411d0aacddc60"},
+    {file = "yarl-1.22.0-cp39-cp39-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:088e4e08f033db4be2ccd1f34cf29fe994772fb54cfe004bbf54db320af56890"},
+    {file = "yarl-1.22.0-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2e4e1f6f0b4da23e61188676e3ed027ef0baa833a2e633c29ff8530800edccba"},
+    {file = "yarl-1.22.0-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:84fc3ec96fce86ce5aa305eb4aa9358279d1aa644b71fab7b8ed33fe3ba1a7ca"},
+    {file = "yarl-1.22.0-cp39-cp39-musllinux_1_2_armv7l.whl", hash = "sha256:5dbeefd6ca588b33576a01b0ad58aa934bc1b41ef89dee505bf2932b22ddffba"},
+    {file = "yarl-1.22.0-cp39-cp39-musllinux_1_2_ppc64le.whl", hash = "sha256:14291620375b1060613f4aab9ebf21850058b6b1b438f386cc814813d901c60b"},
+    {file = "yarl-1.22.0-cp39-cp39-musllinux_1_2_s390x.whl", hash = "sha256:a4fcfc8eb2c34148c118dfa02e6427ca278bfd0f3df7c5f99e33d2c0e81eae3e"},
+    {file = "yarl-1.22.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:029866bde8d7b0878b9c160e72305bbf0a7342bcd20b9999381704ae03308dc8"},
+    {file = "yarl-1.22.0-cp39-cp39-win32.whl", hash = "sha256:4dcc74149ccc8bba31ce1944acee24813e93cfdee2acda3c172df844948ddf7b"},
+    {file = "yarl-1.22.0-cp39-cp39-win_amd64.whl", hash = "sha256:10619d9fdee46d20edc49d3479e2f8269d0779f1b031e6f7c2aa1c76be04b7ed"},
+    {file = "yarl-1.22.0-cp39-cp39-win_arm64.whl", hash = "sha256:dd7afd3f8b0bfb4e0d9fc3c31bfe8a4ec7debe124cfd90619305def3c8ca8cd2"},
+    {file = "yarl-1.22.0-py3-none-any.whl", hash = "sha256:1380560bdba02b6b6c90de54133c81c9f2a453dee9912fe58c1dcced1edb7cff"},
+    {file = "yarl-1.22.0.tar.gz", hash = "sha256:bebf8557577d4401ba8bd9ff33906f1376c877aa78d1fe216ad01b4d6745af71"},
+]
+
+[package.dependencies]
+idna = ">=2.0"
+multidict = ">=4.0"
+propcache = ">=0.2.1"
+
+[[package]]
 name = "zipp"
 version = "3.23.0"
 description = "Backport of pathlib-compatible object wrapper for zip files"
@@ -1872,4 +3355,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = "~3.10"
-content-hash = "cbf5a08f92b51a333775f0fb94a1f2e5e25ddee030bf4d9d6efd25898cda3cfc"
+content-hash = "ff87d9dea3501b66641adf9b3644aa3f4a68651e20f89654b4c3a8098c836e2d"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ ray = "^2.0.0"
 numpy = "^2.0.0"
 gymnasium = {version = "^1.1.0", extras = ["atari", "accept-rom-license", "mujoco"] }
 dynaconf = "^3.1.12"
+lightning = "^2.6.1"
 
 [tool.poetry.group.dev.dependencies]
 bumpversion = "^0.6.0"

--- a/src/tfrlrl/cli/sgd.py
+++ b/src/tfrlrl/cli/sgd.py
@@ -2,7 +2,11 @@ import argparse
 import json
 import logging
 
+import gymnasium as gym
+
+from tfrlrl.features.onehot import OneHotFeatureFunction
 from tfrlrl.policies.dense_neural_network import DenseNetworkPolicy
+from tfrlrl.policies.linear_soft_max import LinearSoftMax
 from tfrlrl.training_algorithms.sgd import train_policy_gradient
 
 logging.basicConfig(format='%(asctime)s %(message)s', force=True)
@@ -56,6 +60,20 @@ def parse_args(args=None):
         default='{}',
         help='Environment-specific keyword arguments as a JSON string (e.g., \'{"is_slippery": false}\').',
     )
+    parser.add_argument(
+        '--policy-class',
+        type=str,
+        required=True,
+        choices=['linear', 'dense'],
+        help='The type of policy class to use in the stochastic gradient algorithm.',
+    )
+    parser.add_argument(
+        '--n-hidden',
+        type=int,
+        nargs='+',
+        default=[16, 32],
+        help='The number of hidden dimensions to use in a dense policy network.',
+    )
     return parser.parse_args(args)
 
 
@@ -81,10 +99,17 @@ def main(args=None):
     if env_kwargs is not None:
         logger.info('Environment Arguments: %s', env_kwargs)
 
-    policy = DenseNetworkPolicy(
-        env_id=parsed_args.env_id,
-        hidden_space_dims=[16, 32],
-    )
+    if parsed_args.policy_class == 'linear':
+        logger.info('Using a linear policy with a one-hot feature encoding.')
+        env = gym.make(parsed_args.env_id)
+        feature_fn = OneHotFeatureFunction(env.observation_space.n, env.action_space.n)
+        policy = LinearSoftMax(parsed_args.env_id, feature_fn)
+    else:
+        logger.info('Using a dense policy with hidden dimensions: %s', parsed_args.n_hidden)
+        policy = DenseNetworkPolicy(
+            env_id=parsed_args.env_id,
+            hidden_space_dims=parsed_args.n_hidden,
+        )
 
     train_policy_gradient(
         env_id=parsed_args.env_id,

--- a/src/tfrlrl/cli/sgd.py
+++ b/src/tfrlrl/cli/sgd.py
@@ -2,11 +2,7 @@ import argparse
 import json
 import logging
 
-import gymnasium as gym
-import numpy as np
-
-from tfrlrl.features.onehot import construct_one_hot_feature_function
-from tfrlrl.policies.linear_soft_max import LinearSoftMax
+from tfrlrl.policies.dense_neural_network import DenseNetworkPolicy
 from tfrlrl.training_algorithms.sgd import train_policy_gradient
 
 logging.basicConfig(format='%(asctime)s %(message)s', force=True)
@@ -85,20 +81,14 @@ def main(args=None):
     if env_kwargs is not None:
         logger.info('Environment Arguments: %s', env_kwargs)
 
-    env = gym.make(parsed_args.env_id)
-    S = env.observation_space.n
-    A = env.action_space.n
-
-    feature_fn = construct_one_hot_feature_function(S=S, A=A)
-    softmax_parameters = np.random.random(size=S * (A - 1))
-    pol = LinearSoftMax(
-        parsed_args.env_id,
-        softmax_parameters,
-        feature_fn,
+    policy = DenseNetworkPolicy(
+        env_id=parsed_args.env_id,
+        hidden_space_dims=[16, 32],
     )
+
     train_policy_gradient(
         env_id=parsed_args.env_id,
-        policy=pol,
+        policy=policy,
         n_iterations=parsed_args.n_iterations,
         n_episodes=parsed_args.n_episodes,
         alpha=parsed_args.alpha,

--- a/src/tfrlrl/data_models/base.py
+++ b/src/tfrlrl/data_models/base.py
@@ -84,17 +84,56 @@ class DictDescriptor(Validator):
 
 
 class NumpyArrayDescriptor(Validator):
-    """A Descriptor validator class for Numpy NdArrays."""
+    """
+    A Descriptor validator class for Numpy NdArrays.
+
+    Attributes:
+        allowed_instances: A tuple of allow instance types. If the validator allows for the conversion of
+        floats/ints to NumPy arrays, then this will include int and float types. Otherwise, it will be a
+        singleton tuple of a NumPy array.
+
+    """
+
+    def __init__(self, allow_numeric: bool = True):
+        """
+        Initialise NumPy descriptor.
+
+        Args:
+            allow_numeric: A Boolean indicating whether numeric types are allowed. If so, then numerics, i.e
+            floats and ints will be converted to a NumPy array of the appropriate type.
+
+        """
+        if allow_numeric:
+            self.allowed_instances = (np.ndarray, int, float)
+        else:
+            self.allowed_instances = (np.ndarray,)
 
     def validate(self, value):
         """Validate that value is an NumPy ndarray."""
-        if not isinstance(value, np.ndarray):
-            raise TypeError(f'Expected {value!r} to be an NumPy ndarray')
+        if not isinstance(value, self.allowed_instances):
+            raise TypeError(f'Expected {value!r} to be on instance of {self.allowed_instances}')
+
+    def _preprocess_value(self, x):
+        """Convert to NumPy array in case of floats or ints."""
+        return (
+            x if isinstance(x, np.ndarray) else x * np.ones(1, dtype=np.float64 if isinstance(x, float) else np.int64)
+        )
 
 
 class NumpyArrayExpandedDescriptor(NumpyArrayDescriptor):
     """A Descriptor validator class for Numpy NdArrays that require an expanded final dimension."""
 
+    def __init__(self, allow_numeric: bool = True):
+        """
+        Initialise NumPy Array Expanded descriptor.
+
+        Args:
+            allow_numeric: A Boolean indicating whether numeric types are allowed. If so, then numerics, i.e
+            floats and ints will be converted to a NumPy array of the appropriate type.
+
+        """
+        super().__init__(allow_numeric=allow_numeric)
+
     def _preprocess_value(self, x):
         """Add a new axis to the end of the raw observation vector."""
-        return x[:, np.newaxis]
+        return super()._preprocess_value(x)[:, np.newaxis]

--- a/src/tfrlrl/data_models/step.py
+++ b/src/tfrlrl/data_models/step.py
@@ -9,6 +9,7 @@ from tfrlrl.data_models.base import (
     DictDescriptor,
     IntDescriptor,
     IntFloatDescriptor,
+    NumpyArrayDescriptor,
     NumpyArrayExpandedDescriptor,
     StringDescriptor,
     Validator,
@@ -25,8 +26,12 @@ def construct_action_space_definition(env_id: str) -> Tuple[str, Type[Validator]
     """
     Construct the (dataclass) definition of the action space for the given environment.
 
-    :param env_id: The I.D. of the environment for which the action space definition is to be constructed.
-    :return: The label of the data class field for the action, along with the descriptor for the action space.
+    Args:
+        env_id: The I.D. of the environment for which the action space definition is to be constructed.
+
+    Returns:
+        The label of the data class field for the action, along with the descriptor for the action space.
+
     """
     env = gym.make(env_id)
     if isinstance(env.action_space, gym.spaces.Discrete):
@@ -40,8 +45,12 @@ def construct_steps_postinitialisation_fn(env_id: str) -> Callable:
     """
     Construct the post-initialisation function for the Steps dataclass.
 
-    :param env_id: The environment I.D. for which the post-initialisation function is to be constructed.
-    :return: The post-initialisation function.
+    Args:
+        env_id: The environment I.D. for which the post-initialisation function is to be constructed.
+
+    Returns:
+        The post-initialisation function.
+
     """
     env = gym.make(env_id)
     if isinstance(env.action_space, gym.spaces.Discrete):
@@ -75,21 +84,37 @@ def construct_steps_postinitialisation_fn(env_id: str) -> Callable:
     raise StepDataclassException('Action space must be Discrete or Box.')
 
 
-def construct_step_dataclass(env_id: str):
+def construct_step_dataclass(env_id: str, expand_observations: bool, expand_next_observations: bool):
     """
     Construct a dataclass to represent a step in the given environment.
 
-    :param env_id: The environment I.D. for which to make the dataclass.
-    :return: The dataclass representing a step in the given environment.
+    Args:
+        env_id: The environment I.D. for which to make the dataclass.
+        expand_observations: Whether the expand the observation with an additional last dimension.
+        expand_next_observations: Whether the expand the next observation with an additional last dimension.
+
+    Returns:
+        The dataclass representing a step in the given environment.
+
     """
+    if expand_observations:
+        obs_tuple = ('observation', NumpyArrayExpandedDescriptor, NumpyArrayExpandedDescriptor())
+    else:
+        obs_tuple = ('observation', NumpyArrayDescriptor, NumpyArrayDescriptor())
+
+    if expand_next_observations:
+        next_obs_tuple = ('next_observation', NumpyArrayExpandedDescriptor, NumpyArrayExpandedDescriptor())
+    else:
+        next_obs_tuple = ('next_observation', NumpyArrayDescriptor, NumpyArrayDescriptor())
+
     return make_dataclass(
         'Step',
         [
             ('env_id', StringDescriptor, StringDescriptor()),
             ('time_step', IntDescriptor, IntDescriptor()),
-            ('observation', NumpyArrayExpandedDescriptor, NumpyArrayExpandedDescriptor()),
+            obs_tuple,
             construct_action_space_definition(env_id),
-            ('next_observation', NumpyArrayExpandedDescriptor, NumpyArrayExpandedDescriptor()),
+            next_obs_tuple,
             ('reward', IntFloatDescriptor, IntFloatDescriptor()),
             ('info', DictDescriptor, DictDescriptor()),
             ('done', BooleanDescriptor, BooleanDescriptor()),
@@ -101,8 +126,12 @@ def construct_steps_dataclass(env_id: str):
     """
     Construct a dataclass to represent a steps in the given environment.
 
-    :param env_id: The environment I.D. for which to make the dataclass.
-    :return: The dataclass representing steps in the given environment.
+    Args:
+        env_id: The environment I.D. for which to make the dataclass.
+
+    Returns:
+        The dataclass representing steps in the given environment.
+
     """
     return make_dataclass(
         'Steps',
@@ -123,13 +152,28 @@ def construct_steps_dataclass(env_id: str):
 
 def construct_step_dataclasses(env_id: str):
     """
-    Construct a dataclass to represent a step and a range of steps in the given environment.
+    Construct a dataclass to represent an observation, a step and a range of steps in the given environment.
 
-    :param env_id: The environment I.D. for which to make the dataclass.
-    :return: The dataclass representing a step in the given environment.
-    :return: The dataclass representing a range steps in the given environment.
+    Args:
+        env_id: The environment I.D. for which to make the dataclass.
+
+    Returns:
+        A three element tuple containing the dataclasses for an observation, a step and steps,
+        respectively.
+
     """
-    step_sls = construct_step_dataclass(env_id)
-    steps_sls = construct_steps_dataclass(env_id)
+    observation_cls = make_dataclass(
+        'Observation',
+        [
+            ('observation', NumpyArrayExpandedDescriptor, NumpyArrayExpandedDescriptor()),
+        ],
+    )
 
-    return step_sls, steps_sls
+    step_cls = construct_step_dataclass(
+        env_id,
+        False,
+        True,
+    )
+    steps_cls = construct_steps_dataclass(env_id)
+
+    return observation_cls, step_cls, steps_cls

--- a/src/tfrlrl/data_models/step.py
+++ b/src/tfrlrl/data_models/step.py
@@ -61,7 +61,7 @@ def construct_steps_postinitialisation_fn(env_id: str) -> Callable:
             self.env_ids = [x.env_id for x in sample_steps]
             self.time_steps = np.array([x.time_step for x in sample_steps])
             self.observations = np.concatenate([x.observation for x in sample_steps], axis=-1)
-            self.actions = np.array([x.action for x in sample_steps])
+            self.actions = np.array([[x.action for x in sample_steps]])
             self.next_observations = np.concatenate([x.next_observation for x in sample_steps], axis=-1)
             self.rewards = np.array([x.reward for x in sample_steps])
             self.dones = np.array([x.done for x in sample_steps])

--- a/src/tfrlrl/features/base.py
+++ b/src/tfrlrl/features/base.py
@@ -1,0 +1,44 @@
+from abc import (
+    ABC,
+    abstractmethod,
+)
+
+from numpy.typing import NDArray
+
+
+class EnvironmentException(Exception):
+    """Exception class to capture environment issues, such as incompatible state/action dimensions."""
+
+    pass
+
+
+class FeatureFunction(ABC):
+    """
+    Abstract base class that represents a feature function.
+
+    Feature function classes are to be used when a hand-coded feature function is to be used, as opposed
+    to features learnt through deep learning. For example, in the case of one-hot encodings in toy discrete
+    domains.
+    """
+
+    @property
+    @abstractmethod
+    def n_features(self) -> int:
+        """Class property that represents the number of features in the feature function."""
+        ...
+
+    @abstractmethod
+    def __call__(self, observations: NDArray) -> NDArray:
+        """
+        Construct features for the given observations.
+
+        This function is used to construct the features for the given observations.
+
+        Args:
+            observations: The observations for which the features are to be constructed.
+
+        Returns:
+            features: The constructed features.
+
+        """
+        ...

--- a/src/tfrlrl/features/base.py
+++ b/src/tfrlrl/features/base.py
@@ -7,7 +7,7 @@ from numpy.typing import NDArray
 
 
 class EnvironmentException(Exception):
-    """Exception class to capture environment issues, such as incompatible state/action dimensions."""
+    """Environment error, such as incompatible state/action dimensions."""
 
     pass
 
@@ -24,7 +24,7 @@ class FeatureFunction(ABC):
     @property
     @abstractmethod
     def n_features(self) -> int:
-        """Class property that represents the number of features in the feature function."""
+        """The number of features in the feature function."""
         ...
 
     @abstractmethod

--- a/src/tfrlrl/features/onehot.py
+++ b/src/tfrlrl/features/onehot.py
@@ -45,7 +45,7 @@ class OneHotFeatureFunction(FeatureFunction):
 
         This function creates one-hot features for the given observations. If a single observation is
         given, in the form of either a NumPy integer or a NumPy array of size 1, then the functon will
-        return a NumPy array of size, [n_features, n_actions], in which n_features is the number of
+        return a NumPy array of size, [n_features, n_actions, 1], in which n_features is the number of
         features and n_actions is the number of actions. If multiple observations are given, then it
         must be in the form of a two-dimensional NumPy array in which the first diemsnion is of size
         one. This dimension represents the index of the state. In this case, the return type is a
@@ -60,7 +60,7 @@ class OneHotFeatureFunction(FeatureFunction):
 
         """
         if observations.size == 1:
-            return self.f[:, observations.flat[0] * self.A : (observations.flat[0] + 1) * self.A]
+            return self.f[:, observations.flat[0] * self.A : (observations.flat[0] + 1) * self.A][:, :, np.newaxis]
 
         if observations.shape[0] > 1 or len(observations.shape) > 2:
             raise EnvironmentException(

--- a/src/tfrlrl/features/onehot.py
+++ b/src/tfrlrl/features/onehot.py
@@ -1,33 +1,75 @@
-from typing import Callable
-
 import numpy as np
 from numpy.typing import NDArray
 
+from tfrlrl.features.base import (
+    EnvironmentException,
+    FeatureFunction,
+)
 
-class EnvironmentException(Exception):
-    """Exception class to capture environment issues, such as incompatible state/action dimensions."""
 
-    pass
-
-
-def construct_one_hot_feature_function(S: int, A: int) -> Callable[[NDArray], NDArray]:
+class OneHotFeatureFunction(FeatureFunction):
     """
-    Construct a one-hot feature function for discrete state-action spaces.
+    Class encapsulating a one-hot feature function.
 
-    This function creates a feature function that maps state observations to one-hot encoded features,
-    excluding one action per state to avoid linear dependency (common in softmax parameterization).
-
-    :param S: The total number of states in the state space.
-    :param A: The number of discrete actions in the action space.
-    :return: A feature function that takes an observation and returns the corresponding feature matrix slice.
+    This class is used to encapsulate a one-hot feature function. It can be used in toy examples to
+    represent a full parameterised policy.
     """
-    f = np.zeros([S * A, S * (A - 1)])
-    inds = np.delete(np.arange(S * A), np.arange(S * A, step=A))
-    f[inds, :] = np.eye(S * (A - 1))
 
-    def feature_fn(observation: NDArray) -> NDArray:
-        if observation.size != 1:
-            raise EnvironmentException('Unsupported observation dimensions for one-hot feature function.')
-        return f[observation.flat[0] : (observation.flat[0] + A), :]
+    def __init__(self, S: int, A: int):
+        """
+        Initialise one-hot feature function for discrete state-action spaces.
 
-    return feature_fn
+        This class represents a feature function that maps state observations to one-hot encoded features,
+        excluding one action per state to avoid linear dependency (common in softmax parameterization).
+
+        Args:
+            S: The total number of states in the state space.
+            A: The number of discrete actions in the action space.
+
+        """
+        self.S = S
+        self.A = A
+
+        self.f = np.zeros([S * (A - 1), S * A])
+        inds = np.delete(np.arange(S * A), np.arange(S * A, step=A))
+        self.f[:, inds] = np.eye(S * (A - 1))
+
+    @property
+    def n_features(self) -> int:
+        """Class property that represents the number of features in the feature function."""
+        return self.S * (self.A - 1)
+
+    def __call__(self, observations: NDArray) -> NDArray:
+        """
+        Construct a one-hot features for the given observations.
+
+        This function creates one-hot features for the given observations. If a single observation is
+        given, in the form of either a NumPy integer or a NumPy array of size 1, then the functon will
+        return a NumPy array of size, [n_features, n_actions], in which n_features is the number of
+        features and n_actions is the number of actions. If multiple observations are given, then it
+        must be in the form of a two-dimensional NumPy array in which the first diemsnion is of size
+        one. This dimension represents the index of the state. In this case, the return type is a
+        three-dimension NumPy array of size, [n_features, n_actions, n_observations], in which
+        n_observations is the number of input observatiuons.
+
+        Args:
+            observations: The observations over which to calculate the features.
+
+        Returns:
+            :return: The feature vectors for the given observations.
+
+        """
+        if observations.size == 1:
+            return self.f[:, observations.flat[0] : (observations.flat[0] + self.A)]
+
+        if observations.shape[0] > 1 or len(observations.shape) > 2:
+            raise EnvironmentException(
+                f'Unsupported observation dimensions for one-hot feature function: {observations.shape}'
+            )
+        return np.concatenate(
+            [
+                self.f[:, observations[0, i] : (observations[0, i] + self.A)][:, :, np.newaxis]
+                for i in range(observations.shape[1])
+            ],
+            axis=2,
+        )

--- a/src/tfrlrl/features/onehot.py
+++ b/src/tfrlrl/features/onehot.py
@@ -56,11 +56,11 @@ class OneHotFeatureFunction(FeatureFunction):
             observations: The observations over which to calculate the features.
 
         Returns:
-            :return: The feature vectors for the given observations.
+            The feature vectors for the given observations.
 
         """
         if observations.size == 1:
-            return self.f[:, observations.flat[0] : (observations.flat[0] + self.A)]
+            return self.f[:, observations.flat[0] * self.A : (observations.flat[0] + 1) * self.A]
 
         if observations.shape[0] > 1 or len(observations.shape) > 2:
             raise EnvironmentException(
@@ -68,7 +68,7 @@ class OneHotFeatureFunction(FeatureFunction):
             )
         return np.concatenate(
             [
-                self.f[:, observations[0, i] : (observations[0, i] + self.A)][:, :, np.newaxis]
+                self.f[:, observations[0, i] * self.A : (observations[0, i] + 1) * self.A][:, :, np.newaxis]
                 for i in range(observations.shape[1])
             ],
             axis=2,

--- a/src/tfrlrl/features/onehot.py
+++ b/src/tfrlrl/features/onehot.py
@@ -9,18 +9,18 @@ from tfrlrl.features.base import (
 
 class OneHotFeatureFunction(FeatureFunction):
     """
-    Class encapsulating a one-hot feature function.
+    A one-hot feature function.
 
-    This class is used to encapsulate a one-hot feature function. It can be used in toy examples to
-    represent a full parameterised policy.
+    A one-hot feature function that can be used in toy discrete domains to represent a full
+    parameterised policy.
     """
 
     def __init__(self, S: int, A: int):
         """
         Initialise one-hot feature function for discrete state-action spaces.
 
-        This class represents a feature function that maps state observations to one-hot encoded features,
-        excluding one action per state to avoid linear dependency (common in softmax parameterization).
+        A feature function that maps state observations to one-hot encoded features, excluding one
+        action per state to avoid linear dependency (common in softmax parameterization).
 
         Args:
             S: The total number of states in the state space.
@@ -36,7 +36,7 @@ class OneHotFeatureFunction(FeatureFunction):
 
     @property
     def n_features(self) -> int:
-        """Class property that represents the number of features in the feature function."""
+        """The number of features in the feature function."""
         return self.S * (self.A - 1)
 
     def __call__(self, observations: NDArray) -> NDArray:

--- a/src/tfrlrl/policies/base.py
+++ b/src/tfrlrl/policies/base.py
@@ -206,12 +206,13 @@ class BasePyTorchPolicy(BasePolicy):
         """
         self.network.load_state_dict(state_dict)
 
-    def update(self, state_dict) -> None:
+    def update(self, state_dict, **kwargs) -> None:
         """
         Update the policy.
 
         Args:
             state_dict: The state dictionary to be assigned to the policy's Pytorch network.
+            kwargs: Optional keyword-arguments for the policy update.
 
         """
         self.set_state(state_dict)

--- a/src/tfrlrl/policies/base.py
+++ b/src/tfrlrl/policies/base.py
@@ -2,7 +2,7 @@ from abc import ABC, abstractmethod
 from typing import Any, Generator, Tuple, Union
 
 import gymnasium as gym
-from numpy.typing import NDArray
+from numpy.typing import ArrayLike
 from torch import (
     Tensor,
     nn,
@@ -24,7 +24,7 @@ class BasePolicy(ABC):
     """
 
     @abstractmethod
-    def generate_action(self, observation: NDArray) -> Tuple[Union[int, float, NDArray]]:
+    def generate_action(self, observation: ArrayLike) -> Tuple[Union[int, float, ArrayLike]]:
         """
         Generate an action for the given state observation.
 
@@ -77,7 +77,7 @@ class UniformActionSamplingPolicy(BasePolicy):
         if not isinstance(self._env.action_space, gym.spaces.Discrete):
             raise PolicyException('The UniformActionSamplingPolicy is applicable to discrete action spaces only.')
 
-    def generate_action(self, observation: NDArray) -> Tuple[Union[int, float, NDArray]]:
+    def generate_action(self, observation: ArrayLike) -> Tuple[Union[int, float, ArrayLike]]:
         """
         Generate a random action uniformly sampled from the discrete action space.
 
@@ -167,7 +167,7 @@ class BasePyTorchPolicy(BasePolicy):
         self.set_state(state_dict)
 
     @abstractmethod
-    def calculate_log_probabilities(self, observations: NDArray, actions: NDArray) -> Tensor:
+    def calculate_log_probabilities(self, observations: ArrayLike, actions: ArrayLike) -> Tensor:
         """
         Calculate the log-probabilities of the given actions for the corresponding observations.
 

--- a/src/tfrlrl/policies/base.py
+++ b/src/tfrlrl/policies/base.py
@@ -99,57 +99,6 @@ class UniformActionSamplingPolicy(BasePolicy):
         pass
 
 
-class BaseDifferentiablePolicy(BasePolicy):
-    """
-    Abstract base class for differentiable parameterized reinforcement learning policies.
-
-    This class extends BasePolicy to support policies with differentiable parameters,
-    enabling gradient-based policy optimization methods such as policy gradient algorithms.
-    Subclasses must implement both generate_action and calculate_log_derivative methods.
-    """
-
-    @abstractmethod
-    def calculate_log_derivative(self, observation: NDArray, action: Tuple[Union[int, float, NDArray]]) -> NDArray:
-        """
-        Calculate the log derivative of the policy with respect to its parameters.
-
-        This method computes the gradient of the log probability of taking the given action
-        in the given observation state with respect to the policy's parameters. This is used
-        in policy gradient methods like REINFORCE, Actor-Critic, and PPO.
-
-        Args:
-            observation: The state observation from the environment.
-            action: The action taken in the given observation state.
-
-        Returns:
-            The log derivative (gradient) of the policy parameters for the given observation-action pair.
-
-        """
-        ...
-
-    @abstractmethod
-    def get_parameters(self) -> NDArray:
-        """
-        Get the current policy parameters.
-
-        Returns:
-            The current parameters of the policy as a numpy array.
-
-        """
-        ...
-
-    @abstractmethod
-    def set_parameters(self, parameters: NDArray) -> None:
-        """
-        Set new policy parameters.
-
-        Args:
-            parameters: The new parameters to set for the policy.
-
-        """
-        ...
-
-
 class BasePyTorchPolicy(BasePolicy):
     """
     Abstract base class for PyTorch reinforcement learning policies.

--- a/src/tfrlrl/policies/base.py
+++ b/src/tfrlrl/policies/base.py
@@ -1,8 +1,12 @@
 from abc import ABC, abstractmethod
-from typing import Tuple, Union
+from typing import Any, Generator, Tuple, Union
 
 import gymnasium as gym
 from numpy.typing import NDArray
+from torch import (
+    Tensor,
+    nn,
+)
 
 
 class PolicyException(Exception):
@@ -122,6 +126,82 @@ class BaseDifferentiablePolicy(BasePolicy):
 
         Args:
             parameters: The new parameters to set for the policy.
+
+        """
+        ...
+
+
+class BasePyTorchPolicy(BasePolicy):
+    """
+    Abstract base class for PyTorch reinforcement learning policies.
+
+    This class extends BasePolicy to support policies which are parameterised through PyTorch,
+    enabling gradient-based policy optimization methods such as policy gradient algorithms.
+    """
+
+    def __init__(self, network: nn.Module):
+        """
+        Initialise dense network policy.
+
+        Initialise the PyTorch policy, including setting the network.
+
+        Args:
+            network: An instance of a PyTorch Module that will be used within the policy.
+
+        """
+        super().__init__()
+        self.network = network
+
+    def get_parameters(self) -> Generator[nn.parameter.Parameter, None, None]:
+        """
+        Get the current policy parameters.
+
+        Return the parameters of the PyTorch neural network. This function can be used to set the
+        parameters in a PyTorch optimisation algorithm.
+
+        Returns:
+            The current parameters of the policy as a generator PyTorch parameters.
+
+        """
+        return self.network.parameters()
+
+    def get_state(self) -> dict[str, Any]:
+        """
+        Get the state dictionary of the Pytorch network.
+
+        Return the state dictionary of the policy's Pytorch network.
+
+        Returns:
+            The current state dictionary of the policy's Pytorch network.
+
+        """
+        return self.network.state_dict()
+
+    def set_state(self, state_dict: dict[str, Any]) -> None:
+        """
+        Set the state dictionary of the Pytorch network.
+
+        Args:
+            state_dict: The state dictionary to be assigned to the policy's Pytorch network.
+
+        """
+        self.network.load_state_dict(state_dict)
+
+    @abstractmethod
+    def calculate_log_probabilities(self, observations: NDArray, actions: NDArray) -> Tensor:
+        """
+        Calculate the log-probabilities of the given actions for the corresponding observations.
+
+        Calculate the log-probabilities for the given actions for the corresponding observations.
+        This function is expected to be used in batch.
+
+        Args:
+            observations: A NumPy array of the observations for which to calculate the log-probabilities.
+            actions: A NumPy array of the actions for which to calculate the log-probabilities (of the corresponding
+            observations).
+
+        Returns:
+            A PyTorch Tensor containing the log-probabilities of the given (observation, action) pairs.
 
         """
         ...

--- a/src/tfrlrl/policies/base.py
+++ b/src/tfrlrl/policies/base.py
@@ -38,6 +38,17 @@ class BasePolicy(ABC):
         """
         ...
 
+    @abstractmethod
+    def update(self, **kwargs) -> None:
+        """
+        Update the policy using the keyword arguments provided.
+
+        Args:
+            kwargs: Keyward arguments passed to the policy update.
+
+        """
+        ...
+
 
 class UniformActionSamplingPolicy(BasePolicy):
     """
@@ -78,6 +89,14 @@ class UniformActionSamplingPolicy(BasePolicy):
 
         """
         return self._env.action_space.sample()
+
+    def update(self, **kwargs) -> None:
+        """
+        Update the policy.
+
+        This is a dummy function, as there is nothing to update in this policy.
+        """
+        pass
 
 
 class BaseDifferentiablePolicy(BasePolicy):
@@ -186,6 +205,16 @@ class BasePyTorchPolicy(BasePolicy):
 
         """
         self.network.load_state_dict(state_dict)
+
+    def update(self, state_dict) -> None:
+        """
+        Update the policy.
+
+        Args:
+            state_dict: The state dictionary to be assigned to the policy's Pytorch network.
+
+        """
+        self.set_state(state_dict)
 
     @abstractmethod
     def calculate_log_probabilities(self, observations: NDArray, actions: NDArray) -> Tensor:

--- a/src/tfrlrl/policies/dense_neural_network.py
+++ b/src/tfrlrl/policies/dense_neural_network.py
@@ -12,7 +12,7 @@ from torch import (
 )
 from torch.distributions.normal import Normal
 
-from tfrlrl.policies.base import BasePyTorchPolicy
+from tfrlrl.policies.base import BasePyTorchPolicy, PolicyException
 
 
 class DensePolicyNetwork(nn.Module):
@@ -83,9 +83,11 @@ class DenseNetworkPolicy(BasePyTorchPolicy):
 
     def __init__(self, env_id: str, hidden_space_dims: List[int]):
         """Initialise dense network policy."""
-        # if not isinstance(self._env.action_space, gym.spaces.Discrete):
-        #     raise PolicyException('The LinearSoftMax is applicable to discrete action spaces only.')
         self._env = gym.make(env_id)
+        if not isinstance(self._env.action_space, gym.spaces.Box):
+            raise PolicyException('The DenseNetworkPolicy is applicable to continuous action spaces only.')
+        if not isinstance(self._env.observation_space, gym.spaces.Box):
+            raise PolicyException('The DenseNetworkPolicy is applicable to continuous observation spaces only.')
         super().__init__(
             network=DensePolicyNetwork(
                 self._env.observation_space.shape[0],

--- a/src/tfrlrl/policies/dense_neural_network.py
+++ b/src/tfrlrl/policies/dense_neural_network.py
@@ -1,0 +1,137 @@
+from collections import OrderedDict
+from typing import List
+
+import gymnasium as gym
+import numpy as np
+import numpy.typing as npt
+from torch import (
+    Tensor,
+    exp,
+    log,
+    nn,
+    tensor,
+)
+from torch.distributions.normal import Normal
+
+from tfrlrl.policies.base import BaseDifferentiablePolicy
+
+
+class DensePolicyNetwork(nn.Module):
+    """
+    PyTorch module class for a dense neural network.
+
+    The dense neural network of this class is used to construct the mean and standard deviation of a Gausssian
+    policy.
+    """
+
+    def __init__(self, obs_space_dims: int, action_space_dims: int, hidden_space_dims: List[int]):
+        """
+        Initialise dense neural network for calculating the mean and standard deviation of a Gaussian policy.
+
+        param: obs_space_dims: The number of dimensions in the observation space.
+        param: action_space_dims: The number of dimensions in the action space.
+        param: hidden_space_dims: A list of the number of dimensions for the hidden layers in the network.
+        """
+        super().__init__()
+
+        # Define the layer dimensions for all the hidden layers.
+        layer_dims = [
+            (obs_space_dims if n == 0 else hidden_space_dims[n - 1], hidden_space_dims[n])
+            for n in range(len(hidden_space_dims))
+        ]
+        # Define the linear layers for all of the hidden layers.
+        lin_layers = [
+            (f'lin_{n}', nn.Linear(layer_dims[n][0], layer_dims[n][1])) for n in range(len(hidden_space_dims))
+        ]
+        # Define the activation layers for all of the hidden layers.
+        act_layers = [(f'actn_{n}', nn.Tanh()) for n in range(len(hidden_space_dims))]
+        # Define sequential network for policy
+        self.shared_net = nn.Sequential(
+            OrderedDict(
+                [lin_layers[n // 2] if n % 2 == 0 else act_layers[n // 2] for n in range(2 * len(hidden_space_dims))]
+            )
+        )
+
+        # Policy Mean specific Linear Layer
+        self.policy_mean_net = nn.Sequential(nn.Linear(hidden_space_dims[-1], action_space_dims))
+
+        # Policy Std Dev specific Linear Layer
+        self.policy_stddev_net = nn.Sequential(nn.Linear(hidden_space_dims[-1], action_space_dims))
+
+    def forward(self, x: Tensor) -> tuple[Tensor, Tensor]:
+        """
+        Perform a forward pass of the network on the given tensor.
+
+        param: x: An input tensor over which to perform the forward pass.
+        return: A tuple of (Tensor, Tensor) for the mean and standard deviation of the policy.
+        """
+        shared_features = self.shared_net(x.float())
+
+        action_means = self.policy_mean_net(shared_features)
+        action_stddevs = log(1 + exp(self.policy_stddev_net(shared_features)))
+
+        return action_means, action_stddevs
+
+
+class DenseNetworkPolicy(BaseDifferentiablePolicy):
+    """Policy class that uses a dense neural network for constructing the mean and standard deviation of a Gaussian."""
+
+    def __init__(self, env_id: str, hidden_space_dims: List[int]):
+        """Initialise dense network policy."""
+        super().__init__()
+        self._env = gym.make(env_id)
+        # if not isinstance(self._env.action_space, gym.spaces.Discrete):
+        #     raise PolicyException('The LinearSoftMax is applicable to discrete action spaces only.')
+
+        self.network = DensePolicyNetwork(
+            self._env.observation_space.shape[0],
+            self._env.action_space.shape[0],
+            hidden_space_dims,
+        )
+        self.eps = 1e-6
+
+    def generate_action(self, observation: npt.ArrayLike) -> npt.ArrayLike:
+        """
+        Generate a random action sampled from the policy.
+
+        This function samples an action from a Gaussian in which the mean and standard deviation are constructed
+        from the dense neural network.
+
+        param: observation: The current state observation.
+        return: A randomly sampled continuous action from the environment's continuous action space.
+        """
+        action_mean, action_stddev = self.network(tensor(observation))
+        dist = Normal(action_mean[0] + self.eps, action_stddev[0] + self.eps)
+        action = dist.sample().numpy()
+        action = action[..., np.newaxis]
+        return action
+
+    def calculate_log_derivative(self):
+        """
+        Calculate the log derivative of the policy with respect to its parameters.
+
+        This method computes the gradient of the log probability of taking the given action
+        in the given observation state with respect to the policy's parameters. This is used
+        in policy gradient methods like REINFORCE, Actor-Critic, and PPO.
+
+        param: observation: The state observation from the environment.
+        param: action: The action taken in the given observation state.
+        return: The log derivative (gradient) of the policy parameters for the given observation-action pair.
+        """
+        raise NotImplementedError
+
+    def get_parameters(self):
+        """
+        Get the current policy parameters.
+
+        return: The current parameters of the policy as a numpy array.
+        """
+        raise NotImplementedError
+
+    def set_parameters(self):
+        """
+        Set new policy parameters.
+
+        param: parameters: The new parameters to set for the policy.
+        """
+        raise NotImplementedError

--- a/src/tfrlrl/policies/dense_neural_network.py
+++ b/src/tfrlrl/policies/dense_neural_network.py
@@ -2,7 +2,6 @@ from collections import OrderedDict
 from typing import List
 
 import gymnasium as gym
-import numpy as np
 import numpy.typing as npt
 from torch import (
     Tensor,
@@ -13,7 +12,7 @@ from torch import (
 )
 from torch.distributions.normal import Normal
 
-from tfrlrl.policies.base import BaseDifferentiablePolicy
+from tfrlrl.policies.base import BasePyTorchPolicy
 
 
 class DensePolicyNetwork(nn.Module):
@@ -73,21 +72,22 @@ class DensePolicyNetwork(nn.Module):
         return action_means, action_stddevs
 
 
-class DenseNetworkPolicy(BaseDifferentiablePolicy):
+class DenseNetworkPolicy(BasePyTorchPolicy):
     """Policy class that uses a dense neural network for constructing the mean and standard deviation of a Gaussian."""
 
     def __init__(self, env_id: str, hidden_space_dims: List[int]):
         """Initialise dense network policy."""
-        super().__init__()
-        self._env = gym.make(env_id)
         # if not isinstance(self._env.action_space, gym.spaces.Discrete):
         #     raise PolicyException('The LinearSoftMax is applicable to discrete action spaces only.')
-
-        self.network = DensePolicyNetwork(
-            self._env.observation_space.shape[0],
-            self._env.action_space.shape[0],
-            hidden_space_dims,
+        self._env = gym.make(env_id)
+        super().__init__(
+            network=DensePolicyNetwork(
+                self._env.observation_space.shape[0],
+                self._env.action_space.shape[0],
+                hidden_space_dims,
+            )
         )
+
         self.eps = 1e-6
 
     def generate_action(self, observation: npt.ArrayLike) -> npt.ArrayLike:
@@ -100,38 +100,24 @@ class DenseNetworkPolicy(BaseDifferentiablePolicy):
         param: observation: The current state observation.
         return: A randomly sampled continuous action from the environment's continuous action space.
         """
-        action_mean, action_stddev = self.network(tensor(observation))
-        dist = Normal(action_mean[0] + self.eps, action_stddev[0] + self.eps)
-        action = dist.sample().numpy()
-        action = action[..., np.newaxis]
-        return action
+        action_mean, action_stddev = self.network(tensor(observation).T)
+        dist = Normal(action_mean + self.eps, action_stddev + self.eps)
+        return dist.sample().numpy()
 
-    def calculate_log_derivative(self):
+    def calculate_log_probabilities(self, observations: npt.NDArray, actions: npt.NDArray) -> Tensor:
         """
-        Calculate the log derivative of the policy with respect to its parameters.
+        Calculate the log-probailities of the for the given (observation, action) pairs.
 
-        This method computes the gradient of the log probability of taking the given action
-        in the given observation state with respect to the policy's parameters. This is used
-        in policy gradient methods like REINFORCE, Actor-Critic, and PPO.
-
-        param: observation: The state observation from the environment.
-        param: action: The action taken in the given observation state.
-        return: The log derivative (gradient) of the policy parameters for the given observation-action pair.
+        param: observations: The state observations from the environment.
+        param: actions: The actions taken in the given observation state.
+        return: The lo-probabilities of the policy for the given observation-action pairs.
         """
-        raise NotImplementedError
-
-    def get_parameters(self):
-        """
-        Get the current policy parameters.
-
-        return: The current parameters of the policy as a numpy array.
-        """
-        raise NotImplementedError
-
-    def set_parameters(self):
-        """
-        Set new policy parameters.
-
-        param: parameters: The new parameters to set for the policy.
-        """
-        raise NotImplementedError
+        action_means, action_stddevs = self.network(tensor(observations).T)
+        return (
+            Normal(
+                action_means[:, 0] + self.eps,
+                action_stddevs[:, 0] + self.eps,
+            )
+            .log_prob(tensor(actions))
+            .T
+        )

--- a/src/tfrlrl/policies/dense_neural_network.py
+++ b/src/tfrlrl/policies/dense_neural_network.py
@@ -17,19 +17,21 @@ from tfrlrl.policies.base import BasePyTorchPolicy
 
 class DensePolicyNetwork(nn.Module):
     """
-    PyTorch module class for a dense neural network.
+    A dense neural network for calculating the mean and standard deviation of a Gaussian distribution.
 
     The dense neural network of this class is used to construct the mean and standard deviation of a Gausssian
-    policy.
+    policy. This is then used to sample actions in an environment with continuous actions.
     """
 
     def __init__(self, obs_space_dims: int, action_space_dims: int, hidden_space_dims: List[int]):
         """
         Initialise dense neural network for calculating the mean and standard deviation of a Gaussian policy.
 
-        param: obs_space_dims: The number of dimensions in the observation space.
-        param: action_space_dims: The number of dimensions in the action space.
-        param: hidden_space_dims: A list of the number of dimensions for the hidden layers in the network.
+        Args:
+            obs_space_dims: The number of dimensions in the observation space.
+            action_space_dims: The number of dimensions in the action space.
+            hidden_space_dims: A list of the number of dimensions for the hidden layers in the network.
+
         """
         super().__init__()
 
@@ -61,8 +63,12 @@ class DensePolicyNetwork(nn.Module):
         """
         Perform a forward pass of the network on the given tensor.
 
-        param: x: An input tensor over which to perform the forward pass.
-        return: A tuple of (Tensor, Tensor) for the mean and standard deviation of the policy.
+        Args:
+            x: An input tensor over which to perform the forward pass.
+
+        Returns:
+            A tuple of (Tensor, Tensor) for the mean and standard deviation of the policy.
+
         """
         shared_features = self.shared_net(x.float())
 
@@ -97,8 +103,13 @@ class DenseNetworkPolicy(BasePyTorchPolicy):
         This function samples an action from a Gaussian in which the mean and standard deviation are constructed
         from the dense neural network.
 
-        param: observation: The current state observation.
-        return: A randomly sampled continuous action from the environment's continuous action space.
+        Args:
+            observation: The current state observation.
+
+        Returns:
+            A NumPy array containing a randomly sampled continuous action from the environment's continuous
+            action space.
+
         """
         action_mean, action_stddev = self.network(tensor(observation).T)
         dist = Normal(action_mean + self.eps, action_stddev + self.eps)
@@ -108,9 +119,13 @@ class DenseNetworkPolicy(BasePyTorchPolicy):
         """
         Calculate the log-probailities of the for the given (observation, action) pairs.
 
-        param: observations: The state observations from the environment.
-        param: actions: The actions taken in the given observation state.
-        return: The lo-probabilities of the policy for the given observation-action pairs.
+        Args:
+            observations: The state observations from the environment.
+            actions: The actions taken in the given observation state.
+
+        Returns:
+            A Tensor containing the log-probabilities of the policy for the given observation-action pairs.
+
         """
         action_means, action_stddevs = self.network(tensor(observations).T)
         return (

--- a/src/tfrlrl/policies/linear_soft_max.py
+++ b/src/tfrlrl/policies/linear_soft_max.py
@@ -1,8 +1,7 @@
 from collections import OrderedDict
 
 import gymnasium as gym
-import numpy.typing as npt
-from numpy.typing import NDArray
+from numpy.typing import ArrayLike
 from torch import (
     Tensor,
     nn,
@@ -91,7 +90,7 @@ class LinearSoftMax(BasePyTorchPolicy):
         )
         self._feature_fn = feature_fn
 
-    def calculate_action_distribution(self, observations: npt.NDArray) -> Categorical:
+    def calculate_action_distribution(self, observations: ArrayLike) -> Categorical:
         """
         Calculate the action probabilities for the given observations.
 
@@ -105,7 +104,7 @@ class LinearSoftMax(BasePyTorchPolicy):
         return Categorical(probs=self.network(tensor(self._feature_fn(observations)).T).squeeze())
 
     # TODO: Fix output type
-    def generate_action(self, observation: NDArray) -> Tensor:
+    def generate_action(self, observation: ArrayLike) -> int:
         """
         Generate an action by sampling from the softmax probability distribution.
 
@@ -118,7 +117,7 @@ class LinearSoftMax(BasePyTorchPolicy):
         """
         return self.calculate_action_distribution(observation).sample().numpy().flat[0]
 
-    def calculate_log_probabilities(self, observations: npt.NDArray, actions: npt.NDArray) -> Tensor:
+    def calculate_log_probabilities(self, observations: ArrayLike, actions: ArrayLike) -> Tensor:
         """
         Calculate the log-probailities of the for the given (observation, action) pairs.
 

--- a/src/tfrlrl/policies/linear_soft_max.py
+++ b/src/tfrlrl/policies/linear_soft_max.py
@@ -1,5 +1,4 @@
 from collections import OrderedDict
-from typing import Callable, Tuple, Union
 
 import gymnasium as gym
 import numpy.typing as npt
@@ -9,8 +8,9 @@ from torch import (
     nn,
     tensor,
 )
-from torch.distributions.multinomial import Multinomial
+from torch.distributions.multinomial import Categorical
 
+from tfrlrl.features.base import FeatureFunction
 from tfrlrl.policies.base import (
     BasePyTorchPolicy,
     PolicyException,
@@ -37,7 +37,7 @@ class LinearSoftMaxNetwork(nn.Module):
             OrderedDict(
                 [
                     ('linear', nn.Linear(n_features, 1)),
-                    ('softmax', nn.Softmax(dim=-1)),
+                    ('softmax', nn.Softmax(dim=1)),
                 ]
             )
         )
@@ -70,29 +70,27 @@ class LinearSoftMax(BasePyTorchPolicy):
 
     """
 
-    def __init__(self, env_id: str, feature_fn: Callable[[NDArray], NDArray]):
+    def __init__(self, env_id: str, feature_fn: FeatureFunction):
         """
         Initialize the LinearSoftMax policy.
 
         Args:
             env_id: The Gymnasium environment ID.
-            softmax_parameters: The parameters of the softmax policy.
-            feature_fn: A function that maps observations to feature representations.
+            feature_fn: An instance of a feature function.
 
         Raises:
             :raises PolicyException: If the environment does not have a discrete action space.
 
         """
-        super().__init__()
         self._env = gym.make(env_id)
         if not isinstance(self._env.action_space, gym.spaces.Discrete):
             raise PolicyException('The LinearSoftMax is applicable to discrete action spaces only.')
-
-        # TODO: Set the correct number of features
-        self.network = LinearSoftMaxNetwork(5)
+        super().__init__(
+            network=LinearSoftMaxNetwork(feature_fn.n_features),
+        )
         self._feature_fn = feature_fn
 
-    def generate_action(self, observation: NDArray) -> Tuple[Union[int, float, NDArray]]:
+    def generate_action(self, observation: NDArray) -> Tensor:
         """
         Generate an action by sampling from the softmax probability distribution.
 
@@ -103,7 +101,7 @@ class LinearSoftMax(BasePyTorchPolicy):
             :return: A sampled action from the discrete action space.
 
         """
-        dist = Multinomial(1, probs=self.network(tensor(self._feature_fn(observation)).T))
+        dist = Categorical(probs=self.network(tensor(self._feature_fn(observation)).T).squeeze())
         return dist.sample().numpy()
 
     def calculate_log_probabilities(self, observations: npt.NDArray, actions: npt.NDArray) -> Tensor:
@@ -114,5 +112,5 @@ class LinearSoftMax(BasePyTorchPolicy):
         param: actions: The actions taken in the given observation state.
         return: The log-probabilities of the policy for the given observation-action pairs.
         """
-        dist = Multinomial(1, probs=self.network(tensor(self._feature_fn(observations)).T))
-        return dist.log_prob(tensor(actions)).T
+        dist = Categorical(probs=self.network(tensor(self._feature_fn(observations)).T).squeeze())
+        return dist.log_prob(tensor(actions))

--- a/src/tfrlrl/policies/linear_soft_max.py
+++ b/src/tfrlrl/policies/linear_soft_max.py
@@ -104,6 +104,7 @@ class LinearSoftMax(BasePyTorchPolicy):
         """
         return Categorical(probs=self.network(tensor(self._feature_fn(observations)).T).squeeze())
 
+    # TODO: Fix output type
     def generate_action(self, observation: NDArray) -> Tensor:
         """
         Generate an action by sampling from the softmax probability distribution.
@@ -115,7 +116,7 @@ class LinearSoftMax(BasePyTorchPolicy):
             return: A sampled action from the discrete action space.
 
         """
-        return self.calculate_action_distribution(observation).sample().numpy()
+        return self.calculate_action_distribution(observation).sample().numpy().flat[0]
 
     def calculate_log_probabilities(self, observations: npt.NDArray, actions: npt.NDArray) -> Tensor:
         """

--- a/src/tfrlrl/policies/linear_soft_max.py
+++ b/src/tfrlrl/policies/linear_soft_max.py
@@ -29,10 +29,14 @@ class LinearSoftMax(BaseDifferentiablePolicy):
         """
         Initialize the LinearSoftMax policy.
 
-        :param env_id: The Gymnasium environment ID.
-        :param softmax_parameters: The parameters of the softmax policy.
-        :param feature_fn: A function that maps observations to feature representations.
-        :raises PolicyException: If the environment does not have a discrete action space.
+        Args:
+            env_id: The Gymnasium environment ID.
+            softmax_parameters: The parameters of the softmax policy.
+            feature_fn: A function that maps observations to feature representations.
+
+        Raises:
+            :raises PolicyException: If the environment does not have a discrete action space.
+
         """
         super().__init__()
         self._env = gym.make(env_id)
@@ -46,8 +50,12 @@ class LinearSoftMax(BaseDifferentiablePolicy):
         """
         Calculate the probability distribution over actions for a given observation.
 
-        :param observation: The current state observation from the environment.
-        :return: A probability distribution over actions.
+        Args:
+            observation: The current state observation from the environment.
+
+        Returns:
+            :return: A probability distribution over actions.
+
         """
         scores = np.matmul(self._feature_fn(observation), self._softmax_parameters)
         scores -= np.max(scores)
@@ -57,8 +65,12 @@ class LinearSoftMax(BaseDifferentiablePolicy):
         """
         Generate an action by sampling from the softmax probability distribution.
 
-        :param observation: The current state observation from the environment.
-        :return: A sampled action from the discrete action space.
+        Args:
+            observation: The current state observation from the environment.
+
+        Returns:
+            :return: A sampled action from the discrete action space.
+
         """
         return self._env.action_space.sample(probability=self.calculate_action_probabilities(observation))
 
@@ -66,10 +78,16 @@ class LinearSoftMax(BaseDifferentiablePolicy):
         """
         Calculate the log derivative of the policy with respect to its parameters.
 
-        :param observation: The state observation from the environment.
-        :param action: The action taken in the given observation state.
-        :return: The log derivative (gradient) of the policy parameters.
-        :raises NotImplementedError: This method is not yet implemented.
+        Args:
+            observation: The state observation from the environment.
+            action: The action taken in the given observation state.
+
+        Returns:
+            :return: The log derivative (gradient) of the policy parameters.
+
+        Raises:
+            :raises NotImplementedError: This method is not yet implemented.
+
         """
         a_probs = self.calculate_action_probabilities(observation)
         f_mat = self._feature_fn(observation)
@@ -79,7 +97,9 @@ class LinearSoftMax(BaseDifferentiablePolicy):
         """
         Get the current policy parameters.
 
-        :return: The current softmax parameters of the policy.
+        Returns:
+            :return: The current softmax parameters of the policy.
+
         """
         return self._softmax_parameters
 
@@ -87,6 +107,18 @@ class LinearSoftMax(BaseDifferentiablePolicy):
         """
         Set new policy parameters.
 
-        :param parameters: The new softmax parameters to set for the policy.
+        Args:
+            parameters: The new softmax parameters to set for the policy.
+
         """
         self._softmax_parameters = parameters
+
+    def update(self, parameters: NDArray) -> None:
+        """
+        Set new policy parameters.
+
+        Args:
+            parameters: The new policy parameters.
+
+        """
+        self.set_parameters(parameters)

--- a/src/tfrlrl/policies/linear_soft_max.py
+++ b/src/tfrlrl/policies/linear_soft_max.py
@@ -113,12 +113,13 @@ class LinearSoftMax(BaseDifferentiablePolicy):
         """
         self._softmax_parameters = parameters
 
-    def update(self, parameters: NDArray) -> None:
+    def update(self, parameters: NDArray, **kwargs) -> None:
         """
         Set new policy parameters.
 
         Args:
             parameters: The new policy parameters.
+            kwargs: Optional keyword-arguments for the policy update.
 
         """
         self.set_parameters(parameters)

--- a/src/tfrlrl/policies/linear_soft_max.py
+++ b/src/tfrlrl/policies/linear_soft_max.py
@@ -103,7 +103,6 @@ class LinearSoftMax(BasePyTorchPolicy):
         """
         return Categorical(probs=self.network(tensor(self._feature_fn(observations)).T).squeeze())
 
-    # TODO: Fix output type
     def generate_action(self, observation: ArrayLike) -> int:
         """
         Generate an action by sampling from the softmax probability distribution.

--- a/src/tfrlrl/policies/linear_soft_max.py
+++ b/src/tfrlrl/policies/linear_soft_max.py
@@ -36,7 +36,7 @@ class LinearSoftMaxNetwork(nn.Module):
             OrderedDict(
                 [
                     ('linear', nn.Linear(n_features, 1)),
-                    ('softmax', nn.Softmax(dim=1)),
+                    ('softmax', nn.Softmax(dim=0)),
                 ]
             )
         )

--- a/src/tfrlrl/policies/linear_soft_max.py
+++ b/src/tfrlrl/policies/linear_soft_max.py
@@ -1,13 +1,58 @@
+from collections import OrderedDict
 from typing import Callable, Tuple, Union
 
 import gymnasium as gym
-import numpy as np
+import numpy.typing as npt
 from numpy.typing import NDArray
+from torch import (
+    Tensor,
+    nn,
+    tensor,
+)
+from torch.distributions.multinomial import Multinomial
 
-from tfrlrl.policies.base import BaseDifferentiablePolicy, PolicyException
+from tfrlrl.policies.base import (
+    BasePyTorchPolicy,
+    PolicyException,
+)
 
 
-class LinearSoftMax(BaseDifferentiablePolicy):
+class LinearSoftMaxNetwork(nn.Module):
+    """
+    PyTorch module class for a linear soft-max network.
+
+    The linear soft-max neural network of this class is used to select from a range of discrete actions.
+    """
+
+    def __init__(self, n_features: int):
+        """
+        Initialise linear soft-max neural network.
+
+        param: n_features: The number of features in the feature space.
+        """
+        super().__init__()
+
+        # Define sequential network for policy
+        self.network = nn.Sequential(
+            OrderedDict(
+                [
+                    ('linear', nn.Linear(n_features, 1)),
+                    ('softmax', nn.Softmax(dim=-1)),
+                ]
+            )
+        )
+
+    def forward(self, x: Tensor) -> tuple[Tensor]:
+        """
+        Perform a forward pass of the network on the given tensor.
+
+        param: x: An input tensor over which to perform the forward pass.
+        return: A Tensor for the action probabilities.
+        """
+        return self.network(x.float())
+
+
+class LinearSoftMax(BasePyTorchPolicy):
     """
     Linear softmax policy for discrete action spaces.
 
@@ -25,7 +70,7 @@ class LinearSoftMax(BaseDifferentiablePolicy):
 
     """
 
-    def __init__(self, env_id: str, softmax_parameters: NDArray, feature_fn: Callable[[NDArray], NDArray]):
+    def __init__(self, env_id: str, feature_fn: Callable[[NDArray], NDArray]):
         """
         Initialize the LinearSoftMax policy.
 
@@ -43,23 +88,9 @@ class LinearSoftMax(BaseDifferentiablePolicy):
         if not isinstance(self._env.action_space, gym.spaces.Discrete):
             raise PolicyException('The LinearSoftMax is applicable to discrete action spaces only.')
 
-        self._softmax_parameters = softmax_parameters
+        # TODO: Set the correct number of features
+        self.network = LinearSoftMaxNetwork(5)
         self._feature_fn = feature_fn
-
-    def calculate_action_probabilities(self, observation: NDArray):
-        """
-        Calculate the probability distribution over actions for a given observation.
-
-        Args:
-            observation: The current state observation from the environment.
-
-        Returns:
-            :return: A probability distribution over actions.
-
-        """
-        scores = np.matmul(self._feature_fn(observation), self._softmax_parameters)
-        scores -= np.max(scores)
-        return np.exp(scores) / np.sum(np.exp(scores))
 
     def generate_action(self, observation: NDArray) -> Tuple[Union[int, float, NDArray]]:
         """
@@ -72,54 +103,16 @@ class LinearSoftMax(BaseDifferentiablePolicy):
             :return: A sampled action from the discrete action space.
 
         """
-        return self._env.action_space.sample(probability=self.calculate_action_probabilities(observation))
+        dist = Multinomial(1, probs=self.network(tensor(self._feature_fn(observation)).T))
+        return dist.sample().numpy()
 
-    def calculate_log_derivative(self, observation: NDArray, action: int) -> NDArray:
+    def calculate_log_probabilities(self, observations: npt.NDArray, actions: npt.NDArray) -> Tensor:
         """
-        Calculate the log derivative of the policy with respect to its parameters.
+        Calculate the log-probailities of the for the given (observation, action) pairs.
 
-        Args:
-            observation: The state observation from the environment.
-            action: The action taken in the given observation state.
-
-        Returns:
-            :return: The log derivative (gradient) of the policy parameters.
-
-        Raises:
-            :raises NotImplementedError: This method is not yet implemented.
-
+        param: observations: The state observations from the environment.
+        param: actions: The actions taken in the given observation state.
+        return: The log-probabilities of the policy for the given observation-action pairs.
         """
-        a_probs = self.calculate_action_probabilities(observation)
-        f_mat = self._feature_fn(observation)
-        return f_mat[action, :] - np.matmul(a_probs, f_mat)
-
-    def get_parameters(self) -> NDArray:
-        """
-        Get the current policy parameters.
-
-        Returns:
-            :return: The current softmax parameters of the policy.
-
-        """
-        return self._softmax_parameters
-
-    def set_parameters(self, parameters: NDArray) -> None:
-        """
-        Set new policy parameters.
-
-        Args:
-            parameters: The new softmax parameters to set for the policy.
-
-        """
-        self._softmax_parameters = parameters
-
-    def update(self, parameters: NDArray, **kwargs) -> None:
-        """
-        Set new policy parameters.
-
-        Args:
-            parameters: The new policy parameters.
-            kwargs: Optional keyword-arguments for the policy update.
-
-        """
-        self.set_parameters(parameters)
+        dist = Multinomial(1, probs=self.network(tensor(self._feature_fn(observations)).T))
+        return dist.log_prob(tensor(actions)).T

--- a/src/tfrlrl/policies/linear_soft_max.py
+++ b/src/tfrlrl/policies/linear_soft_max.py
@@ -60,9 +60,10 @@ class LinearSoftMax(BasePyTorchPolicy):
     feature functions. The policy is differentiable with respect to its parameters, enabling
     gradient-based optimization.
 
+    The policy is applicable to domains with a discreta action space.
+
     Args:
         env_id: The Gymnasium environment ID (e.g., 'CliffWalking-v0').
-        softmax_parameters: The parameters of the softmax policy.
         feature_fn: A function that maps observations to feature representations.
 
     Raises:
@@ -90,6 +91,19 @@ class LinearSoftMax(BasePyTorchPolicy):
         )
         self._feature_fn = feature_fn
 
+    def calculate_action_distribution(self, observations: npt.NDArray) -> Categorical:
+        """
+        Calculate the action probabilities for the given observations.
+
+        Args:
+            observations: The state observations from the environment.
+
+        Returns:
+            return: The log-probabilities of the policy for the given observation-action pairs.
+
+        """
+        return Categorical(probs=self.network(tensor(self._feature_fn(observations)).T).squeeze())
+
     def generate_action(self, observation: NDArray) -> Tensor:
         """
         Generate an action by sampling from the softmax probability distribution.
@@ -98,19 +112,21 @@ class LinearSoftMax(BasePyTorchPolicy):
             observation: The current state observation from the environment.
 
         Returns:
-            :return: A sampled action from the discrete action space.
+            return: A sampled action from the discrete action space.
 
         """
-        dist = Categorical(probs=self.network(tensor(self._feature_fn(observation)).T).squeeze())
-        return dist.sample().numpy()
+        return self.calculate_action_distribution(observation).sample().numpy()
 
     def calculate_log_probabilities(self, observations: npt.NDArray, actions: npt.NDArray) -> Tensor:
         """
         Calculate the log-probailities of the for the given (observation, action) pairs.
 
-        param: observations: The state observations from the environment.
-        param: actions: The actions taken in the given observation state.
-        return: The log-probabilities of the policy for the given observation-action pairs.
+        Args:
+            observations: The state observations from the environment.
+            actions: The actions taken in the given observation state.
+
+        Returns:
+            return: The log-probabilities of the policy for the given observation-action pairs.
+
         """
-        dist = Categorical(probs=self.network(tensor(self._feature_fn(observations)).T).squeeze())
-        return dist.log_prob(tensor(actions))
+        return self.calculate_action_distribution(observations).log_prob(tensor(actions))

--- a/src/tfrlrl/policies/linear_soft_max.py
+++ b/src/tfrlrl/policies/linear_soft_max.py
@@ -90,6 +90,16 @@ class LinearSoftMax(BasePyTorchPolicy):
         )
         self._feature_fn = feature_fn
 
+    def construct_network_input(self, observations: ArrayLike) -> Tensor:
+        """
+        Construct input for PyTorch network from given observations.
+
+        Args:
+            observations: The observations for which the input PyTorch tensors are to be constructed.
+
+        """
+        return tensor(self._feature_fn(observations)).T
+
     def calculate_action_distribution(self, observations: ArrayLike) -> Categorical:
         """
         Calculate the action probabilities for the given observations.
@@ -101,7 +111,7 @@ class LinearSoftMax(BasePyTorchPolicy):
             return: The log-probabilities of the policy for the given observation-action pairs.
 
         """
-        return Categorical(probs=self.network(tensor(self._feature_fn(observations)).T).squeeze())
+        return Categorical(probs=self.network(self.construct_network_input(observations)).squeeze())
 
     def generate_action(self, observation: ArrayLike) -> int:
         """

--- a/src/tfrlrl/policies/linear_soft_max.py
+++ b/src/tfrlrl/policies/linear_soft_max.py
@@ -36,7 +36,7 @@ class LinearSoftMaxNetwork(nn.Module):
             OrderedDict(
                 [
                     ('linear', nn.Linear(n_features, 1)),
-                    ('softmax', nn.Softmax(dim=0)),
+                    ('softmax', nn.Softmax(dim=1)),
                 ]
             )
         )

--- a/src/tfrlrl/policies/linear_soft_max.py
+++ b/src/tfrlrl/policies/linear_soft_max.py
@@ -27,7 +27,9 @@ class LinearSoftMaxNetwork(nn.Module):
         """
         Initialise linear soft-max neural network.
 
-        param: n_features: The number of features in the feature space.
+        Args:
+            n_features: The number of features in the feature space.
+
         """
         super().__init__()
 
@@ -45,8 +47,12 @@ class LinearSoftMaxNetwork(nn.Module):
         """
         Perform a forward pass of the network on the given tensor.
 
-        param: x: An input tensor over which to perform the forward pass.
-        return: A Tensor for the action probabilities.
+        Args:
+            x: An input tensor over which to perform the forward pass.
+
+        Returns:
+            A Tensor for the action probabilities.
+
         """
         return self.network(x.float())
 

--- a/src/tfrlrl/sampling/episodic_sampler.py
+++ b/src/tfrlrl/sampling/episodic_sampler.py
@@ -27,13 +27,15 @@ class EpisodicSampler:
         """
         Initialise instance of EpisodicSampler, which entails initialising the environment and setting member variables.
 
-        :param env_id: The Gym environment ID to be used in the sampling.
-        :param statistics_collector: An instance of a statistics collector.
-        :param n_episodes: If given, the number of episodes to sample from the environment. If not given, then there is
-          no limit on the number of sampled episodes.
-        :param policy: Optional policy instance for action selection. If not provided, defaults to
-        UniformActionSamplingPolicy.
-        :param kwargs: Optional keyword-arguments for the environment.
+        Args:
+            env_id: The Gym environment ID to be used in the sampling.
+            statistics_collector: An instance of a statistics collector.
+            n_episodes: If given, the number of episodes to sample from the environment. If not given,
+            then there is no limit on the number of sampled episodes.
+            policy: Optional policy instance for action selection. If not provided, defaults to
+            UniformActionSamplingPolicy.
+            kwargs: Optional keyword-arguments for the environment.
+
         """
         self._sampler = Sampler(env_id, policy=policy, **kwargs)
         self._statistics_collector = statistics_collector
@@ -62,14 +64,15 @@ class EpisodicSampler:
         self._statistics_collector.reset()
         self._n_episodes_taken = 0
 
-    def update_policy(self, new_policy: BasePolicy) -> None:
+    def update(self, **kwargs) -> None:
         """
-        Update the policy used for action selection.
+        Update the the sampler, e.g., the policy used for action selection.
 
-        :param new_policy: New policy instance to use for sampling.
+        Args:
+            kwargs: The keyword arguments to be passed to the sampler update.
+
         """
-        self._sampler._policy = new_policy
-        self._statistics_collector.update_policy(new_policy)
+        self._sampler.update(**kwargs)
 
     def sample(self) -> BaseStatistics:
         """Sample all episodes from the sampler and merge the statistics."""
@@ -98,13 +101,16 @@ class RayEpisodicSampler:
         """
         Initialise instance of RayEpisodicSampler, which entails initialising multiple samplers to be used by Ray.
 
-        :param env_id: The Gym environment ID to be used in the sampling.
-        :param statistics_collector: Optional instance of a statistics collector.
-        :param n_episodes: If given, the number of episodes to sample from the environment (in each of the Ray
-        workers). If not given, then there is no limit on the number of sampled episodes.
-        :param policy: Optional policy instance for action selection. If not provided, defaults to
-        UniformActionSamplingPolicy.
-        :param kwargs: Optional keyword-arguments for the environment.
+        Args:
+            env_id: The Gym environment ID to be used in the sampling.
+            n_samplers: The number of samplers to be used in sampling.
+            statistics_collector: Optional instance of a statistics collector.
+            n_episodes: If given, the number of episodes to sample from the environment (in each of the Ray
+            workers). If not given, then there is no limit on the number of sampled episodes.
+            policy: Optional policy instance for action selection. If not provided, defaults to
+            UniformActionSamplingPolicy.
+            kwargs: Optional keyword-arguments for the environment.
+
         """
         self.statistics_collector = statistics_collector
         self.samplers = [
@@ -132,13 +138,15 @@ class RayEpisodicSampler:
         """Reset all samplers."""
         ray.get([env.reset.remote() for env in self.samplers])
 
-    def update_policy(self, new_policy: BasePolicy) -> None:
+    def update(self, **kwargs) -> None:
         """
-        Update the policy across all samplers.
+        Update the the sampler, e.g., the policy used for action selection.
 
-        :param new_policy: New policy instance to use for sampling across all samplers.
+        Args:
+            kwargs: Keyword arguments to be passed to the sampler updated.
+
         """
-        ray.get([env.update_policy.remote(new_policy) for env in self.samplers])
+        ray.get([env.update.remote(**kwargs) for env in self.samplers])
 
     def sample(self) -> BaseStatistics:
         """Sample all episodes from the sampler and merge the statistics."""

--- a/src/tfrlrl/sampling/episodic_sampler.py
+++ b/src/tfrlrl/sampling/episodic_sampler.py
@@ -19,7 +19,7 @@ class EpisodicSampler:
     def __init__(
         self,
         env_id: str,
-        statistics_collector: Optional[BaseStatisticsCollector],
+        statistics_collector: BaseStatisticsCollector,
         n_episodes: int = None,
         policy: Optional[BasePolicy] = None,
         **kwargs,
@@ -28,7 +28,7 @@ class EpisodicSampler:
         Initialise instance of EpisodicSampler, which entails initialising the environment and setting member variables.
 
         :param env_id: The Gym environment ID to be used in the sampling.
-        :param statistics_collector: Optional instance of a statistics collector.
+        :param statistics_collector: An instance of a statistics collector.
         :param n_episodes: If given, the number of episodes to sample from the environment. If not given, then there is
           no limit on the number of sampled episodes.
         :param policy: Optional policy instance for action selection. If not provided, defaults to

--- a/src/tfrlrl/sampling/sampler.py
+++ b/src/tfrlrl/sampling/sampler.py
@@ -61,7 +61,6 @@ class Sampler:
         next_observation, reward, terminated, truncated, info = self._env.step(
             action,
         )
-
         self.step = self.step_cls(
             env_id=self._env_id,
             time_step=self._n_env_steps_taken,

--- a/src/tfrlrl/sampling/sampler.py
+++ b/src/tfrlrl/sampling/sampler.py
@@ -21,12 +21,14 @@ class Sampler:
         """
         Initialise instance of Sampler, which entails initialising the environment and setting member variables.
 
-        :param env_id: The Gym environment ID to be used in the sampling.
-        :param n_steps: If given, the number of steps to sample from the environment. If not given, then there is no
-        limit on the number of sampled steps.
-        :param policy: Optional policy instance for action selection. If not provided, defaults to
-        UniformActionSamplingPolicy.
-        :param kwargs: Optional keyword-arguments for the environment.
+        Args:
+            env_id: The Gym environment ID to be used in the sampling.
+            n_steps: If given, the number of steps to sample from the environment. If not given, then there is no
+            limit on the number of sampled steps.
+            policy: Optional policy instance for action selection. If not provided, defaults to
+            UniformActionSamplingPolicy.
+            kwargs: Optional keyword-arguments for the environment.
+
         """
         self.step_cls, self.steps_cls = construct_step_dataclasses(env_id)
         self._env = gym.make(env_id, **kwargs)
@@ -90,10 +92,12 @@ class Sampler:
         if self._n_steps_taken is not None:
             self._n_steps_taken = 0
 
-    def update_policy(self, new_policy: BasePolicy) -> None:
+    def update(self, **kwargs) -> None:
         """
-        Update the policy used for action selection.
+        Update the sampler, e.g. the policy used for action selection.
 
-        :param new_policy: New policy instance to use for sampling.
+        Args:
+            kwargs: Keyword arguments passed to the policy update.
+
         """
-        self._policy = new_policy
+        self._policy.update(**kwargs)

--- a/src/tfrlrl/sampling/sampler.py
+++ b/src/tfrlrl/sampling/sampler.py
@@ -2,7 +2,6 @@ import uuid
 from typing import Dict, Optional, Tuple, Union
 
 import gymnasium as gym
-import numpy as np
 from numpy.typing import NDArray
 
 from tfrlrl.data_models.step import construct_step_dataclasses
@@ -30,19 +29,15 @@ class Sampler:
             kwargs: Optional keyword-arguments for the environment.
 
         """
-        self.step_cls, self.steps_cls = construct_step_dataclasses(env_id)
+        self.obs_cls, self.step_cls, self.steps_cls = construct_step_dataclasses(
+            env_id,
+        )
         self._env = gym.make(env_id, **kwargs)
         self._env_id = str(uuid.uuid4())
         self._n_steps = n_steps
         self._n_steps_taken = 0
         self._n_env_steps_taken = 0
-        self._observation = None
-        self._next_observation = None
-        self._action = None
-        self._reward = None
-        self._terminated = True
-        self._truncated = True
-        self._info = None
+        self.step = None
         self._policy = policy if policy is not None else UniformActionSamplingPolicy(env_id)
 
     def __iter__(self):
@@ -54,38 +49,33 @@ class Sampler:
         if self._n_steps is not None and self._n_steps_taken >= self._n_steps:
             raise StopIteration
 
-        if self._terminated or self._truncated:
-            self._observation, self._info = self._env.reset()
-            if isinstance(self._observation, float):
-                self._observation = self._observation * np.ones(1)
-            elif isinstance(self._observation, int):
-                self._observation = self._observation * np.ones(1, dtype=np.int64)
+        if self.step is None or self.step.done:
+            initial_observation, info = self._env.reset()
+            observation = self.obs_cls(observation=initial_observation).observation
             self._env_id = str(uuid.uuid4())
             self._n_env_steps_taken = 0
         else:
-            self._observation = self._next_observation
+            observation = self.step.next_observation
 
-        self._action = self._policy.generate_action(self._observation)
-        self._next_observation, self._reward, self._terminated, self._truncated, self._info = self._env.step(
-            self._action,
+        action = self._policy.generate_action(observation[..., 0])
+        next_observation, reward, terminated, truncated, info = self._env.step(
+            action,
         )
-        if isinstance(self._next_observation, float):
-            self._next_observation = self._next_observation * np.ones(1)
-        elif isinstance(self._next_observation, int):
-            self._next_observation = self._next_observation * np.ones(1, dtype=np.int64)
+
+        self.step = self.step_cls(
+            env_id=self._env_id,
+            time_step=self._n_env_steps_taken,
+            observation=observation,
+            action=action,
+            next_observation=next_observation,
+            reward=reward,
+            done=terminated or truncated,
+            info=info,
+        )
 
         self._n_steps_taken += 1
         self._n_env_steps_taken += 1
-        return self.step_cls(
-            env_id=self._env_id,
-            time_step=self._n_env_steps_taken,
-            observation=self._observation,
-            action=self._action,
-            next_observation=self._next_observation,
-            reward=self._reward,
-            done=self._terminated or self._truncated,
-            info=self._info,
-        )
+        return self.step
 
     def reset(self) -> None:
         """Reset the iterator so that a new iterable can be created."""

--- a/src/tfrlrl/sampling/statistics_collection.py
+++ b/src/tfrlrl/sampling/statistics_collection.py
@@ -1,11 +1,10 @@
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import List, Optional
+from typing import List
 
 import numpy as np
 
 from tfrlrl.data_models.statistics import BaseStatistics
-from tfrlrl.policies.base import BaseDifferentiablePolicy, BasePolicy
 
 
 class BaseStatisticsCollector(ABC):
@@ -16,10 +15,10 @@ class BaseStatisticsCollector(ABC):
         """Reset the statistics in the collector."""
         ...
 
-    @abstractmethod
-    def update_policy(self, new_policy: BasePolicy) -> None:
-        """Update the policy of the statistics collector."""
-        ...
+    # @abstractmethod
+    # def update(self) -> None:
+    #     """Update the statistics collector."""
+    #     ...
 
     @abstractmethod
     def collect_step_statistics(self, sample) -> None:
@@ -43,42 +42,46 @@ class EpisodePolicyGradientStatistics(BaseStatistics):
     """Dataclass for the statistics collected in episodic policy gradients."""
 
     total_reward: float
-    episode_gradient: np.ndarray
+    observations: np.ndarray
+    actions: np.ndarray
+    total_expected_rewards: np.ndarray
 
 
 class EpisocidPolicyGradientStatisticsCollector(BaseStatisticsCollector):
     """Class for collecting policy statistics during episodes."""
 
-    def __init__(self, policy: Optional[BaseDifferentiablePolicy]):
+    def __init__(self):
         """Initialise the policy-gradients statistics collector."""
-        self._policy = policy
+        self.observations = []
+        self.actions = []
         self.rewards = []
-        self.log_pol_grads = []
 
     def reset(self) -> None:
         """Reset the collected statistics to empty lists."""
+        self.observations = []
+        self.actions = []
         self.rewards = []
-        self.log_pol_grads = []
-
-    def update_policy(self, new_policy: BaseDifferentiablePolicy) -> None:
-        """Update the policy of the statistics collector."""
-        self._policy = new_policy
 
     def collect_step_statistics(self, sample) -> None:
         """
         Collect statistics for the given step sample.
 
-        This function collects the statistics for the given step sample. This consists of the gradient of the
-        log-polify and the reward.
+        This function collects the statistics for the given step sample.
 
-        :param: sample: The step sample from which to calculate the statistics.
+        Args:
+            sample: The step sample from which to calculate the statistics.
+
         """
-        self.log_pol_grads.append(
-            self._policy.calculate_log_derivative(
-                sample.observation,
-                sample.action,
-            )
-        )
+        # TODO: Fix the actions to be a consistent shape.
+        # This should be done in the samplers, not here.
+        if isinstance(sample.action, int):
+            self.actions.append(sample.action * np.ones(1))
+        elif isinstance(sample.action, np.integer):
+            self.actions.append(sample.action[..., np.newaxis][..., np.newaxis])
+        else:
+            self.actions.append(sample.action)
+
+        self.observations.append(sample.observation)
         self.rewards.append(sample.reward)
 
     def aggregate_statistics(self) -> EpisodePolicyGradientStatistics:
@@ -87,22 +90,39 @@ class EpisocidPolicyGradientStatisticsCollector(BaseStatisticsCollector):
 
         This function calculates the policy gradient from the collected episode. It then returns this
         gradient and the rewards.
-        :return: The policy gradient and step rewards of the episode.
+
+        Returns:
+            An instance of the EpisodePolicyGradientStatistics dataclass.
+
         """
-        log_pol_grads = np.array(self.log_pol_grads)
+        observations = np.concatenate(self.observations, axis=1)
+        actions = np.concatenate(self.actions, axis=1)
         rewards = np.array(self.rewards)
+
         T = rewards.size
-        episode_gradient = np.matmul(np.matmul(rewards, np.tril(np.ones(T))), log_pol_grads) / T
-        episode_gradient = episode_gradient[..., np.newaxis]
+        total_expected_rewards = np.matmul(rewards, np.tril(np.ones(T))) / T
+
         return EpisodePolicyGradientStatistics(
             total_reward=np.sum(rewards),
-            episode_gradient=episode_gradient,
+            observations=observations,
+            actions=actions,
+            total_expected_rewards=total_expected_rewards,
         )
 
     @classmethod
     def merge_statistics(cls, statistics: List[EpisodePolicyGradientStatistics]) -> EpisodePolicyGradientStatistics:
-        """Merge statistics across different episodes."""
+        """
+        Merge statistics across different episodes.
+
+        This merges statistics across different instances of the EpisodePolicyGradientStatistics data class.
+
+        Returns:
+            An instance of the EpisodePolicyGradientStatistics dataclass.
+
+        """
         return EpisodePolicyGradientStatistics(
             total_reward=np.array([x.total_reward for x in statistics]),
-            episode_gradient=np.concatenate([x.episode_gradient for x in statistics], axis=1),
+            observations=np.concatenate([x.observations for x in statistics], axis=1),
+            actions=np.concatenate([x.actions for x in statistics], axis=1),
+            total_expected_rewards=np.concatenate([x.total_expected_rewards for x in statistics]),
         )

--- a/src/tfrlrl/sampling/statistics_collection.py
+++ b/src/tfrlrl/sampling/statistics_collection.py
@@ -16,11 +16,6 @@ class BaseStatisticsCollector(ABC):
         """Reset the statistics in the collector."""
         ...
 
-    # @abstractmethod
-    # def update(self) -> None:
-    #     """Update the statistics collector."""
-    #     ...
-
     @abstractmethod
     def collect_step_statistics(self, sample) -> None:
         """Collect statistics from a sample step."""

--- a/src/tfrlrl/sampling/statistics_collection.py
+++ b/src/tfrlrl/sampling/statistics_collection.py
@@ -5,6 +5,7 @@ from typing import List
 import numpy as np
 
 from tfrlrl.data_models.statistics import BaseStatistics
+from tfrlrl.data_models.step import construct_step_dataclasses
 
 
 class BaseStatisticsCollector(ABC):
@@ -48,19 +49,35 @@ class EpisodePolicyGradientStatistics(BaseStatistics):
 
 
 class EpisocidPolicyGradientStatisticsCollector(BaseStatisticsCollector):
-    """Class for collecting policy statistics during episodes."""
+    """
+    Statistics collector for episodic-level statistics collection.
 
-    def __init__(self):
-        """Initialise the policy-gradients statistics collector."""
-        self.observations = []
-        self.actions = []
-        self.rewards = []
+    This class can be used to collect statistics for episodes sampled from environments. In
+    particular, it collects the actions, observations and total future rewards for all of the
+    steps in an episode.
+
+    Attributes:
+        steps_cls: A dataclass for aggregating a collection of steps.
+        steps: The collection of steps collected to date.
+
+    """
+
+    def __init__(self, env_id: str):
+        """
+        Initialise the policy-gradients statistics collector.
+
+        Args:
+            env_id: The I.D. of the environment from which to collect statistics.
+
+        """
+        _, _, self.steps_cls = construct_step_dataclasses(
+            env_id,
+        )
+        self.steps = []
 
     def reset(self) -> None:
         """Reset the collected statistics to empty lists."""
-        self.observations = []
-        self.actions = []
-        self.rewards = []
+        self.steps = []
 
     def collect_step_statistics(self, sample) -> None:
         """
@@ -72,17 +89,7 @@ class EpisocidPolicyGradientStatisticsCollector(BaseStatisticsCollector):
             sample: The step sample from which to calculate the statistics.
 
         """
-        # TODO: Fix the actions to be a consistent shape.
-        # This should be done in the samplers, not here.
-        if isinstance(sample.action, int):
-            self.actions.append(sample.action * np.ones(1))
-        elif isinstance(sample.action, np.integer):
-            self.actions.append(sample.action[..., np.newaxis][..., np.newaxis])
-        else:
-            self.actions.append(sample.action)
-
-        self.observations.append(sample.observation)
-        self.rewards.append(sample.reward)
+        self.steps.append(sample)
 
     def aggregate_statistics(self) -> EpisodePolicyGradientStatistics:
         """
@@ -95,17 +102,15 @@ class EpisocidPolicyGradientStatisticsCollector(BaseStatisticsCollector):
             An instance of the EpisodePolicyGradientStatistics dataclass.
 
         """
-        observations = np.concatenate(self.observations, axis=1)
-        actions = np.concatenate(self.actions, axis=1)
-        rewards = np.array(self.rewards)
+        steps = self.steps_cls(sample_steps=self.steps)
 
-        T = rewards.size
-        total_expected_rewards = np.matmul(rewards, np.tril(np.ones(T))) / T
+        T = steps.rewards.size
+        total_expected_rewards = np.matmul(steps.rewards, np.tril(np.ones(T))) / T
 
         return EpisodePolicyGradientStatistics(
-            total_reward=np.sum(rewards),
-            observations=observations,
-            actions=actions,
+            total_reward=np.sum(steps.rewards),
+            observations=steps.observations,
+            actions=steps.actions,
             total_expected_rewards=total_expected_rewards,
         )
 
@@ -122,7 +127,7 @@ class EpisocidPolicyGradientStatisticsCollector(BaseStatisticsCollector):
         """
         return EpisodePolicyGradientStatistics(
             total_reward=np.array([x.total_reward for x in statistics]),
-            observations=np.concatenate([x.observations for x in statistics], axis=1),
-            actions=np.concatenate([x.actions for x in statistics], axis=1),
+            observations=np.concatenate([x.observations for x in statistics], axis=-1),
+            actions=np.concatenate([x.actions for x in statistics], axis=-1),
             total_expected_rewards=np.concatenate([x.total_expected_rewards for x in statistics]),
         )

--- a/src/tfrlrl/training_algorithms/sgd.py
+++ b/src/tfrlrl/training_algorithms/sgd.py
@@ -5,6 +5,7 @@ import logging
 import numpy as np
 import ray
 from torch import (
+    no_grad,
     sum,
     tensor,
 )
@@ -49,7 +50,7 @@ def train_policy_gradient(
 
     """
     statistics_collector = EpisocidPolicyGradientStatisticsCollector(env_id)
-    optimizer = SGD(policy.get_parameters(), lr=alpha, momentum=0.9)
+    optimizer = SGD(policy.get_parameters(), lr=alpha)
 
     if n_samplers > 1:
         if not ray.is_initialized():
@@ -76,17 +77,15 @@ def train_policy_gradient(
         )
 
     for n in range(n_iterations):
-        statistics = sampler.sample()
+        with no_grad():
+            statistics = sampler.sample()
 
-        # Update the policy network
         optimizer.zero_grad()
-
         log_probabilities = policy.calculate_log_probabilities(
             observations=statistics.observations,
             actions=statistics.actions,
         )
         loss = -sum(log_probabilities * tensor(statistics.total_expected_rewards))
-
         loss.backward()
         optimizer.step()
 

--- a/src/tfrlrl/training_algorithms/sgd.py
+++ b/src/tfrlrl/training_algorithms/sgd.py
@@ -9,7 +9,7 @@ from torch import (
     tensor,
 )
 from torch.optim import (
-    AdamW,
+    SGD,
 )
 
 from tfrlrl import settings
@@ -35,17 +35,21 @@ def train_policy_gradient(
     """
     Train a policy using stochastic gradient ascent on the policy gradient.
 
-    :param env_id: Gymnasium environment ID (e.g., CartPole-v1, MountainCar-v0).
-    :param policy: The policy to train. Must have get_parameters() and set_parameters() methods.
-    :param n_iterations: The number of policy updates to perform.
-    :param n_episodes: The number of episodes to sample during each policy update.
-    :param alpha: The initial step size to take in stochastic gradient ascent.
-    :param n_samplers: The number of samplers to used to sample from the environment.
-    :param kwargs: Additional keyword arguments to pass to the EpisodicSampler (e.g., is_slippery).
-    :return: The trained policy.
+    Args:
+        env_id: Gymnasium environment ID (e.g., CartPole-v1, MountainCar-v0).
+        policy: The policy to train. Must have get_parameters() and set_parameters() methods.
+        n_iterations: The number of policy updates to perform.
+        n_episodes: The number of episodes to sample during each policy update.
+        alpha: The initial step size to take in stochastic gradient ascent.
+        n_samplers: The number of samplers to used to sample from the environment.
+        kwargs: Additional keyword arguments to pass to the EpisodicSampler (e.g., is_slippery).
+
+    Returns:
+        The trained policy.
+
     """
     statistics_collector = EpisocidPolicyGradientStatisticsCollector(env_id)
-    optimizer = AdamW(policy.get_parameters(), lr=alpha)
+    optimizer = SGD(policy.get_parameters(), lr=alpha, momentum=0.9)
 
     if n_samplers > 1:
         if not ray.is_initialized():

--- a/src/tfrlrl/training_algorithms/sgd.py
+++ b/src/tfrlrl/training_algorithms/sgd.py
@@ -44,7 +44,7 @@ def train_policy_gradient(
     :param kwargs: Additional keyword arguments to pass to the EpisodicSampler (e.g., is_slippery).
     :return: The trained policy.
     """
-    statistics_collector = EpisocidPolicyGradientStatisticsCollector()
+    statistics_collector = EpisocidPolicyGradientStatisticsCollector(env_id)
     optimizer = AdamW(policy.get_parameters(), lr=alpha)
 
     if n_samplers > 1:

--- a/src/tfrlrl/training_algorithms/sgd.py
+++ b/src/tfrlrl/training_algorithms/sgd.py
@@ -74,27 +74,17 @@ def train_policy_gradient(
     for n in range(n_iterations):
         statistics = sampler.sample()
 
-        actions = statistics.actions
-        actions = actions[np.newaxis, :]
-
         # Update the policy network
         optimizer.zero_grad()
 
         log_probabilities = policy.calculate_log_probabilities(
             observations=statistics.observations,
-            actions=actions,
+            actions=statistics.actions,
         )
         loss = -sum(log_probabilities * tensor(statistics.total_expected_rewards))
 
         loss.backward()
         optimizer.step()
-
-        print(f'iteration: {n}')
-        # print(statistics.observations.shape)
-        # print(actions.shape)
-        # print(log_probabilities.shape)
-        # print(tensor(statistics.total_expected_rewards).shape)
-        print(loss)
 
         if n % 10 == 0:
             logger.info('Policy update: %s', n)

--- a/src/tfrlrl/training_algorithms/sgd.py
+++ b/src/tfrlrl/training_algorithms/sgd.py
@@ -74,16 +74,27 @@ def train_policy_gradient(
     for n in range(n_iterations):
         statistics = sampler.sample()
 
-        log_probabilities = policy.calculate_log_probabilities(
-            observations=statistics.observations,
-            actions=statistics.actions,
-        )
-        loss = -sum(log_probabilities * tensor(statistics.total_expected_rewards))
+        actions = statistics.actions
+        actions = actions[np.newaxis, :]
 
         # Update the policy network
         optimizer.zero_grad()
+
+        log_probabilities = policy.calculate_log_probabilities(
+            observations=statistics.observations,
+            actions=actions,
+        )
+        loss = -sum(log_probabilities * tensor(statistics.total_expected_rewards))
+
         loss.backward()
         optimizer.step()
+
+        print(f'iteration: {n}')
+        # print(statistics.observations.shape)
+        # print(actions.shape)
+        # print(log_probabilities.shape)
+        # print(tensor(statistics.total_expected_rewards).shape)
+        print(loss)
 
         if n % 10 == 0:
             logger.info('Policy update: %s', n)

--- a/src/tfrlrl/training_algorithms/sgd.py
+++ b/src/tfrlrl/training_algorithms/sgd.py
@@ -4,9 +4,16 @@ import logging
 
 import numpy as np
 import ray
+from torch import (
+    sum,
+    tensor,
+)
+from torch.optim import (
+    AdamW,
+)
 
 from tfrlrl import settings
-from tfrlrl.policies.base import BasePolicy
+from tfrlrl.policies.base import BasePyTorchPolicy
 from tfrlrl.sampling.episodic_sampler import (
     EpisodicSampler,
     RayEpisodicSampler,
@@ -18,13 +25,13 @@ logger = logging.getLogger(__name__)
 
 def train_policy_gradient(
     env_id: str,
-    policy: BasePolicy,
+    policy: BasePyTorchPolicy,
     n_iterations: int,
     n_episodes: int,
     alpha: float,
     n_samplers: int = 1,
     **kwargs,
-) -> BasePolicy:
+) -> BasePyTorchPolicy:
     """
     Train a policy using stochastic gradient ascent on the policy gradient.
 
@@ -37,7 +44,8 @@ def train_policy_gradient(
     :param kwargs: Additional keyword arguments to pass to the EpisodicSampler (e.g., is_slippery).
     :return: The trained policy.
     """
-    statistics_collector = EpisocidPolicyGradientStatisticsCollector(policy)
+    statistics_collector = EpisocidPolicyGradientStatisticsCollector()
+    optimizer = AdamW(policy.get_parameters(), lr=alpha)
 
     if n_samplers > 1:
         if not ray.is_initialized():
@@ -65,15 +73,23 @@ def train_policy_gradient(
 
     for n in range(n_iterations):
         statistics = sampler.sample()
-        policy_gradient = np.average(np.array(statistics.episode_gradient), axis=1)
-        policy.set_parameters(policy.get_parameters() + (alpha / (n + 1)) * policy_gradient)
+
+        log_probabilities = policy.calculate_log_probabilities(
+            observations=statistics.observations,
+            actions=statistics.actions,
+        )
+        loss = -sum(log_probabilities * tensor(statistics.total_expected_rewards))
+
+        # Update the policy network
+        optimizer.zero_grad()
+        loss.backward()
+        optimizer.step()
 
         if n % 10 == 0:
             logger.info('Policy update: %s', n)
             logger.info('Average total episodic reward: %s', np.average(statistics.total_reward))
-            logger.info('Policy gradient magnitude: %s', np.sum(np.abs(policy_gradient)))
 
         sampler.reset()
-        sampler.update_policy(policy)
+        sampler.update(state_dict=policy.get_state())
 
     return policy

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,50 @@
 import os
+from collections import ChainMap, defaultdict
+from dataclasses import dataclass
+from typing import List
 
 from pytest import fixture
+
+from tfrlrl.policies.base import BasePolicy
+from tfrlrl.sampling.statistics_collection import BaseStatisticsCollector
+
+
+@dataclass
+class DummyStatistics:
+    """Dataclass for the statistics collected test sample episodes."""
+
+    samples: dict[str, list]  # A map from the episode ID to the list of steps in the episode.
+
+
+class DummyStatisticsCollector(BaseStatisticsCollector):
+    """Test class for collecting statistics during sampling."""
+
+    def __init__(self):
+        """Initialise statistics collector."""
+        self._samples = defaultdict(list)
+
+    def reset(self):
+        """Reset the statistics in the collector."""
+        self._samples = defaultdict(list)
+
+    def update_policy(self, new_policy: BasePolicy) -> None:
+        """Update the policy of the statistics collector."""
+        pass
+
+    def collect_step_statistics(self, sample):
+        """Collect statistics from a sample step."""
+        self._samples[sample.env_id].append(sample)
+
+    def aggregate_statistics(self):
+        """Aggregate the statistics collected by the collector."""
+        return DummyStatistics(samples=self._samples)
+
+    @classmethod
+    def merge_statistics(cls, statistics: List[DummyStatistics]):
+        """Aggregate the statistics collected by the collector."""
+        return DummyStatistics(
+            samples=dict(ChainMap(*[x.samples for x in statistics])),
+        )
 
 
 @fixture(scope='session')

--- a/tests/tfrlrl/cli/test_sgd.py
+++ b/tests/tfrlrl/cli/test_sgd.py
@@ -14,17 +14,58 @@ class TestParseArgs:
         'args,expected',
         [
             (
-                ['--env-id', 'FrozenLake-v1', '--n-iterations', '10', '--n-episodes', '20', '--alpha', '1.0'],
-                {'env_id': 'FrozenLake-v1', 'n_iterations': 10, 'n_episodes': 20, 'alpha': 1.0, 'env_kwargs': '{}'},
+                [
+                    '--env-id',
+                    'FrozenLake-v1',
+                    '--n-iterations',
+                    '10',
+                    '--n-episodes',
+                    '20',
+                    '--alpha',
+                    '1.0',
+                    '--policy-class',
+                    'dense',
+                ],
+                {
+                    'env_id': 'FrozenLake-v1',
+                    'n_iterations': 10,
+                    'n_episodes': 20,
+                    'alpha': 1.0,
+                    'env_kwargs': '{}',
+                    'policy_class': 'dense',
+                },
             ),
             (
-                ['--env-id', 'FrozenLake-v1', '--env-kwargs', '{"is_slippery": false}'],
+                ['--env-id', 'FrozenLake-v1', '--env-kwargs', '{"is_slippery": false}', '--policy-class', 'dense'],
                 {
                     'env_id': 'FrozenLake-v1',
                     'n_iterations': 100,
                     'n_episodes': 100,
                     'alpha': 100.0,
                     'env_kwargs': '{"is_slippery": false}',
+                    'policy_class': 'dense',
+                },
+            ),
+            (
+                [
+                    '--env-id',
+                    'FrozenLake-v1',
+                    '--n-iterations',
+                    '10',
+                    '--n-episodes',
+                    '20',
+                    '--alpha',
+                    '1.0',
+                    '--policy-class',
+                    'linear',
+                ],
+                {
+                    'env_id': 'FrozenLake-v1',
+                    'n_iterations': 10,
+                    'n_episodes': 20,
+                    'alpha': 1.0,
+                    'env_kwargs': '{}',
+                    'policy_class': 'linear',
                 },
             ),
         ],
@@ -47,25 +88,44 @@ class TestParseArgs:
 class TestMain:
     """Tests for the main function."""
 
-    @pytest.mark.parametrize('env_id', ['InvertedPendulum-v5'])
+    @pytest.mark.parametrize(
+        'env_id, policy_class',
+        [
+            (
+                'InvertedPendulum-v5',
+                'dense',
+            ),
+            (
+                'FrozenLake-v1',
+                'linear',
+            ),
+        ],
+    )
     @given(
         n_iterations=st.integers(min_value=1, max_value=3),
         n_episodes=st.integers(min_value=5, max_value=15),
         alpha=st.floats(min_value=0.0001, max_value=0.001),
     )
     @settings(deadline=10000)
-    def test_main_with_different_parameters(self, env_id: str, n_iterations: int, n_episodes: int, alpha: float):
+    def test_main_with_different_parameters(
+        self, env_id: str, policy_class: str, n_iterations: int, n_episodes: int, alpha: float
+    ):
         """
         Test main function with different parameter values.
 
-        :param env_id: The Gym environment ID to be used in training.
-        :param n_iterations: The number of policy updates to perform.
-        :param n_episodes: The number of episodes to sample during each policy update.
-        :param alpha: The initial step size for stochastic gradient ascent.
+        Args:
+            env_id: The Gym environment ID to be used in training.
+            policy_class: The policy class to use in SGD.
+            n_iterations: The number of policy updates to perform.
+            n_episodes: The number of episodes to sample during each policy update.
+            alpha: The initial step size for stochastic gradient ascent.
+
         """
         args = [
             '--env-id',
             env_id,
+            '--policy-class',
+            policy_class,
             '--n-iterations',
             str(n_iterations),
             '--n-episodes',
@@ -78,16 +138,32 @@ class TestMain:
 
         assert exit_code is None or exit_code == 0
 
-    @pytest.mark.parametrize('env_id', ['InvertedPendulum-v5'])
-    def test_main_with_env_kwargs(self, env_id: str):
+    @pytest.mark.parametrize(
+        'env_id, policy_class, env_kwargs',
+        [
+            ('InvertedPendulum-v5', 'dense', '{"reset_noise_scale": 0.001}'),
+            (
+                'FrozenLake-v1',
+                'linear',
+                '{"is_slippery": false}',
+            ),
+        ],
+    )
+    def test_main_with_env_kwargs(self, env_id: str, policy_class: str, env_kwargs: str):
         """
         Test main function with env-kwargs set.
 
-        :param env_id: The Gym environment ID to be used in training.
+        Args:
+            env_id: The Gym environment ID to be used in training.
+            policy_class: The policy class to use in SGD.
+            env_kwargs: Any key-words passed to the environment.
+
         """
         args = [
             '--env-id',
             env_id,
+            '--policy-class',
+            policy_class,
             '--n-iterations',
             '2',
             '--n-episodes',
@@ -95,23 +171,40 @@ class TestMain:
             '--alpha',
             '1.0',
             '--env-kwargs',
-            '{"reset_noise_scale": 0.001}',
+            env_kwargs,
         ]
 
         exit_code = main(args)
 
         assert exit_code is None or exit_code == 0
 
-    @pytest.mark.parametrize('env_id', ['InvertedPendulum-v5'])
-    def test_main_with_default_env_kwargs(self, env_id: str):
+    @pytest.mark.parametrize(
+        'env_id, policy_class',
+        [
+            (
+                'InvertedPendulum-v5',
+                'dense',
+            ),
+            (
+                'FrozenLake-v1',
+                'linear',
+            ),
+        ],
+    )
+    def test_main_with_default_env_kwargs(self, env_id: str, policy_class: str):
         """
         Test main function with default (empty) env-kwargs.
 
-        :param env_id: The Gym environment ID to be used in training.
+        Args:
+            env_id: The Gym environment ID to be used in training.
+            policy_class: The policy class to use in SGD.
+
         """
         args = [
             '--env-id',
             env_id,
+            '--policy-class',
+            policy_class,
             '--n-iterations',
             '2',
             '--n-episodes',
@@ -140,7 +233,9 @@ class TestMain:
         """
         Test main function with malformed env-kwargs returns exit code 1.
 
-        :param malformed_json: Malformed JSON string to test.
+        Args:
+            malformed_json: Malformed JSON string to test.
+
         """
         args = [
             '--env-id',
@@ -153,6 +248,8 @@ class TestMain:
             '1.0',
             '--env-kwargs',
             malformed_json,
+            '--policy-class',
+            'dense',
         ]
 
         exit_code = main(args)

--- a/tests/tfrlrl/cli/test_sgd.py
+++ b/tests/tfrlrl/cli/test_sgd.py
@@ -47,11 +47,11 @@ class TestParseArgs:
 class TestMain:
     """Tests for the main function."""
 
-    @pytest.mark.parametrize('env_id', ['FrozenLake-v1'])
+    @pytest.mark.parametrize('env_id', ['InvertedPendulum-v5'])
     @given(
         n_iterations=st.integers(min_value=1, max_value=3),
         n_episodes=st.integers(min_value=5, max_value=15),
-        alpha=st.floats(min_value=0.1, max_value=5.0),
+        alpha=st.floats(min_value=0.0001, max_value=0.001),
     )
     @settings(deadline=10000)
     def test_main_with_different_parameters(self, env_id: str, n_iterations: int, n_episodes: int, alpha: float):
@@ -78,7 +78,7 @@ class TestMain:
 
         assert exit_code is None or exit_code == 0
 
-    @pytest.mark.parametrize('env_id', ['FrozenLake-v1'])
+    @pytest.mark.parametrize('env_id', ['InvertedPendulum-v5'])
     def test_main_with_env_kwargs(self, env_id: str):
         """
         Test main function with env-kwargs set.
@@ -95,14 +95,14 @@ class TestMain:
             '--alpha',
             '1.0',
             '--env-kwargs',
-            '{"is_slippery": false}',
+            '{"reset_noise_scale": 0.001}',
         ]
 
         exit_code = main(args)
 
         assert exit_code is None or exit_code == 0
 
-    @pytest.mark.parametrize('env_id', ['FrozenLake-v1'])
+    @pytest.mark.parametrize('env_id', ['InvertedPendulum-v5'])
     def test_main_with_default_env_kwargs(self, env_id: str):
         """
         Test main function with default (empty) env-kwargs.

--- a/tests/tfrlrl/data_models/test_step.py
+++ b/tests/tfrlrl/data_models/test_step.py
@@ -41,7 +41,7 @@ from tfrlrl.data_models.step import construct_step_dataclasses
 )
 def test_step_valid_example(env_id, time_step, observation, action, next_observation, reward, done, info):
     """Test that the Step class properly formats observation and next_obaservation."""
-    step_cls, steps_cls = construct_step_dataclasses(env_id)
+    initial_obs_cls, step_cls, steps_cls = construct_step_dataclasses(env_id)
 
     step = step_cls(
         env_id=env_id,
@@ -55,8 +55,10 @@ def test_step_valid_example(env_id, time_step, observation, action, next_observa
     )
     assert step.env_id == env_id
     assert step.time_step == time_step
-    assert step.observation.shape == observation.shape + (1,)
-    np.testing.assert_allclose(step.observation[:, 0], observation)
+    assert step.observation.shape == observation.shape
+    # assert step.observation.shape == observation.shape + (1,)
+
+    # np.testing.assert_allclose(step.observation[:, 0], observation)
     if isinstance(action, int):
         assert step.action == action
     else:
@@ -108,7 +110,7 @@ def test_step_valid_example(env_id, time_step, observation, action, next_observa
 )
 def test_step_invalid_example(env_id, time_step, observation, action, next_observation, reward, done, info):
     """Test that the Step class throws error on invalid data inputs."""
-    step_cls, steps_cls = construct_step_dataclasses(env_id)
+    initial_obs_cls, step_cls, steps_cls = construct_step_dataclasses(env_id)
 
     with pytest.raises(TypeError):
         step_cls(
@@ -150,7 +152,7 @@ def test_step_invalid_example(env_id, time_step, observation, action, next_obser
 )
 def test_steps_valid_example(env_id, time_step, observation, action, next_observation, reward, done, info):
     """Test that the Steps class properly formats data from list of steps."""
-    step_cls, steps_cls = construct_step_dataclasses(env_id)
+    initial_obs_cls, step_cls, steps_cls = construct_step_dataclasses(env_id)
 
     n_steps = 10
     steps = steps_cls(
@@ -180,7 +182,7 @@ def test_steps_valid_example(env_id, time_step, observation, action, next_observ
     assert isinstance(steps.dones, np.ndarray)
 
     assert steps.time_steps.shape == (n_steps,)
-    assert steps.observations.shape == observation.shape + (n_steps,)
+    # assert steps.observations.shape == observation.shape + (n_steps,)
     assert steps.next_observations.shape == next_observation.shape + (n_steps,)
     assert steps.rewards.shape == (n_steps,)
     assert steps.dones.shape == (n_steps,)

--- a/tests/tfrlrl/features/test_onehot.py
+++ b/tests/tfrlrl/features/test_onehot.py
@@ -69,7 +69,7 @@ def test_feature_function_output_shape_with_single_observation(env_id: str, obse
     features = feature_fn(np.array([observation]))
 
     # The feature function should return a matrix of shape (S * (A - 1), A)
-    expected_shape = (S * (A - 1), A)
+    expected_shape = (S * (A - 1), A, 1)
     assert features.shape == expected_shape
 
 

--- a/tests/tfrlrl/features/test_onehot.py
+++ b/tests/tfrlrl/features/test_onehot.py
@@ -122,8 +122,8 @@ def test_feature_function_one_hot_encoding(env_id: str):
     # The first action is excluded to avoid linear dependency
     for i in range(1, A):
         row_sum = np.sum(features[:, i])
-        assert row_sum == 1.0, f'Row {i} should sum to 1.0, got {row_sum}'
-        assert np.sum(features[:, i] == 1.0) == 1, f'Row {i} should have exactly one 1.0'
+        assert row_sum == 1.0
+        assert np.sum(features[:, i] == 1.0) == 1
 
 
 @pytest.mark.parametrize('env_id', ['CliffWalking-v1'])

--- a/tests/tfrlrl/features/test_onehot.py
+++ b/tests/tfrlrl/features/test_onehot.py
@@ -99,13 +99,15 @@ def test_feature_function_output_shape_with_multiple_observations(env_id: str, n
     assert features.shape == expected_shape
 
 
+@given(observation=st.integers(min_value=0, max_value=47))
 @pytest.mark.parametrize('env_id', ['CliffWalking-v1'])
-def test_feature_function_one_hot_encoding(env_id: str):
+def test_feature_function_one_hot_encoding(env_id: str, observation: int):
     """
     Test that the feature function produces correct one-hot encoded features.
 
     Args:
         env_id: The Gymnasium environment ID to be used.
+        observation: The state observation.
 
     """
     env = gym.make(env_id)
@@ -115,15 +117,87 @@ def test_feature_function_one_hot_encoding(env_id: str):
     feature_fn = OneHotFeatureFunction(S, A)
 
     # Test a specific observation
-    observation = 0
     features = feature_fn(np.array([observation]))
 
-    # Check that each row (except possibly the first action) has exactly one non-zero element
+    # Check that each column (except possibly the first action) has exactly one non-zero element
     # The first action is excluded to avoid linear dependency
     for i in range(1, A):
-        row_sum = np.sum(features[:, i])
-        assert row_sum == 1.0
+        col_sum = np.sum(features[:, i])
+        assert col_sum == 1.0
         assert np.sum(features[:, i] == 1.0) == 1
+
+    assert np.sum(features[:, 0]) == 0
+    assert features[observation * 3, 1] == 1
+    assert features[observation * 3 + 1, 2] == 1
+    assert features[observation * 3 + 2, 3] == 1
+
+
+@given(n_observations=st.integers(min_value=2, max_value=100))
+@pytest.mark.parametrize('env_id', ['CliffWalking-v1'])
+def test_feature_function_one_hot_encoding_with_multiple_observations(env_id: str, n_observations: int):
+    """
+    Test that the feature function produces correct one-hot encoded features.
+
+    Args:
+        env_id: The Gymnasium environment ID to be used.
+        n_observations: The number of state observation to sample.
+
+    """
+    env = gym.make(env_id)
+    S = env.observation_space.n
+    A = env.action_space.n
+
+    feature_fn = OneHotFeatureFunction(S, A)
+
+    observations = np.random.randint(low=0, high=47, size=(1, n_observations))
+
+    # Test a specific observation
+    features = feature_fn(observations)
+
+    for o in range(n_observations):
+        # Check that each column (except possibly the first action) has exactly one non-zero element
+        # The first action is excluded to avoid linear dependency
+        for i in range(1, A):
+            col_sum = np.sum(features[:, i, o])
+            assert col_sum == 1.0
+            assert np.sum(features[:, i, o] == 1.0) == 1
+
+        assert np.sum(features[:, 0, o]) == 0
+        assert features[observations[0, o] * 3, 1, o] == 1
+        assert features[observations[0, o] * 3 + 1, 2, o] == 1
+        assert features[observations[0, o] * 3 + 2, 3, o] == 1
+
+
+@given(
+    observation1=st.integers(min_value=0, max_value=47),
+    observation2=st.integers(min_value=0, max_value=47),
+)
+@pytest.mark.parametrize('env_id', ['CliffWalking-v1'])
+def test_feature_function_one_hot_encoding_with_different_observations(
+    env_id: str, observation1: int, observation2: int
+):
+    """
+    Test that the feature function produces different encodings for different observations.
+
+    Args:
+        env_id: The Gymnasium environment ID to be used.
+        observation1: The first state observation.
+        observation2: The second state observation.
+
+    """
+    env = gym.make(env_id)
+    S = env.observation_space.n
+    A = env.action_space.n
+
+    feature_fn = OneHotFeatureFunction(S, A)
+
+    features1 = feature_fn(np.array([observation1]))
+    features2 = feature_fn(np.array([observation2]))
+
+    if observation1 != observation2:
+        assert np.sum(np.abs(features1 - features2)) > 0
+    else:
+        assert np.sum(np.abs(features1 - features2)) == 0
 
 
 @pytest.mark.parametrize('env_id', ['CliffWalking-v1'])

--- a/tests/tfrlrl/features/test_onehot.py
+++ b/tests/tfrlrl/features/test_onehot.py
@@ -1,24 +1,29 @@
+from typing import List
+
 import gymnasium as gym
 import numpy as np
 import pytest
 from hypothesis import given, settings
 from hypothesis import strategies as st
 
-from tfrlrl.features.onehot import construct_one_hot_feature_function
+from tfrlrl.features.base import EnvironmentException
+from tfrlrl.features.onehot import OneHotFeatureFunction
 
 
 @pytest.mark.parametrize('env_id', ['CliffWalking-v1'])
 def test_returns_callable(env_id: str):
     """
-    Test that construct_one_hot_feature_function returns a callable function.
+    Test that OneHotFeatureFunction acts as a callable function.
 
-    :param env_id: The Gymnasium environment ID to be used.
+    Args:
+        env_id: The Gymnasium environment ID to be used.
+
     """
     env = gym.make(env_id)
     S = env.observation_space.n
     A = env.action_space.n
 
-    feature_fn = construct_one_hot_feature_function(S, A)
+    feature_fn = OneHotFeatureFunction(S, A)
     assert callable(feature_fn)
 
 
@@ -27,13 +32,15 @@ def test_feature_function_returns_numpy_array(env_id: str):
     """
     Test that the feature function returns a numpy array for valid observations.
 
-    :param env_id: The Gymnasium environment ID to be used.
+    Args:
+        env_id: The Gymnasium environment ID to be used.
+
     """
     env = gym.make(env_id)
     S = env.observation_space.n
     A = env.action_space.n
 
-    feature_fn = construct_one_hot_feature_function(S, A)
+    feature_fn = OneHotFeatureFunction(S, A)
 
     # Test with the initial observation
     observation, _ = env.reset()
@@ -45,22 +52,50 @@ def test_feature_function_returns_numpy_array(env_id: str):
 @pytest.mark.parametrize('env_id', ['CliffWalking-v1'])
 @given(observation=st.integers(min_value=0, max_value=47))
 @settings(deadline=None)
-def test_feature_function_output_shape(env_id: str, observation: int):
+def test_feature_function_output_shape_with_single_observation(env_id: str, observation: int):
     """
-    Test that the feature function returns the correct output shape.
+    Test that the feature function returns the correct output shape in case of single observations.
 
-    :param env_id: The Gymnasium environment ID to be used.
-    :param observation: A valid observation (state) from the environment.
+    Args:
+        env_id: The Gymnasium environment ID to be used.
+        observation: A valid observation (state) from the environment.
+
     """
     env = gym.make(env_id)
     S = env.observation_space.n
     A = env.action_space.n
 
-    feature_fn = construct_one_hot_feature_function(S, A)
+    feature_fn = OneHotFeatureFunction(S, A)
     features = feature_fn(np.array([observation]))
 
-    # The feature function should return a matrix of shape (A, S * (A - 1))
-    expected_shape = (A, S * (A - 1))
+    # The feature function should return a matrix of shape (S * (A - 1), A)
+    expected_shape = (S * (A - 1), A)
+    assert features.shape == expected_shape
+
+
+@pytest.mark.parametrize('env_id', ['CliffWalking-v1'])
+@given(n_observations=st.integers(min_value=2, max_value=10))
+@settings(deadline=None)
+def test_feature_function_output_shape_with_multiple_observations(env_id: str, n_observations: int):
+    """
+    Test that the feature function returns the correct output shape in case of multiple observations.
+
+    Args:
+        env_id: The Gymnasium environment ID to be used.
+        n_observations: The number of observations for which to construct the features.
+
+    """
+    env = gym.make(env_id)
+    S = env.observation_space.n
+    A = env.action_space.n
+
+    observations = np.array([np.random.randint(0, 47) for _ in range(n_observations)])[np.newaxis, :]
+
+    feature_fn = OneHotFeatureFunction(S, A)
+    features = feature_fn(observations)
+
+    # The feature function should return a matrix of shape (S * (A - 1), A, n_observations)
+    expected_shape = (S * (A - 1), A, n_observations)
     assert features.shape == expected_shape
 
 
@@ -69,13 +104,15 @@ def test_feature_function_one_hot_encoding(env_id: str):
     """
     Test that the feature function produces correct one-hot encoded features.
 
-    :param env_id: The Gymnasium environment ID to be used.
+    Args:
+        env_id: The Gymnasium environment ID to be used.
+
     """
     env = gym.make(env_id)
     S = env.observation_space.n
     A = env.action_space.n
 
-    feature_fn = construct_one_hot_feature_function(S, A)
+    feature_fn = OneHotFeatureFunction(S, A)
 
     # Test a specific observation
     observation = 0
@@ -84,9 +121,9 @@ def test_feature_function_one_hot_encoding(env_id: str):
     # Check that each row (except possibly the first action) has exactly one non-zero element
     # The first action is excluded to avoid linear dependency
     for i in range(1, A):
-        row_sum = np.sum(features[i, :])
+        row_sum = np.sum(features[:, i])
         assert row_sum == 1.0, f'Row {i} should sum to 1.0, got {row_sum}'
-        assert np.sum(features[i, :] == 1.0) == 1, f'Row {i} should have exactly one 1.0'
+        assert np.sum(features[:, i] == 1.0) == 1, f'Row {i} should have exactly one 1.0'
 
 
 @pytest.mark.parametrize('env_id', ['CliffWalking-v1'])
@@ -96,14 +133,16 @@ def test_feature_function_consistent_output(env_id: str, observation: int):
     """
     Test that the feature function produces consistent output for the same observation.
 
-    :param env_id: The Gymnasium environment ID to be used.
-    :param observation: A valid observation (state) from the environment.
+    Args:
+        env_id: The Gymnasium environment ID to be used.
+        observation: A valid observation (state) from the environment.
+
     """
     env = gym.make(env_id)
     S = env.observation_space.n
     A = env.action_space.n
 
-    feature_fn = construct_one_hot_feature_function(S, A)
+    feature_fn = OneHotFeatureFunction(S, A)
 
     # Call the feature function multiple times with the same observation
     features1 = feature_fn(np.array([observation]))
@@ -111,3 +150,52 @@ def test_feature_function_consistent_output(env_id: str, observation: int):
 
     # Results should be identical
     np.testing.assert_array_equal(features1, features2)
+
+
+@pytest.mark.parametrize('env_id', ['CliffWalking-v1'])
+def test_feature_function_n_features(env_id: str):
+    """
+    Test that n_features returns the correct number of features.
+
+    Args:
+        env_id: The Gymnasium environment ID to be used.
+
+    """
+    env = gym.make(env_id)
+    S = env.observation_space.n
+    A = env.action_space.n
+
+    feature_fn = OneHotFeatureFunction(S, A)
+    assert feature_fn.n_features == S * (A - 1)
+
+
+@pytest.mark.parametrize(
+    'env_id, size',
+    [
+        (
+            'CliffWalking-v1',
+            [2, 1],
+        ),
+        (
+            'CliffWalking-v1',
+            [1, 1, 2],
+        ),
+    ],
+)
+def test_one_hot_feature_function_with_incorrect_shapes(env_id: str, size: List[int]):
+    """
+    Test that one-hot feature function throws error with incorrect observation sizes.
+
+    Args:
+        env_id: The Gymnasium environment ID to be used.
+        size: The size of the observation matrix.
+
+    """
+    env = gym.make(env_id)
+    S = env.observation_space.n
+    A = env.action_space.n
+
+    feature_fn = OneHotFeatureFunction(S, A)
+
+    with pytest.raises(EnvironmentException):
+        feature_fn(np.random.randint(0, 47, size=size))

--- a/tests/tfrlrl/policies/test_dense_neural_network.py
+++ b/tests/tfrlrl/policies/test_dense_neural_network.py
@@ -7,10 +7,28 @@ from hypothesis import strategies as st
 from tests.conftest import (
     DummyStatisticsCollector,
 )
+from tfrlrl.policies.base import PolicyException
 from tfrlrl.policies.dense_neural_network import DenseNetworkPolicy
 from tfrlrl.sampling.episodic_sampler import (
     EpisodicSampler,
 )
+
+
+@pytest.mark.parametrize('env_id', ['CliffWalking-v1'])
+def test_dense_network_policy_with_discrete_environment(env_id):
+    """
+    Test the DenseNetworkPolicy throws environment error on discrete domain.
+
+    Args:
+        env_id: The environment I.D. from which to sample episodes.
+
+    """
+    hidden_space_dims = [16, 32]
+    with pytest.raises(PolicyException):
+        DenseNetworkPolicy(
+            env_id=env_id,
+            hidden_space_dims=hidden_space_dims,
+        )
 
 
 @pytest.mark.parametrize('env_id', ['InvertedPendulum-v5'])

--- a/tests/tfrlrl/policies/test_dense_neural_network.py
+++ b/tests/tfrlrl/policies/test_dense_neural_network.py
@@ -18,7 +18,9 @@ def test_sample_single_action_from_dense_network_policy(env_id):
     """
     Test sampling a single action with a DenseNetworkPolicy.
 
-    env_id: The environment I.D. from which to sample episodes.
+    Args:
+        env_id: The environment I.D. from which to sample episodes.
+
     """
     env = gym.make(env_id)
 
@@ -43,10 +45,12 @@ def test_sample_episode_with_dense_network_policy(env_id: str, n_episodes: int, 
     """
     Test sampling of episodes with a DenseNetworkPolicy.
 
-    env_id: The environment I.D. from which to sample episodes.
-    n_episodes: The number of episodes to sample.
-    h1_dimensions: The number of units in the first hidden layer.
-    h2_dimensions: The number of units in the second hidden layer.
+    Args:
+        env_id: The environment I.D. from which to sample episodes.
+        n_episodes: The number of episodes to sample.
+        h1_dimensions: The number of units in the first hidden layer.
+        h2_dimensions: The number of units in the second hidden layer.
+
     """
     statistics_collector = DummyStatisticsCollector()
 
@@ -71,7 +75,9 @@ def test_calculate_log_probabilities_from_dense_network_policy_single_observatio
     """
     Test calculate_log_probabilities with a single observation with a DenseNetworkPolicy.
 
-    env_id: The environment I.D. from which to sample episodes.
+    Args:
+        env_id: The environment I.D. from which to sample episodes.
+
     """
     env = gym.make(env_id)
 
@@ -111,7 +117,11 @@ def test_calculate_log_probabilities_from_dense_network_policy_multiple_observat
     """
     Test calculate_log_probabilities with multiple observations with a DenseNetworkPolicy.
 
-    env_id: The environment I.D. from which to sample episodes.
+    Args:
+        env_id: The environment I.D. from which to sample episodes.
+        n_observations: The number of observations to sample.
+        extend_actions: A Boolean indicating whether to extend the diemsions of the actions.
+
     """
     env = gym.make(env_id)
 

--- a/tests/tfrlrl/policies/test_dense_neural_network.py
+++ b/tests/tfrlrl/policies/test_dense_neural_network.py
@@ -1,0 +1,65 @@
+import gymnasium as gym
+import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from tests.conftest import (
+    DummyStatisticsCollector,
+)
+from tfrlrl.policies.dense_neural_network import DenseNetworkPolicy
+from tfrlrl.sampling.episodic_sampler import (
+    EpisodicSampler,
+)
+
+
+@pytest.mark.parametrize('env_id', ['InvertedPendulum-v5'])
+def test_sample_single_action_from_dense_network_policy(env_id):
+    """
+    Test sampling a single action with a DenseNetworkPolicy.
+
+    env_id: The environment I.D. from which to sample episodes.
+    """
+    env = gym.make(env_id)
+
+    hidden_space_dims = [16, 32]
+    policy = DenseNetworkPolicy(
+        env_id=env_id,
+        hidden_space_dims=hidden_space_dims,
+    )
+
+    action = policy.generate_action(env.observation_space.sample())
+    assert action.shape == (1,)
+
+
+@pytest.mark.parametrize('env_id', ['InvertedPendulum-v5'])
+@given(
+    n_episodes=st.integers(min_value=0, max_value=20),
+    h1_dimensions=st.integers(min_value=8, max_value=32),
+    h2_dimensions=st.integers(min_value=24, max_value=48),
+)
+@settings(deadline=None)
+def test_sample_episode_with_dense_network_policy(env_id: str, n_episodes: int, h1_dimensions: int, h2_dimensions: int):
+    """
+    Test sampling of episodes with a DenseNetworkPolicy.
+
+    env_id: The environment I.D. from which to sample episodes.
+    n_episodes: The number of episodes to sample.
+    h1_dimensions: The number of units in the first hidden layer.
+    h2_dimensions: The number of units in the second hidden layer.
+    """
+    statistics_collector = DummyStatisticsCollector()
+
+    hidden_space_dims = [h1_dimensions, h2_dimensions]
+    policy = DenseNetworkPolicy(
+        env_id=env_id,
+        hidden_space_dims=hidden_space_dims,
+    )
+
+    sampler = EpisodicSampler(
+        env_id=env_id,
+        statistics_collector=statistics_collector,
+        n_episodes=n_episodes,
+        policy=policy,
+    )
+    samples = list(sampler)
+    assert len(samples) == n_episodes

--- a/tests/tfrlrl/policies/test_dense_neural_network.py
+++ b/tests/tfrlrl/policies/test_dense_neural_network.py
@@ -1,4 +1,5 @@
 import gymnasium as gym
+import numpy as np
 import pytest
 from hypothesis import given, settings
 from hypothesis import strategies as st
@@ -63,3 +64,83 @@ def test_sample_episode_with_dense_network_policy(env_id: str, n_episodes: int, 
     )
     samples = list(sampler)
     assert len(samples) == n_episodes
+
+
+@pytest.mark.parametrize('env_id', ['InvertedPendulum-v5'])
+def test_calculate_log_probabilities_from_dense_network_policy_single_observation(env_id):
+    """
+    Test calculate_log_probabilities with a single observation with a DenseNetworkPolicy.
+
+    env_id: The environment I.D. from which to sample episodes.
+    """
+    env = gym.make(env_id)
+
+    hidden_space_dims = [16, 32]
+    policy = DenseNetworkPolicy(
+        env_id=env_id,
+        hidden_space_dims=hidden_space_dims,
+    )
+
+    log_probability = policy.calculate_log_probabilities(
+        env.observation_space.sample()[..., np.newaxis],
+        env.action_space.sample(),
+    )
+    assert log_probability.shape == (1,)
+
+
+@pytest.mark.parametrize(
+    'env_id, extend_actions',
+    [
+        (
+            'InvertedPendulum-v5',
+            True,
+        ),
+        (
+            'InvertedPendulum-v5',
+            False,
+        ),
+    ],
+)
+@given(
+    n_observations=st.integers(min_value=1, max_value=20),
+)
+@settings(deadline=None)
+def test_calculate_log_probabilities_from_dense_network_policy_multiple_observations(
+    env_id, n_observations, extend_actions
+):
+    """
+    Test calculate_log_probabilities with multiple observations with a DenseNetworkPolicy.
+
+    env_id: The environment I.D. from which to sample episodes.
+    """
+    env = gym.make(env_id)
+
+    hidden_space_dims = [16, 32]
+    policy = DenseNetworkPolicy(
+        env_id=env_id,
+        hidden_space_dims=hidden_space_dims,
+    )
+
+    observations = np.concatenate(
+        [env.observation_space.sample()[..., np.newaxis] for _ in range(n_observations)],
+        axis=1,
+    )
+    if extend_actions:
+        actions = np.concatenate(
+            [env.action_space.sample()[..., np.newaxis] for _ in range(n_observations)],
+            axis=1,
+        )
+    else:
+        actions = np.concatenate(
+            [env.action_space.sample() for _ in range(n_observations)],
+        )
+
+    log_probabilities = policy.calculate_log_probabilities(
+        observations,
+        actions,
+    )
+
+    if extend_actions:
+        assert log_probabilities.shape == (n_observations, 1)
+    else:
+        assert log_probabilities.shape == (n_observations,)

--- a/tests/tfrlrl/policies/test_linear_soft_max.py
+++ b/tests/tfrlrl/policies/test_linear_soft_max.py
@@ -48,7 +48,7 @@ def test_linear_softmax_policy_generate_action(env_id: str, observation: int, se
     policy = LinearSoftMax(env_id, feature_fn)
     action = policy.generate_action(np.array([observation]))
 
-    assert isinstance(action, np.ndarray)
+    assert isinstance(action, np.int64)
     assert action.size == 1
     assert action.flat[0] in [0, 1, 2, 3]
 

--- a/tests/tfrlrl/policies/test_linear_soft_max.py
+++ b/tests/tfrlrl/policies/test_linear_soft_max.py
@@ -1,198 +1,198 @@
-import gymnasium as gym
-import numpy as np
-import pytest
-from hypothesis import given, settings
-from hypothesis import strategies as st
+# import gymnasium as gym
+# import numpy as np
+# import pytest
+# from hypothesis import given, settings
+# from hypothesis import strategies as st
 
-from tfrlrl.features.onehot import construct_one_hot_feature_function
-from tfrlrl.policies.linear_soft_max import LinearSoftMax
-
-
-@pytest.mark.parametrize('env_id', ['CliffWalking-v1'])
-def test_init_with_discrete_action_space(env_id: str):
-    """
-    Test that LinearSoftMax can be initialized with discrete action space environments.
-
-    :param env_id: The Gymnasium environment ID with a discrete action space.
-    """
-    env = gym.make(env_id)
-    softmax_parameters = np.random.uniform(
-        low=-1.0,
-        high=1.0,
-        size=(env.observation_space.n * (env.action_space.n - 1),),
-    )
-    feature_fn = construct_one_hot_feature_function(env.observation_space.n, env.action_space.n)
-
-    policy = LinearSoftMax(env_id, softmax_parameters, feature_fn)
-    assert isinstance(policy, LinearSoftMax)
-    assert policy._env.spec.id == env_id
+# from tfrlrl.features.onehot import construct_one_hot_feature_function
+# from tfrlrl.policies.linear_soft_max import LinearSoftMax
 
 
-@pytest.mark.parametrize('env_id', ['CliffWalking-v1'])
-@given(observation=st.integers(min_value=0, max_value=47), seed=st.integers(min_value=0, max_value=10000))
-@settings(deadline=None)
-def test_action_probabilities_sum_to_one(env_id: str, observation: int, seed: int):
-    """
-    Test that action probabilities sum to one for various observations and parameter values.
+# @pytest.mark.parametrize('env_id', ['CliffWalking-v1'])
+# def test_init_with_discrete_action_space(env_id: str):
+#     """
+#     Test that LinearSoftMax can be initialized with discrete action space environments.
 
-    :param env_id: The Gymnasium environment ID with a discrete action space.
-    :param observation: A valid observation (state) from the environment.
-    :param seed: Random seed for generating softmax parameters.
-    """
-    env = gym.make(env_id)
-    np.random.seed(seed)
-    softmax_parameters = np.random.uniform(
-        low=-10.0,
-        high=10.0,
-        size=(env.observation_space.n * (env.action_space.n - 1),),
-    )
-    feature_fn = construct_one_hot_feature_function(env.observation_space.n, env.action_space.n)
+#     :param env_id: The Gymnasium environment ID with a discrete action space.
+#     """
+#     env = gym.make(env_id)
+#     softmax_parameters = np.random.uniform(
+#         low=-1.0,
+#         high=1.0,
+#         size=(env.observation_space.n * (env.action_space.n - 1),),
+#     )
+#     feature_fn = construct_one_hot_feature_function(env.observation_space.n, env.action_space.n)
 
-    policy = LinearSoftMax(env_id, softmax_parameters, feature_fn)
-    action_probs = policy.calculate_action_probabilities(np.array([observation]))
-
-    # Check that probabilities sum to 1.0 (within numerical tolerance)
-    np.testing.assert_allclose(np.sum(action_probs), 1.0, rtol=1e-6, atol=1e-9)
-
-    # Check that all probabilities are non-negative
-    assert np.all(action_probs >= 0.0), 'All action probabilities should be non-negative'
-
-    # Check that all probabilities are <= 1.0
-    assert np.all(action_probs <= 1.0), 'All action probabilities should be <= 1.0'
+#     policy = LinearSoftMax(env_id, softmax_parameters, feature_fn)
+#     assert isinstance(policy, LinearSoftMax)
+#     assert policy._env.spec.id == env_id
 
 
-@pytest.mark.parametrize('env_id', ['CliffWalking-v1'])
-@given(observation=st.integers(min_value=0, max_value=47), seed=st.integers(min_value=0, max_value=10000))
-@settings(deadline=None)
-def test_generate_action_returns_valid_actions(env_id: str, observation: int, seed: int):
-    """
-    Test that generate_action returns valid actions for various policy initializations.
+# @pytest.mark.parametrize('env_id', ['CliffWalking-v1'])
+# @given(observation=st.integers(min_value=0, max_value=47), seed=st.integers(min_value=0, max_value=10000))
+# @settings(deadline=None)
+# def test_action_probabilities_sum_to_one(env_id: str, observation: int, seed: int):
+#     """
+#     Test that action probabilities sum to one for various observations and parameter values.
 
-    :param env_id: The Gymnasium environment ID with a discrete action space.
-    :param observation: A valid observation (state) from the environment.
-    :param seed: Random seed for generating softmax parameters.
-    """
-    env = gym.make(env_id)
-    np.random.seed(seed)
-    softmax_parameters = np.random.uniform(
-        low=-10.0,
-        high=10.0,
-        size=(env.observation_space.n * (env.action_space.n - 1),),
-    )
-    feature_fn = construct_one_hot_feature_function(env.observation_space.n, env.action_space.n)
+#     :param env_id: The Gymnasium environment ID with a discrete action space.
+#     :param observation: A valid observation (state) from the environment.
+#     :param seed: Random seed for generating softmax parameters.
+#     """
+#     env = gym.make(env_id)
+#     np.random.seed(seed)
+#     softmax_parameters = np.random.uniform(
+#         low=-10.0,
+#         high=10.0,
+#         size=(env.observation_space.n * (env.action_space.n - 1),),
+#     )
+#     feature_fn = construct_one_hot_feature_function(env.observation_space.n, env.action_space.n)
 
-    policy = LinearSoftMax(env_id, softmax_parameters, feature_fn)
+#     policy = LinearSoftMax(env_id, softmax_parameters, feature_fn)
+#     action_probs = policy.calculate_action_probabilities(np.array([observation]))
 
-    # Generate multiple actions to test consistency
-    for _ in range(10):
-        action = policy.generate_action(np.array([observation]))
+#     # Check that probabilities sum to 1.0 (within numerical tolerance)
+#     np.testing.assert_allclose(np.sum(action_probs), 1.0, rtol=1e-6, atol=1e-9)
 
-        # Check that action is an integer
-        assert isinstance(action, (int, np.integer)), f'Action should be an integer, got {type(action)}'
+#     # Check that all probabilities are non-negative
+#     assert np.all(action_probs >= 0.0), 'All action probabilities should be non-negative'
 
-        # Check that action is within valid range
-        assert 0 <= action < env.action_space.n, f'Action {action} is out of valid range [0, {env.action_space.n})'
-
-
-@pytest.mark.parametrize('env_id', ['CliffWalking-v1'])
-@given(
-    observation=st.integers(min_value=0, max_value=47),
-    action=st.integers(min_value=0, max_value=3),
-    seed=st.integers(min_value=0, max_value=1000),
-)
-@settings(deadline=None)
-def test_calculate_log_derivative_finite_difference(env_id: str, observation: int, action: int, seed: int):
-    """
-    Test that calculate_log_derivative matches finite difference approximation.
-
-    :param env_id: The Gymnasium environment ID with a discrete action space.
-    :param observation: A valid observation (state) from the environment.
-    :param action: A valid action from the action space.
-    :param seed: Random seed for generating softmax parameters.
-    """
-    env = gym.make(env_id)
-    np.random.seed(seed)
-    softmax_parameters = np.random.uniform(
-        low=-5.0,
-        high=5.0,
-        size=(env.observation_space.n * (env.action_space.n - 1),),
-    )
-    feature_fn = construct_one_hot_feature_function(env.observation_space.n, env.action_space.n)
-
-    policy = LinearSoftMax(env_id, softmax_parameters, feature_fn)
-
-    # Calculate analytical gradient
-    analytical_grad = policy.calculate_log_derivative(np.array([observation]), action)
-
-    # Calculate numerical gradient using finite differences
-    epsilon = 1e-5
-    numerical_grad = np.zeros_like(softmax_parameters)
-
-    for i in range(len(softmax_parameters)):
-        # Perturb parameter positively
-        params_plus = softmax_parameters.copy()
-        params_plus[i] += epsilon
-        policy_plus = LinearSoftMax(env_id, params_plus, feature_fn)
-        probs_plus = policy_plus.calculate_action_probabilities(np.array([observation]))
-        log_prob_plus = np.log(probs_plus[action] + 1e-10)
-
-        # Perturb parameter negatively
-        params_minus = softmax_parameters.copy()
-        params_minus[i] -= epsilon
-        policy_minus = LinearSoftMax(env_id, params_minus, feature_fn)
-        probs_minus = policy_minus.calculate_action_probabilities(np.array([observation]))
-        log_prob_minus = np.log(probs_minus[action] + 1e-10)
-
-        # Finite difference approximation
-        numerical_grad[i] = (log_prob_plus - log_prob_minus) / (2 * epsilon)
-
-    # Compare analytical and numerical gradients
-    np.testing.assert_allclose(
-        analytical_grad,
-        numerical_grad,
-        rtol=1e-3,
-        atol=1e-4,
-        err_msg='Analytical gradient does not match numerical gradient',
-    )
+#     # Check that all probabilities are <= 1.0
+#     assert np.all(action_probs <= 1.0), 'All action probabilities should be <= 1.0'
 
 
-@pytest.mark.parametrize('env_id', ['CliffWalking-v1'])
-@given(observation=st.integers(min_value=0, max_value=47), seed=st.integers(min_value=0, max_value=10000))
-@settings(deadline=None)
-def test_update_linear_softmax_policy(env_id: str, observation: int, seed: int):
-    """
-    Test the update of the policy parameter values.
+# @pytest.mark.parametrize('env_id', ['CliffWalking-v1'])
+# @given(observation=st.integers(min_value=0, max_value=47), seed=st.integers(min_value=0, max_value=10000))
+# @settings(deadline=None)
+# def test_generate_action_returns_valid_actions(env_id: str, observation: int, seed: int):
+#     """
+#     Test that generate_action returns valid actions for various policy initializations.
 
-    Args:
-        env_id: The Gymnasium environment ID with a discrete action space.
-        observation: A valid observation (state) from the environment.
-        seed: Random seed for generating softmax parameters.
+#     :param env_id: The Gymnasium environment ID with a discrete action space.
+#     :param observation: A valid observation (state) from the environment.
+#     :param seed: Random seed for generating softmax parameters.
+#     """
+#     env = gym.make(env_id)
+#     np.random.seed(seed)
+#     softmax_parameters = np.random.uniform(
+#         low=-10.0,
+#         high=10.0,
+#         size=(env.observation_space.n * (env.action_space.n - 1),),
+#     )
+#     feature_fn = construct_one_hot_feature_function(env.observation_space.n, env.action_space.n)
 
-    """
-    env = gym.make(env_id)
-    np.random.seed(seed)
-    softmax_parameters = np.random.uniform(
-        low=-10.0,
-        high=10.0,
-        size=(env.observation_space.n * (env.action_space.n - 1),),
-    )
-    feature_fn = construct_one_hot_feature_function(env.observation_space.n, env.action_space.n)
+#     policy = LinearSoftMax(env_id, softmax_parameters, feature_fn)
 
-    policy = LinearSoftMax(env_id, softmax_parameters, feature_fn)
-    action_probs = policy.calculate_action_probabilities(np.array([observation]))
+#     # Generate multiple actions to test consistency
+#     for _ in range(10):
+#         action = policy.generate_action(np.array([observation]))
 
-    # Check that probabilities sum to 1.0 (within numerical tolerance)
-    np.testing.assert_allclose(np.sum(action_probs), 1.0, rtol=1e-6, atol=1e-9)
+#         # Check that action is an integer
+#         assert isinstance(action, (int, np.integer)), f'Action should be an integer, got {type(action)}'
 
-    new_softmax_parameters = np.random.uniform(
-        low=-10.0,
-        high=10.0,
-        size=(env.observation_space.n * (env.action_space.n - 1),),
-    )
-    policy.update(new_softmax_parameters)
+#         # Check that action is within valid range
+#         assert 0 <= action < env.action_space.n, f'Action {action} is out of valid range [0, {env.action_space.n})'
 
-    # Check that all probabilities are non-negative
-    assert np.all(action_probs >= 0.0), 'All action probabilities should be non-negative'
 
-    # Check that all probabilities are <= 1.0
-    assert np.all(action_probs <= 1.0), 'All action probabilities should be <= 1.0'
+# @pytest.mark.parametrize('env_id', ['CliffWalking-v1'])
+# @given(
+#     observation=st.integers(min_value=0, max_value=47),
+#     action=st.integers(min_value=0, max_value=3),
+#     seed=st.integers(min_value=0, max_value=1000),
+# )
+# @settings(deadline=None)
+# def test_calculate_log_derivative_finite_difference(env_id: str, observation: int, action: int, seed: int):
+#     """
+#     Test that calculate_log_derivative matches finite difference approximation.
+
+#     :param env_id: The Gymnasium environment ID with a discrete action space.
+#     :param observation: A valid observation (state) from the environment.
+#     :param action: A valid action from the action space.
+#     :param seed: Random seed for generating softmax parameters.
+#     """
+#     env = gym.make(env_id)
+#     np.random.seed(seed)
+#     softmax_parameters = np.random.uniform(
+#         low=-5.0,
+#         high=5.0,
+#         size=(env.observation_space.n * (env.action_space.n - 1),),
+#     )
+#     feature_fn = construct_one_hot_feature_function(env.observation_space.n, env.action_space.n)
+
+#     policy = LinearSoftMax(env_id, softmax_parameters, feature_fn)
+
+#     # Calculate analytical gradient
+#     analytical_grad = policy.calculate_log_derivative(np.array([observation]), action)
+
+#     # Calculate numerical gradient using finite differences
+#     epsilon = 1e-5
+#     numerical_grad = np.zeros_like(softmax_parameters)
+
+#     for i in range(len(softmax_parameters)):
+#         # Perturb parameter positively
+#         params_plus = softmax_parameters.copy()
+#         params_plus[i] += epsilon
+#         policy_plus = LinearSoftMax(env_id, params_plus, feature_fn)
+#         probs_plus = policy_plus.calculate_action_probabilities(np.array([observation]))
+#         log_prob_plus = np.log(probs_plus[action] + 1e-10)
+
+#         # Perturb parameter negatively
+#         params_minus = softmax_parameters.copy()
+#         params_minus[i] -= epsilon
+#         policy_minus = LinearSoftMax(env_id, params_minus, feature_fn)
+#         probs_minus = policy_minus.calculate_action_probabilities(np.array([observation]))
+#         log_prob_minus = np.log(probs_minus[action] + 1e-10)
+
+#         # Finite difference approximation
+#         numerical_grad[i] = (log_prob_plus - log_prob_minus) / (2 * epsilon)
+
+#     # Compare analytical and numerical gradients
+#     np.testing.assert_allclose(
+#         analytical_grad,
+#         numerical_grad,
+#         rtol=1e-3,
+#         atol=1e-4,
+#         err_msg='Analytical gradient does not match numerical gradient',
+#     )
+
+
+# @pytest.mark.parametrize('env_id', ['CliffWalking-v1'])
+# @given(observation=st.integers(min_value=0, max_value=47), seed=st.integers(min_value=0, max_value=10000))
+# @settings(deadline=None)
+# def test_update_linear_softmax_policy(env_id: str, observation: int, seed: int):
+#     """
+#     Test the update of the policy parameter values.
+
+#     Args:
+#         env_id: The Gymnasium environment ID with a discrete action space.
+#         observation: A valid observation (state) from the environment.
+#         seed: Random seed for generating softmax parameters.
+
+#     """
+#     env = gym.make(env_id)
+#     np.random.seed(seed)
+#     softmax_parameters = np.random.uniform(
+#         low=-10.0,
+#         high=10.0,
+#         size=(env.observation_space.n * (env.action_space.n - 1),),
+#     )
+#     feature_fn = construct_one_hot_feature_function(env.observation_space.n, env.action_space.n)
+
+#     policy = LinearSoftMax(env_id, softmax_parameters, feature_fn)
+#     action_probs = policy.calculate_action_probabilities(np.array([observation]))
+
+#     # Check that probabilities sum to 1.0 (within numerical tolerance)
+#     np.testing.assert_allclose(np.sum(action_probs), 1.0, rtol=1e-6, atol=1e-9)
+
+#     new_softmax_parameters = np.random.uniform(
+#         low=-10.0,
+#         high=10.0,
+#         size=(env.observation_space.n * (env.action_space.n - 1),),
+#     )
+#     policy.update(new_softmax_parameters)
+
+#     # Check that all probabilities are non-negative
+#     assert np.all(action_probs >= 0.0), 'All action probabilities should be non-negative'
+
+#     # Check that all probabilities are <= 1.0
+#     assert np.all(action_probs <= 1.0), 'All action probabilities should be <= 1.0'

--- a/tests/tfrlrl/policies/test_linear_soft_max.py
+++ b/tests/tfrlrl/policies/test_linear_soft_max.py
@@ -154,3 +154,45 @@ def test_calculate_log_derivative_finite_difference(env_id: str, observation: in
         atol=1e-4,
         err_msg='Analytical gradient does not match numerical gradient',
     )
+
+
+@pytest.mark.parametrize('env_id', ['CliffWalking-v1'])
+@given(observation=st.integers(min_value=0, max_value=47), seed=st.integers(min_value=0, max_value=10000))
+@settings(deadline=None)
+def test_update_linear_softmax_policy(env_id: str, observation: int, seed: int):
+    """
+    Test the update of the policy parameter values.
+
+    Args:
+        env_id: The Gymnasium environment ID with a discrete action space.
+        observation: A valid observation (state) from the environment.
+        seed: Random seed for generating softmax parameters.
+
+    """
+    env = gym.make(env_id)
+    np.random.seed(seed)
+    softmax_parameters = np.random.uniform(
+        low=-10.0,
+        high=10.0,
+        size=(env.observation_space.n * (env.action_space.n - 1),),
+    )
+    feature_fn = construct_one_hot_feature_function(env.observation_space.n, env.action_space.n)
+
+    policy = LinearSoftMax(env_id, softmax_parameters, feature_fn)
+    action_probs = policy.calculate_action_probabilities(np.array([observation]))
+
+    # Check that probabilities sum to 1.0 (within numerical tolerance)
+    np.testing.assert_allclose(np.sum(action_probs), 1.0, rtol=1e-6, atol=1e-9)
+
+    new_softmax_parameters = np.random.uniform(
+        low=-10.0,
+        high=10.0,
+        size=(env.observation_space.n * (env.action_space.n - 1),),
+    )
+    policy.update(new_softmax_parameters)
+
+    # Check that all probabilities are non-negative
+    assert np.all(action_probs >= 0.0), 'All action probabilities should be non-negative'
+
+    # Check that all probabilities are <= 1.0
+    assert np.all(action_probs <= 1.0), 'All action probabilities should be <= 1.0'

--- a/tests/tfrlrl/policies/test_linear_soft_max.py
+++ b/tests/tfrlrl/policies/test_linear_soft_max.py
@@ -1,198 +1,86 @@
-# import gymnasium as gym
-# import numpy as np
-# import pytest
-# from hypothesis import given, settings
-# from hypothesis import strategies as st
+import gymnasium as gym
+import numpy as np
+import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
+from torch import (
+    Tensor,
+)
 
-# from tfrlrl.features.onehot import construct_one_hot_feature_function
-# from tfrlrl.policies.linear_soft_max import LinearSoftMax
-
-
-# @pytest.mark.parametrize('env_id', ['CliffWalking-v1'])
-# def test_init_with_discrete_action_space(env_id: str):
-#     """
-#     Test that LinearSoftMax can be initialized with discrete action space environments.
-
-#     :param env_id: The Gymnasium environment ID with a discrete action space.
-#     """
-#     env = gym.make(env_id)
-#     softmax_parameters = np.random.uniform(
-#         low=-1.0,
-#         high=1.0,
-#         size=(env.observation_space.n * (env.action_space.n - 1),),
-#     )
-#     feature_fn = construct_one_hot_feature_function(env.observation_space.n, env.action_space.n)
-
-#     policy = LinearSoftMax(env_id, softmax_parameters, feature_fn)
-#     assert isinstance(policy, LinearSoftMax)
-#     assert policy._env.spec.id == env_id
+from tfrlrl.features.onehot import OneHotFeatureFunction
+from tfrlrl.policies.linear_soft_max import LinearSoftMax
 
 
-# @pytest.mark.parametrize('env_id', ['CliffWalking-v1'])
-# @given(observation=st.integers(min_value=0, max_value=47), seed=st.integers(min_value=0, max_value=10000))
-# @settings(deadline=None)
-# def test_action_probabilities_sum_to_one(env_id: str, observation: int, seed: int):
-#     """
-#     Test that action probabilities sum to one for various observations and parameter values.
+@pytest.mark.parametrize('env_id', ['CliffWalking-v1'])
+def test_linear_softmax_policy_init_with_discrete_action_space(env_id: str):
+    """
+    Test that LinearSoftMax can be initialized with discrete action space environments.
 
-#     :param env_id: The Gymnasium environment ID with a discrete action space.
-#     :param observation: A valid observation (state) from the environment.
-#     :param seed: Random seed for generating softmax parameters.
-#     """
-#     env = gym.make(env_id)
-#     np.random.seed(seed)
-#     softmax_parameters = np.random.uniform(
-#         low=-10.0,
-#         high=10.0,
-#         size=(env.observation_space.n * (env.action_space.n - 1),),
-#     )
-#     feature_fn = construct_one_hot_feature_function(env.observation_space.n, env.action_space.n)
+    Args:
+        env_id: The Gymnasium environment ID with a discrete action space.
 
-#     policy = LinearSoftMax(env_id, softmax_parameters, feature_fn)
-#     action_probs = policy.calculate_action_probabilities(np.array([observation]))
+    """
+    env = gym.make(env_id)
+    feature_fn = OneHotFeatureFunction(env.observation_space.n, env.action_space.n)
 
-#     # Check that probabilities sum to 1.0 (within numerical tolerance)
-#     np.testing.assert_allclose(np.sum(action_probs), 1.0, rtol=1e-6, atol=1e-9)
-
-#     # Check that all probabilities are non-negative
-#     assert np.all(action_probs >= 0.0), 'All action probabilities should be non-negative'
-
-#     # Check that all probabilities are <= 1.0
-#     assert np.all(action_probs <= 1.0), 'All action probabilities should be <= 1.0'
+    policy = LinearSoftMax(env_id, feature_fn)
+    assert isinstance(policy, LinearSoftMax)
+    assert policy._env.spec.id == env_id
 
 
-# @pytest.mark.parametrize('env_id', ['CliffWalking-v1'])
-# @given(observation=st.integers(min_value=0, max_value=47), seed=st.integers(min_value=0, max_value=10000))
-# @settings(deadline=None)
-# def test_generate_action_returns_valid_actions(env_id: str, observation: int, seed: int):
-#     """
-#     Test that generate_action returns valid actions for various policy initializations.
+@pytest.mark.parametrize('env_id', ['CliffWalking-v1'])
+@given(observation=st.integers(min_value=0, max_value=47), seed=st.integers(min_value=0, max_value=10000))
+@settings(deadline=None)
+def test_linear_softmax_policy_generate_action(env_id: str, observation: int, seed: int):
+    """
+    Test the generate_action function of the LinearSoftMax policy.
 
-#     :param env_id: The Gymnasium environment ID with a discrete action space.
-#     :param observation: A valid observation (state) from the environment.
-#     :param seed: Random seed for generating softmax parameters.
-#     """
-#     env = gym.make(env_id)
-#     np.random.seed(seed)
-#     softmax_parameters = np.random.uniform(
-#         low=-10.0,
-#         high=10.0,
-#         size=(env.observation_space.n * (env.action_space.n - 1),),
-#     )
-#     feature_fn = construct_one_hot_feature_function(env.observation_space.n, env.action_space.n)
+    Args:
+        env_id: The Gymnasium environment ID with a discrete action space.
+        observation: A valid observation (state) from the environment.
+        seed: Random seed for generating softmax parameters.
 
-#     policy = LinearSoftMax(env_id, softmax_parameters, feature_fn)
+    """
+    env = gym.make(env_id)
+    np.random.seed(seed)
+    feature_fn = OneHotFeatureFunction(env.observation_space.n, env.action_space.n)
 
-#     # Generate multiple actions to test consistency
-#     for _ in range(10):
-#         action = policy.generate_action(np.array([observation]))
+    policy = LinearSoftMax(env_id, feature_fn)
+    action = policy.generate_action(np.array([observation]))
 
-#         # Check that action is an integer
-#         assert isinstance(action, (int, np.integer)), f'Action should be an integer, got {type(action)}'
-
-#         # Check that action is within valid range
-#         assert 0 <= action < env.action_space.n, f'Action {action} is out of valid range [0, {env.action_space.n})'
+    assert isinstance(action, np.ndarray)
+    assert action.size == 1
+    assert action.flat[0] in [0, 1, 2, 3]
 
 
-# @pytest.mark.parametrize('env_id', ['CliffWalking-v1'])
-# @given(
-#     observation=st.integers(min_value=0, max_value=47),
-#     action=st.integers(min_value=0, max_value=3),
-#     seed=st.integers(min_value=0, max_value=1000),
-# )
-# @settings(deadline=None)
-# def test_calculate_log_derivative_finite_difference(env_id: str, observation: int, action: int, seed: int):
-#     """
-#     Test that calculate_log_derivative matches finite difference approximation.
+@pytest.mark.parametrize('env_id', ['CliffWalking-v1'])
+@given(n_observations=st.integers(min_value=2, max_value=2), seed=st.integers(min_value=0, max_value=10000))
+@settings(deadline=None)
+def test_linear_softmax_policy_calculate_log_probabilities(env_id: str, n_observations: int, seed: int):
+    """
+    Test the generate_action function of the LinearSoftMax policy.
 
-#     :param env_id: The Gymnasium environment ID with a discrete action space.
-#     :param observation: A valid observation (state) from the environment.
-#     :param action: A valid action from the action space.
-#     :param seed: Random seed for generating softmax parameters.
-#     """
-#     env = gym.make(env_id)
-#     np.random.seed(seed)
-#     softmax_parameters = np.random.uniform(
-#         low=-5.0,
-#         high=5.0,
-#         size=(env.observation_space.n * (env.action_space.n - 1),),
-#     )
-#     feature_fn = construct_one_hot_feature_function(env.observation_space.n, env.action_space.n)
+    Args:
+        env_id: The Gymnasium environment ID with a discrete action space.
+        n_observations: The number of observations for which to calculate the log-probabilities.
+        seed: Random seed for generating softmax parameters.
 
-#     policy = LinearSoftMax(env_id, softmax_parameters, feature_fn)
+    """
+    env = gym.make(env_id)
+    np.random.seed(seed)
+    feature_fn = OneHotFeatureFunction(env.observation_space.n, env.action_space.n)
+    policy = LinearSoftMax(env_id, feature_fn)
 
-#     # Calculate analytical gradient
-#     analytical_grad = policy.calculate_log_derivative(np.array([observation]), action)
+    observations = np.array([np.random.randint(0, 47) for _ in range(n_observations)])[np.newaxis, :]
+    actions = np.array([policy.generate_action(observations[0, i]) for i in range(n_observations)])
 
-#     # Calculate numerical gradient using finite differences
-#     epsilon = 1e-5
-#     numerical_grad = np.zeros_like(softmax_parameters)
+    log_probs = policy.calculate_log_probabilities(observations, actions)
 
-#     for i in range(len(softmax_parameters)):
-#         # Perturb parameter positively
-#         params_plus = softmax_parameters.copy()
-#         params_plus[i] += epsilon
-#         policy_plus = LinearSoftMax(env_id, params_plus, feature_fn)
-#         probs_plus = policy_plus.calculate_action_probabilities(np.array([observation]))
-#         log_prob_plus = np.log(probs_plus[action] + 1e-10)
-
-#         # Perturb parameter negatively
-#         params_minus = softmax_parameters.copy()
-#         params_minus[i] -= epsilon
-#         policy_minus = LinearSoftMax(env_id, params_minus, feature_fn)
-#         probs_minus = policy_minus.calculate_action_probabilities(np.array([observation]))
-#         log_prob_minus = np.log(probs_minus[action] + 1e-10)
-
-#         # Finite difference approximation
-#         numerical_grad[i] = (log_prob_plus - log_prob_minus) / (2 * epsilon)
-
-#     # Compare analytical and numerical gradients
-#     np.testing.assert_allclose(
-#         analytical_grad,
-#         numerical_grad,
-#         rtol=1e-3,
-#         atol=1e-4,
-#         err_msg='Analytical gradient does not match numerical gradient',
-#     )
+    assert isinstance(log_probs, Tensor)
+    assert log_probs.shape == (n_observations,)
+    np.testing.assert_array_less(log_probs.detach().numpy(), 0)
 
 
-# @pytest.mark.parametrize('env_id', ['CliffWalking-v1'])
-# @given(observation=st.integers(min_value=0, max_value=47), seed=st.integers(min_value=0, max_value=10000))
-# @settings(deadline=None)
-# def test_update_linear_softmax_policy(env_id: str, observation: int, seed: int):
-#     """
-#     Test the update of the policy parameter values.
-
-#     Args:
-#         env_id: The Gymnasium environment ID with a discrete action space.
-#         observation: A valid observation (state) from the environment.
-#         seed: Random seed for generating softmax parameters.
-
-#     """
-#     env = gym.make(env_id)
-#     np.random.seed(seed)
-#     softmax_parameters = np.random.uniform(
-#         low=-10.0,
-#         high=10.0,
-#         size=(env.observation_space.n * (env.action_space.n - 1),),
-#     )
-#     feature_fn = construct_one_hot_feature_function(env.observation_space.n, env.action_space.n)
-
-#     policy = LinearSoftMax(env_id, softmax_parameters, feature_fn)
-#     action_probs = policy.calculate_action_probabilities(np.array([observation]))
-
-#     # Check that probabilities sum to 1.0 (within numerical tolerance)
-#     np.testing.assert_allclose(np.sum(action_probs), 1.0, rtol=1e-6, atol=1e-9)
-
-#     new_softmax_parameters = np.random.uniform(
-#         low=-10.0,
-#         high=10.0,
-#         size=(env.observation_space.n * (env.action_space.n - 1),),
-#     )
-#     policy.update(new_softmax_parameters)
-
-#     # Check that all probabilities are non-negative
-#     assert np.all(action_probs >= 0.0), 'All action probabilities should be non-negative'
-
-#     # Check that all probabilities are <= 1.0
-#     assert np.all(action_probs <= 1.0), 'All action probabilities should be <= 1.0'
+# TODO: Add tests check the probabilities are as expected.
+# TODO: Add tests check that the values of the log-probabilities are correct.
+# TODO: Add tests with end-to-end sampling to ensure consistency with expected sizes.

--- a/tests/tfrlrl/policies/test_linear_soft_max.py
+++ b/tests/tfrlrl/policies/test_linear_soft_max.py
@@ -7,6 +7,7 @@ from hypothesis import given, settings
 from hypothesis import strategies as st
 from torch import (
     Tensor,
+    sum,
 )
 from torch.optim import (
     SGD,
@@ -91,7 +92,7 @@ def test_linear_softmax_policy_calculate_log_probabilities(env_id: str, n_observ
 @settings(deadline=None)
 def test_linear_softmax_policy_action_probabilities_sum_to_one(env_id: str, observation: int, seed: int):
     """
-    Test that action probabilities sum to one for various observations and parameter values.
+    Test action probabilities sum to one for single observations and parameter values.
 
     Args:
         env_id: The Gymnasium environment ID with a discrete action space.
@@ -129,14 +130,60 @@ def test_linear_softmax_policy_action_probabilities_sum_to_one(env_id: str, obse
 
 @pytest.mark.parametrize('env_id', ['CliffWalking-v1'])
 @given(
+    n_observations=st.integers(min_value=2, max_value=100),
+    seed=st.integers(min_value=0, max_value=10000),
+)
+@settings(deadline=None)
+def test_linear_softmax_policy_action_probabilities_sum_to_one_multiple_observations(
+    env_id: str, n_observations: int, seed: int
+):
+    """
+    Test action probabilities sum to one for multiple observations and parameter values.
+
+    Args:
+        env_id: The Gymnasium environment ID with a discrete action space.
+        n_observations: The number of observations for which to calculate the probabilities.
+        seed: Random seed for generating softmax parameters.
+
+    """
+    env = gym.make(env_id)
+    np.random.seed(seed)
+    feature_fn = OneHotFeatureFunction(env.observation_space.n, env.action_space.n)
+    policy = LinearSoftMax(env_id, feature_fn)
+
+    observations = np.random.randint(low=0, high=47, size=(1, n_observations))
+
+    action_probs = policy.calculate_action_distribution(observations).probs.detach().numpy()
+    action_probs_from_network = policy.network(policy.construct_network_input(observations)).squeeze()
+
+    # Check that probabilities are consistent with those obtained from the network
+    np.testing.assert_allclose(
+        action_probs,
+        action_probs_from_network.detach().numpy(),
+        rtol=1e-6,
+        atol=1e-9,
+    )
+
+    # Check that probabilities sum to 1.0 (within numerical tolerance)
+    np.testing.assert_allclose(np.sum(action_probs, axis=1), np.ones(shape=(n_observations)), rtol=1e-6, atol=1e-9)
+
+    # Check that all probabilities are non-negative
+    assert np.all(action_probs >= 0.0)
+
+    # Check that all probabilities are <= 1.0
+    assert np.all(action_probs <= 1.0)
+
+
+@pytest.mark.parametrize('env_id', ['CliffWalking-v1'])
+@given(
     observation=st.integers(min_value=0, max_value=47),
     action=st.integers(min_value=0, max_value=3),
     seed=st.integers(min_value=0, max_value=10000),
 )
 @settings(deadline=None)
-def test_linear_softmax_policy_log_probabilities(env_id: str, observation: int, action: int, seed: int):
+def test_linear_softmax_policy_log_probability(env_id: str, observation: int, action: int, seed: int):
     """
-    Test that calculate_log_probabilities returns the log-probabilities of the given actions.
+    Test calculate_log_probabilities returns log-probabilities of the given action for single observation.
 
     Args:
         env_id: The Gymnasium environment ID with a discrete action space.
@@ -162,6 +209,42 @@ def test_linear_softmax_policy_log_probabilities(env_id: str, observation: int, 
         rtol=1e-6,
         atol=1e-9,
     )
+
+
+@pytest.mark.parametrize('env_id', ['CliffWalking-v1'])
+@given(
+    n_observations=st.integers(min_value=2, max_value=100),
+    seed=st.integers(min_value=0, max_value=10000),
+)
+@settings(deadline=None)
+def test_linear_softmax_policy_log_probabilities(env_id: str, n_observations: int, seed: int):
+    """
+    Test that calculate_log_probabilities returns the log-probabilities for multiple observations.
+
+    Args:
+        env_id: The Gymnasium environment ID with a discrete action space.
+        n_observations: The number of observations for which to calculate the log-probabilities.
+        seed: Random seed for generating softmax parameters.
+
+    """
+    env = gym.make(env_id)
+    np.random.seed(seed)
+    feature_fn = OneHotFeatureFunction(env.observation_space.n, env.action_space.n)
+    policy = LinearSoftMax(env_id, feature_fn)
+
+    observations = np.random.randint(low=0, high=47, size=(1, n_observations))
+    actions = np.random.randint(low=0, high=3, size=(1, n_observations))
+
+    action_probs = policy.calculate_action_distribution(observations).probs.detach().numpy()
+    log_probabilities = policy.calculate_log_probabilities(observations, actions).detach().numpy()
+
+    for n in range(n_observations):
+        np.testing.assert_allclose(
+            np.log(action_probs[n, actions[0, n]]),
+            log_probabilities[0, n],
+            rtol=1e-6,
+            atol=1e-9,
+        )
 
 
 @pytest.mark.parametrize('env_id', ['CliffWalking-v1'])
@@ -214,6 +297,87 @@ def test_linear_softmax_policy_log_probabilities_derivatives(env_id: str, observ
     optimizer = SGD(policy.get_parameters())
     optimizer.zero_grad()
     loss = policy.calculate_log_probabilities(observation, action)
+    loss.backward()
+
+    df_log_probs = list(policy.get_parameters())[0].grad.detach().numpy()
+
+    np.testing.assert_almost_equal(
+        df_log_probs,
+        df_log_probs_finite_diffs,
+        decimal=2,
+    )
+
+
+@pytest.mark.parametrize('env_id', ['CliffWalking-v1'])
+@given(
+    n_observations=st.integers(min_value=2, max_value=10),
+    seed=st.integers(min_value=0, max_value=10000),
+)
+@settings(deadline=None)
+def test_linear_softmax_policy_log_probabilities_derivatives_multiple_observations(
+    env_id: str, n_observations: int, seed: int
+):
+    """
+    Test calculation of the derivativres of the log-probabilities of the policy with multiple observations.
+
+    Args:
+        env_id: The Gymnasium environment ID with a discrete action space.
+        n_observations: The number of observations to sample from the environment.
+        seed: Random seed for generating softmax parameters.
+
+    """
+    eps = 0.01
+
+    env = gym.make(env_id)
+    np.random.seed(seed)
+    feature_fn = OneHotFeatureFunction(env.observation_space.n, env.action_space.n)
+    policy = LinearSoftMax(env_id, feature_fn)
+
+    observations = np.random.randint(low=0, high=47, size=(1, n_observations))
+    actions = np.random.randint(low=0, high=3, size=(1, n_observations))
+
+    policy_dict = copy.deepcopy(policy.get_state())
+    n_weights = policy_dict['network.linear.weight'].shape[1]
+
+    df_log_probs_finite_diffs = np.zeros((1, n_weights))
+
+    for i in range(n_observations):
+        for n in range(n_weights):
+            new_policy_dict_plus = copy.deepcopy(policy_dict)
+            new_policy_dict_minus = copy.deepcopy(policy_dict)
+
+            new_policy_dict_plus['network.linear.weight'][0, n] += eps
+            policy.set_state(new_policy_dict_plus)
+            log_probability_plus = (
+                policy.calculate_log_probabilities(
+                    observations[:, i],
+                    actions[:, i],
+                )
+                .detach()
+                .numpy()
+            )
+
+            new_policy_dict_minus['network.linear.weight'][0, n] -= eps
+            policy.set_state(new_policy_dict_minus)
+            log_probability_minus = (
+                policy.calculate_log_probabilities(
+                    observations[:, i],
+                    actions[:, i],
+                )
+                .detach()
+                .numpy()
+            )
+
+            df_log_probs_finite_diffs[0, n] += 0.5 * (log_probability_plus - log_probability_minus) / eps
+
+    optimizer = SGD(policy.get_parameters())
+    optimizer.zero_grad()
+    loss = sum(
+        policy.calculate_log_probabilities(
+            observations=observations,
+            actions=actions,
+        )
+    )
     loss.backward()
 
     df_log_probs = list(policy.get_parameters())[0].grad.detach().numpy()

--- a/tests/tfrlrl/policies/test_linear_soft_max.py
+++ b/tests/tfrlrl/policies/test_linear_soft_max.py
@@ -104,7 +104,18 @@ def test_linear_softmax_policy_action_probabilities_sum_to_one(env_id: str, obse
     feature_fn = OneHotFeatureFunction(env.observation_space.n, env.action_space.n)
     policy = LinearSoftMax(env_id, feature_fn)
 
-    action_probs = policy.calculate_action_distribution(np.array([observation])).probs.detach().numpy()
+    observation = np.array([observation])
+
+    action_probs = policy.calculate_action_distribution(observation).probs.detach().numpy()
+    action_probs_from_network = policy.network(policy.construct_network_input(observation)).squeeze()
+
+    # Check that probabilities are consistent with those obtained from the network
+    np.testing.assert_allclose(
+        action_probs,
+        action_probs_from_network.detach().numpy(),
+        rtol=1e-6,
+        atol=1e-9,
+    )
 
     # Check that probabilities sum to 1.0 (within numerical tolerance)
     np.testing.assert_allclose(np.sum(action_probs), 1.0, rtol=1e-6, atol=1e-9)

--- a/tests/tfrlrl/policies/test_linear_soft_max.py
+++ b/tests/tfrlrl/policies/test_linear_soft_max.py
@@ -1,3 +1,5 @@
+import copy
+
 import gymnasium as gym
 import numpy as np
 import pytest
@@ -5,6 +7,9 @@ from hypothesis import given, settings
 from hypothesis import strategies as st
 from torch import (
     Tensor,
+)
+from torch.optim import (
+    SGD,
 )
 
 from tfrlrl.features.onehot import OneHotFeatureFunction
@@ -58,7 +63,7 @@ def test_linear_softmax_policy_generate_action(env_id: str, observation: int, se
 @settings(deadline=None)
 def test_linear_softmax_policy_calculate_log_probabilities(env_id: str, n_observations: int, seed: int):
     """
-    Test the generate_action function of the LinearSoftMax policy.
+    Test the calculate_log_probabilities function of the LinearSoftMax policy.
 
     Args:
         env_id: The Gymnasium environment ID with a discrete action space.
@@ -145,4 +150,65 @@ def test_linear_softmax_policy_log_probabilities(env_id: str, observation: int, 
         log_probability,
         rtol=1e-6,
         atol=1e-9,
+    )
+
+
+@pytest.mark.parametrize('env_id', ['CliffWalking-v1'])
+@given(
+    observation=st.integers(min_value=0, max_value=47),
+    action=st.integers(min_value=0, max_value=3),
+    seed=st.integers(min_value=0, max_value=10000),
+)
+@settings(deadline=None)
+def test_linear_softmax_policy_log_probabilities_derivatives(env_id: str, observation: int, action: int, seed: int):
+    """
+    Test calculation of the derivativres of the log-probabilities of the policy.
+
+    Args:
+        env_id: The Gymnasium environment ID with a discrete action space.
+        observation: A valid observation (state) from the environment.
+        action: A valid action from the environment.
+        seed: Random seed for generating softmax parameters.
+
+    """
+    eps = 0.01
+
+    env = gym.make(env_id)
+    np.random.seed(seed)
+    feature_fn = OneHotFeatureFunction(env.observation_space.n, env.action_space.n)
+    policy = LinearSoftMax(env_id, feature_fn)
+
+    action = np.array([action])
+    observation = np.array([observation])
+
+    policy_dict = copy.deepcopy(policy.get_state())
+    n_weights = policy_dict['network.linear.weight'].shape[1]
+
+    df_log_probs_finite_diffs = np.zeros((1, n_weights))
+
+    for n in range(n_weights):
+        new_policy_dict_plus = copy.deepcopy(policy_dict)
+        new_policy_dict_minus = copy.deepcopy(policy_dict)
+
+        new_policy_dict_plus['network.linear.weight'][0, n] += eps
+        policy.set_state(new_policy_dict_plus)
+        log_probability_plus = policy.calculate_log_probabilities(observation, action).detach().numpy()
+
+        new_policy_dict_minus['network.linear.weight'][0, n] -= eps
+        policy.set_state(new_policy_dict_minus)
+        log_probability_minus = policy.calculate_log_probabilities(observation, action).detach().numpy()
+
+        df_log_probs_finite_diffs[0, n] = 0.5 * (log_probability_plus - log_probability_minus) / eps
+
+    optimizer = SGD(policy.get_parameters())
+    optimizer.zero_grad()
+    loss = policy.calculate_log_probabilities(observation, action)
+    loss.backward()
+
+    df_log_probs = list(policy.get_parameters())[0].grad.detach().numpy()
+
+    np.testing.assert_almost_equal(
+        df_log_probs,
+        df_log_probs_finite_diffs,
+        decimal=2,
     )

--- a/tests/tfrlrl/policies/test_linear_soft_max.py
+++ b/tests/tfrlrl/policies/test_linear_soft_max.py
@@ -81,6 +81,68 @@ def test_linear_softmax_policy_calculate_log_probabilities(env_id: str, n_observ
     np.testing.assert_array_less(log_probs.detach().numpy(), 0)
 
 
-# TODO: Add tests check the probabilities are as expected.
-# TODO: Add tests check that the values of the log-probabilities are correct.
-# TODO: Add tests with end-to-end sampling to ensure consistency with expected sizes.
+@pytest.mark.parametrize('env_id', ['CliffWalking-v1'])
+@given(observation=st.integers(min_value=0, max_value=47), seed=st.integers(min_value=0, max_value=10000))
+@settings(deadline=None)
+def test_linear_softmax_policy_action_probabilities_sum_to_one(env_id: str, observation: int, seed: int):
+    """
+    Test that action probabilities sum to one for various observations and parameter values.
+
+    Args:
+        env_id: The Gymnasium environment ID with a discrete action space.
+        observation: A valid observation (state) from the environment.
+        seed: Random seed for generating softmax parameters.
+
+    """
+    env = gym.make(env_id)
+    np.random.seed(seed)
+    feature_fn = OneHotFeatureFunction(env.observation_space.n, env.action_space.n)
+    policy = LinearSoftMax(env_id, feature_fn)
+
+    action_probs = policy.calculate_action_distribution(np.array([observation])).probs.detach().numpy()
+
+    # Check that probabilities sum to 1.0 (within numerical tolerance)
+    np.testing.assert_allclose(np.sum(action_probs), 1.0, rtol=1e-6, atol=1e-9)
+
+    # Check that all probabilities are non-negative
+    assert np.all(action_probs >= 0.0)
+
+    # Check that all probabilities are <= 1.0
+    assert np.all(action_probs <= 1.0)
+
+
+@pytest.mark.parametrize('env_id', ['CliffWalking-v1'])
+@given(
+    observation=st.integers(min_value=0, max_value=47),
+    action=st.integers(min_value=0, max_value=3),
+    seed=st.integers(min_value=0, max_value=10000),
+)
+@settings(deadline=None)
+def test_linear_softmax_policy_log_probabilities(env_id: str, observation: int, action: int, seed: int):
+    """
+    Test that calculate_log_probabilities returns the log-probabilities of the given actions.
+
+    Args:
+        env_id: The Gymnasium environment ID with a discrete action space.
+        observation: A valid observation (state) from the environment.
+        action: A valid action from the environment.
+        seed: Random seed for generating softmax parameters.
+
+    """
+    env = gym.make(env_id)
+    np.random.seed(seed)
+    feature_fn = OneHotFeatureFunction(env.observation_space.n, env.action_space.n)
+    policy = LinearSoftMax(env_id, feature_fn)
+
+    action = np.array([action])
+    observation = np.array([observation])
+
+    action_probs = policy.calculate_action_distribution(observation).probs.detach().numpy()
+    log_probability = policy.calculate_log_probabilities(observation, action).detach().numpy()
+
+    np.testing.assert_allclose(
+        np.log(action_probs[action]),
+        log_probability,
+        rtol=1e-6,
+        atol=1e-9,
+    )

--- a/tests/tfrlrl/replay_buffer/test_replay_buffer.py
+++ b/tests/tfrlrl/replay_buffer/test_replay_buffer.py
@@ -39,7 +39,7 @@ def test_add_steps(env_id: str, n_steps: int):
     :param n_steps: The number of steps to sample from the environment.
     """
     buffer_size = 1000
-    _, steps_cls = construct_step_dataclasses(env_id)
+    _, _, steps_cls = construct_step_dataclasses(env_id)
     sampler = Sampler(env_id, n_steps)
 
     buffer = ReplayBuffer(

--- a/tests/tfrlrl/sampling/test_episodic_sampler.py
+++ b/tests/tfrlrl/sampling/test_episodic_sampler.py
@@ -26,8 +26,10 @@ class TestEpisodicSampler:
         """
         Test that n-episodes can be sampled from the environment and that the outputs follow the expected format.
 
-        :param env_id: The Gym environment ID to be used in the sampling.
-        :param n_steps: The number of steps to sample from the environment.
+        Args:
+            env_id: The Gym environment ID to be used in the sampling.
+            n_episodes: The number of n_episodes to sample from the environment.
+
         """
         env = gym.make(env_id)
         S = env.observation_space.n
@@ -65,7 +67,9 @@ class TestEpisodicSampler:
 
         Uses FrozenLake-v1 with is_slippery parameter to verify kwargs functionality.
 
-        :param n_steps: The number of steps to sample from the environment.
+        Args:
+            n_episodes: The number of episodes to sample from the environment.
+
         """
         env_id = 'FrozenLake-v1'
         env = gym.make(env_id)
@@ -104,11 +108,79 @@ class TestEpisodicSampler:
 
     @given(n_episodes=st.integers(min_value=2, max_value=10))
     @settings(deadline=2000)
+    def test_sample_episode_with_policy_update(self, n_episodes: int):
+        """
+        Test that updating the policy.
+
+        Uses LinearSoftmaxPolicy to test update of policies.
+
+        Args:
+            n_episodes: The number of episodes to sample from the environment.
+
+        """
+        env_id = 'FrozenLake-v1'
+        env = gym.make(env_id)
+        S = env.observation_space.n
+        A = env.action_space.n
+
+        feature_fn = construct_one_hot_feature_function(S=S, A=A)
+        softmax_parameters = np.random.random(size=S * (A - 1))
+        pol = LinearSoftMax(
+            env_id,
+            softmax_parameters,
+            feature_fn,
+        )
+        stats_collector = DummyStatisticsCollector()
+        sampler = EpisodicSampler(
+            env_id,
+            stats_collector,
+            n_episodes=n_episodes,
+            policy=pol,
+            is_slippery=False,
+        )
+        statistics = list(sampler)
+        assert len(statistics) == n_episodes
+        for statistic in statistics:
+            assert isinstance(statistic.samples, dict)
+            assert len(statistic.samples) == 1
+            env_id = next(iter(statistic.samples))
+            for step in statistic.samples[env_id]:
+                assert isinstance(step.env_id, str)
+                assert isinstance(step.time_step, int)
+                assert isinstance(step.observation, np.ndarray)
+                assert isinstance(step.next_observation, np.ndarray)
+                assert isinstance(step.reward, float) or isinstance(step.reward, int)
+                assert isinstance(step.done, bool)
+                assert isinstance(step.info, dict)
+
+        new_softmax_parameters = np.random.random(size=S * (A - 1))
+        sampler.reset()
+        sampler.update(parameters=new_softmax_parameters)
+
+        statistics = list(sampler)
+        assert len(statistics) == n_episodes
+        for statistic in statistics:
+            assert isinstance(statistic.samples, dict)
+            assert len(statistic.samples) == 1
+            env_id = next(iter(statistic.samples))
+            for step in statistic.samples[env_id]:
+                assert isinstance(step.env_id, str)
+                assert isinstance(step.time_step, int)
+                assert isinstance(step.observation, np.ndarray)
+                assert isinstance(step.next_observation, np.ndarray)
+                assert isinstance(step.reward, float) or isinstance(step.reward, int)
+                assert isinstance(step.done, bool)
+                assert isinstance(step.info, dict)
+
+    @given(n_episodes=st.integers(min_value=2, max_value=10))
+    @settings(deadline=2000)
     def test_reset_allows_reuse_as_iterator(self, n_episodes: int):
         """
         Test that the reset method allows the EpisodicSampler to be used as an iterator multiple times.
 
-        :param n_episodes: The number of episodes to sample from the environment.
+        Args:
+            n_episodes: The number of episodes to sample from the environment.
+
         """
         env_id = 'FrozenLake-v1'
         env = gym.make(env_id)
@@ -182,8 +254,10 @@ class TestEpisodicSampler:
         """
         Test the sample function of the EpisodicSampler class and that the outputs follow the expected format.
 
-        :param env_id: The Gym environment ID to be used in the sampling.
-        :param n_steps: The number of steps to sample from the environment.
+        Args:
+            env_id: The Gym environment ID to be used in the sampling.
+            n_episodes: The number of episodes to sample from the environment.
+
         """
         env = gym.make(env_id)
         S = env.observation_space.n
@@ -222,9 +296,11 @@ class TestRayEpisodicSampler:
         """
         Test that n-episodes can be sampled from the environment and that the outputs follow the expected format.
 
-        :param env_id: The Gym environment ID to be used in the sampling.
-        :param n_steps: The number of steps to sample from the environment.
-        :param test_ray_cluster: Test Ray cluster.
+        Args:
+            env_id: The Gym environment ID to be used in the sampling.
+            n_episodes: The number of episodes to sample from the environment.
+            test_ray_cluster: Test Ray cluster.
+
         """
         n_samplers = 2
         env = gym.make(env_id)
@@ -269,8 +345,10 @@ class TestRayEpisodicSampler:
 
         Uses FrozenLake-v1 with is_slippery parameter to verify kwargs functionality.
 
-        :param n_steps: The number of steps to sample from the environment.
-        :param test_ray_cluster: Test Ray cluster.
+        Args:
+            n_episodes: The number of episodes to sample from the environment.
+            test_ray_cluster: Test Ray cluster.
+
         """
         n_samplers = 2
         env_id = 'FrozenLake-v1'
@@ -315,8 +393,10 @@ class TestRayEpisodicSampler:
         """
         Test that the reset method allows the EpisodicSampler to be used as an iterator multiple times.
 
-        :param n_episodes: The number of episodes to sample from the environment.
-        :param test_ray_cluster: Test Ray cluster.
+        Args:
+            n_episodes: The number of episodes to sample from the environment.
+            test_ray_cluster: Test Ray cluster.
+
         """
         n_samplers = 2
         env_id = 'FrozenLake-v1'
@@ -393,9 +473,11 @@ class TestRayEpisodicSampler:
         """
         Test the sample function of the EpisodicSampler class and that the outputs follow the expected format.
 
-        :param env_id: The Gym environment ID to be used in the sampling.
-        :param n_steps: The number of steps to sample from the environment.
-        :param test_ray_cluster: Test Ray cluster.
+        Args:
+            env_id: The Gym environment ID to be used in the sampling.
+            n_episodes: The number of episodes to sample from the environment.
+            test_ray_cluster: Test Ray cluster.
+
         """
         n_samplers = 2
         env = gym.make(env_id)

--- a/tests/tfrlrl/sampling/test_episodic_sampler.py
+++ b/tests/tfrlrl/sampling/test_episodic_sampler.py
@@ -263,9 +263,10 @@ class TestEpisodicSampler:
 class TestRayEpisodicSampler:
     """Class that encapsulates the unit tests for the RayEpisodicSampler class."""
 
+    @pytest.mark.slow
     @pytest.mark.parametrize('env_id', ['FrozenLake-v1'])
     @given(n_episodes=st.integers(min_value=2, max_value=10))
-    @settings(deadline=2000)
+    @settings(deadline=5000)
     def test_ray_sample_n_episodes_without_limit(self, env_id: str, n_episodes: int, test_ray_cluster):
         """
         Test that n-episodes can be sampled from the environment and that the outputs follow the expected format.
@@ -304,8 +305,9 @@ class TestRayEpisodicSampler:
                     assert isinstance(step.done, bool)
                     assert isinstance(step.info, dict)
 
+    @pytest.mark.slow
     @given(n_episodes=st.integers(min_value=2, max_value=10))
-    @settings(deadline=2000)
+    @settings(deadline=5000)
     def test_ray_sample_episode_with_env_kwargs(self, n_episodes: int, test_ray_cluster):
         """
         Test that environment kwargs are correctly passed through to the environment construction.
@@ -347,8 +349,9 @@ class TestRayEpisodicSampler:
                     assert isinstance(step.done, bool)
                     assert isinstance(step.info, dict)
 
+    @pytest.mark.slow
     @given(n_episodes=st.integers(min_value=2, max_value=10))
-    @settings(deadline=2000)
+    @settings(deadline=5000)
     def test_ray_reset_allows_reuse_as_iterator(self, n_episodes: int, test_ray_cluster):
         """
         Test that the reset method allows the EpisodicSampler to be used as an iterator multiple times.
@@ -419,9 +422,10 @@ class TestRayEpisodicSampler:
                     assert isinstance(step.info, dict)
             second_iteration_count += 1
 
+    @pytest.mark.slow
     @pytest.mark.parametrize('env_id', ['FrozenLake-v1'])
     @given(n_episodes=st.integers(min_value=2, max_value=10))
-    @settings(deadline=2000)
+    @settings(deadline=5000)
     def test_ray_sample_without_limits(self, env_id: str, n_episodes: int, test_ray_cluster):
         """
         Test the sample function of the EpisodicSampler class and that the outputs follow the expected format.

--- a/tests/tfrlrl/sampling/test_episodic_sampler.py
+++ b/tests/tfrlrl/sampling/test_episodic_sampler.py
@@ -1,59 +1,19 @@
-from collections import ChainMap, defaultdict
-from dataclasses import dataclass
-from typing import List
-
 import gymnasium as gym
 import numpy as np
 import pytest
 from hypothesis import given, settings
 from hypothesis import strategies as st
 
+from tests.conftest import (
+    DummyStatistics,
+    DummyStatisticsCollector,
+)
 from tfrlrl.features.onehot import construct_one_hot_feature_function
-from tfrlrl.policies.base import BasePolicy
 from tfrlrl.policies.linear_soft_max import LinearSoftMax
 from tfrlrl.sampling.episodic_sampler import (
     EpisodicSampler,
     RayEpisodicSampler,
 )
-from tfrlrl.sampling.statistics_collection import BaseStatisticsCollector
-
-
-@dataclass
-class DummyStatistics:
-    """Dataclass for the statistics collected test sample episodes."""
-
-    samples: dict[str, list]  # A map from the episode ID to the list of steps in the episode.
-
-
-class DummyStatisticsCollector(BaseStatisticsCollector):
-    """Test class for collecting statistics during sampling."""
-
-    def __init__(self):
-        """Initialise statistics collector."""
-        self._samples = defaultdict(list)
-
-    def reset(self):
-        """Reset the statistics in the collector."""
-        self._samples = defaultdict(list)
-
-    def update_policy(self, new_policy: BasePolicy) -> None:
-        """Update the policy of the statistics collector."""
-        pass
-
-    def collect_step_statistics(self, sample):
-        """Collect statistics from a sample step."""
-        self._samples[sample.env_id].append(sample)
-
-    def aggregate_statistics(self):
-        """Aggregate the statistics collected by the collector."""
-        return DummyStatistics(samples=self._samples)
-
-    @classmethod
-    def merge_statistics(cls, statistics: List[DummyStatistics]):
-        """Aggregate the statistics collected by the collector."""
-        return DummyStatistics(
-            samples=dict(ChainMap(*[x.samples for x in statistics])),
-        )
 
 
 class TestEpisodicSampler:

--- a/tests/tfrlrl/sampling/test_episodic_sampler.py
+++ b/tests/tfrlrl/sampling/test_episodic_sampler.py
@@ -1,513 +1,459 @@
-# import gymnasium as gym
-# import numpy as np
-# import pytest
-# from hypothesis import given, settings
-# from hypothesis import strategies as st
+import gymnasium as gym
+import numpy as np
+import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
 
-# from tests.conftest import (
-#     DummyStatistics,
-#     DummyStatisticsCollector,
-# )
-# from tfrlrl.features.onehot import construct_one_hot_feature_function
-# from tfrlrl.policies.linear_soft_max import LinearSoftMax
-# from tfrlrl.sampling.episodic_sampler import (
-#     EpisodicSampler,
-#     RayEpisodicSampler,
-# )
-
-
-# class TestEpisodicSampler:
-#     """Class that encapsulates the unit tests for the EpisodicSampler class."""
-
-#     @pytest.mark.parametrize('env_id', ['FrozenLake-v1'])
-#     @given(n_episodes=st.integers(min_value=2, max_value=10))
-#     @settings(deadline=2000)
-#     def test_sample_n_episodes_without_limit(self, env_id: str, n_episodes: int):
-#         """
-#         Test that n-episodes can be sampled from the environment and that the outputs follow the expected format.
-
-#         Args:
-#             env_id: The Gym environment ID to be used in the sampling.
-#             n_episodes: The number of n_episodes to sample from the environment.
-
-#         """
-#         env = gym.make(env_id)
-#         S = env.observation_space.n
-#         A = env.action_space.n
-
-#         feature_fn = construct_one_hot_feature_function(S=S, A=A)
-#         softmax_parameters = np.random.random(size=S * (A - 1))
-#         pol = LinearSoftMax(
-#             env_id,
-#             softmax_parameters,
-#             feature_fn,
-#         )
-#         stats_collector = DummyStatisticsCollector()
-#         sampler = EpisodicSampler(env_id, stats_collector, n_episodes=n_episodes, policy=pol)
-#         statistics = list(sampler)
-#         assert len(statistics) == n_episodes
-#         for statistic in statistics:
-#             assert isinstance(statistic.samples, dict)
-#             assert len(statistic.samples) == 1
-#             env_id = next(iter(statistic.samples))
-#             for step in statistic.samples[env_id]:
-#                 assert isinstance(step.env_id, str)
-#                 assert isinstance(step.time_step, int)
-#                 assert isinstance(step.observation, np.ndarray)
-#                 assert isinstance(step.next_observation, np.ndarray)
-#                 assert isinstance(step.reward, float) or isinstance(step.reward, int)
-#                 assert isinstance(step.done, bool)
-#                 assert isinstance(step.info, dict)
-
-#     @given(n_episodes=st.integers(min_value=2, max_value=10))
-#     @settings(deadline=2000)
-#     def test_sample_episode_with_env_kwargs(self, n_episodes: int):
-#         """
-#         Test that environment kwargs are correctly passed through to the environment construction.
-
-#         Uses FrozenLake-v1 with is_slippery parameter to verify kwargs functionality.
-
-#         Args:
-#             n_episodes: The number of episodes to sample from the environment.
-
-#         """
-#         env_id = 'FrozenLake-v1'
-#         env = gym.make(env_id)
-#         S = env.observation_space.n
-#         A = env.action_space.n
-
-#         feature_fn = construct_one_hot_feature_function(S=S, A=A)
-#         softmax_parameters = np.random.random(size=S * (A - 1))
-#         pol = LinearSoftMax(
-#             env_id,
-#             softmax_parameters,
-#             feature_fn,
-#         )
-#         stats_collector = DummyStatisticsCollector()
-#         sampler = EpisodicSampler(
-#             env_id,
-#             stats_collector,
-#             n_episodes=n_episodes,
-#             policy=pol,
-#             is_slippery=False,
-#         )
-#         statistics = list(sampler)
-#         assert len(statistics) == n_episodes
-#         for statistic in statistics:
-#             assert isinstance(statistic.samples, dict)
-#             assert len(statistic.samples) == 1
-#             env_id = next(iter(statistic.samples))
-#             for step in statistic.samples[env_id]:
-#                 assert isinstance(step.env_id, str)
-#                 assert isinstance(step.time_step, int)
-#                 assert isinstance(step.observation, np.ndarray)
-#                 assert isinstance(step.next_observation, np.ndarray)
-#                 assert isinstance(step.reward, float) or isinstance(step.reward, int)
-#                 assert isinstance(step.done, bool)
-#                 assert isinstance(step.info, dict)
-
-#     @given(n_episodes=st.integers(min_value=2, max_value=10))
-#     @settings(deadline=2000)
-#     def test_sample_episode_with_policy_update(self, n_episodes: int):
-#         """
-#         Test that updating the policy.
-
-#         Uses LinearSoftmaxPolicy to test update of policies.
-
-#         Args:
-#             n_episodes: The number of episodes to sample from the environment.
-
-#         """
-#         env_id = 'FrozenLake-v1'
-#         env = gym.make(env_id)
-#         S = env.observation_space.n
-#         A = env.action_space.n
-
-#         feature_fn = construct_one_hot_feature_function(S=S, A=A)
-#         softmax_parameters = np.random.random(size=S * (A - 1))
-#         pol = LinearSoftMax(
-#             env_id,
-#             softmax_parameters,
-#             feature_fn,
-#         )
-#         stats_collector = DummyStatisticsCollector()
-#         sampler = EpisodicSampler(
-#             env_id,
-#             stats_collector,
-#             n_episodes=n_episodes,
-#             policy=pol,
-#             is_slippery=False,
-#         )
-#         statistics = list(sampler)
-#         assert len(statistics) == n_episodes
-#         for statistic in statistics:
-#             assert isinstance(statistic.samples, dict)
-#             assert len(statistic.samples) == 1
-#             env_id = next(iter(statistic.samples))
-#             for step in statistic.samples[env_id]:
-#                 assert isinstance(step.env_id, str)
-#                 assert isinstance(step.time_step, int)
-#                 assert isinstance(step.observation, np.ndarray)
-#                 assert isinstance(step.next_observation, np.ndarray)
-#                 assert isinstance(step.reward, float) or isinstance(step.reward, int)
-#                 assert isinstance(step.done, bool)
-#                 assert isinstance(step.info, dict)
-
-#         new_softmax_parameters = np.random.random(size=S * (A - 1))
-#         sampler.reset()
-#         sampler.update(parameters=new_softmax_parameters)
-
-#         statistics = list(sampler)
-#         assert len(statistics) == n_episodes
-#         for statistic in statistics:
-#             assert isinstance(statistic.samples, dict)
-#             assert len(statistic.samples) == 1
-#             env_id = next(iter(statistic.samples))
-#             for step in statistic.samples[env_id]:
-#                 assert isinstance(step.env_id, str)
-#                 assert isinstance(step.time_step, int)
-#                 assert isinstance(step.observation, np.ndarray)
-#                 assert isinstance(step.next_observation, np.ndarray)
-#                 assert isinstance(step.reward, float) or isinstance(step.reward, int)
-#                 assert isinstance(step.done, bool)
-#                 assert isinstance(step.info, dict)
-
-#     @given(n_episodes=st.integers(min_value=2, max_value=10))
-#     @settings(deadline=2000)
-#     def test_reset_allows_reuse_as_iterator(self, n_episodes: int):
-#         """
-#         Test that the reset method allows the EpisodicSampler to be used as an iterator multiple times.
-
-#         Args:
-#             n_episodes: The number of episodes to sample from the environment.
-
-#         """
-#         env_id = 'FrozenLake-v1'
-#         env = gym.make(env_id)
-#         S = env.observation_space.n
-#         A = env.action_space.n
-
-#         feature_fn = construct_one_hot_feature_function(S=S, A=A)
-#         softmax_parameters = np.random.random(size=S * (A - 1))
-#         pol = LinearSoftMax(
-#             env_id,
-#             softmax_parameters,
-#             feature_fn,
-#         )
-#         stats_collector = DummyStatisticsCollector()
-#         sampler = EpisodicSampler(env_id, stats_collector, n_episodes=n_episodes, policy=pol)
-#         statistics = list(sampler)
-#         assert len(statistics) == n_episodes
-
-#         # First iteration: consume all episodes
-#         first_iteration_count = 0
-#         for statistic in statistics:
-#             assert isinstance(statistic.samples, dict)
-#             assert len(statistic.samples) == 1
-#             env_id = next(iter(statistic.samples))
-#             for step in statistic.samples[env_id]:
-#                 assert isinstance(step.env_id, str)
-#                 assert isinstance(step.time_step, int)
-#                 assert isinstance(step.observation, np.ndarray)
-#                 assert isinstance(step.next_observation, np.ndarray)
-#                 assert isinstance(step.reward, float) or isinstance(step.reward, int)
-#                 assert isinstance(step.done, bool)
-#                 assert isinstance(step.info, dict)
-#             first_iteration_count += 1
-
-#         assert first_iteration_count == n_episodes
-
-#         # Iterator should be exhausted - trying to iterate should yield no results
-#         exhausted_count = 0
-#         for _, _ in sampler:
-#             exhausted_count += 1
-
-#         assert exhausted_count == 0
-
-#         # Reset the sampler
-#         sampler.reset()
-#         statistics = list(sampler)
-#         assert len(statistics) == n_episodes
-
-#         # Second iteration: should work again after reset
-#         second_iteration_count = 0
-#         for statistic in statistics:
-#             assert isinstance(statistic.samples, dict)
-#             assert len(statistic.samples) == 1
-#             env_id = next(iter(statistic.samples))
-#             for step in statistic.samples[env_id]:
-#                 assert isinstance(step.env_id, str)
-#                 assert isinstance(step.time_step, int)
-#                 assert isinstance(step.observation, np.ndarray)
-#                 assert isinstance(step.next_observation, np.ndarray)
-#                 assert isinstance(step.reward, float) or isinstance(step.reward, int)
-#                 assert isinstance(step.done, bool)
-#                 assert isinstance(step.info, dict)
-#             second_iteration_count += 1
-
-#         assert second_iteration_count == n_episodes
-
-#     @pytest.mark.parametrize('env_id', ['FrozenLake-v1'])
-#     @given(n_episodes=st.integers(min_value=2, max_value=10))
-#     @settings(deadline=2000)
-#     def test_sample_without_limits(self, env_id: str, n_episodes: int):
-#         """
-#         Test the sample function of the EpisodicSampler class and that the outputs follow the expected format.
-
-#         Args:
-#             env_id: The Gym environment ID to be used in the sampling.
-#             n_episodes: The number of episodes to sample from the environment.
-
-#         """
-#         env = gym.make(env_id)
-#         S = env.observation_space.n
-#         A = env.action_space.n
-
-#         feature_fn = construct_one_hot_feature_function(S=S, A=A)
-#         softmax_parameters = np.random.random(size=S * (A - 1))
-#         pol = LinearSoftMax(
-#             env_id,
-#             softmax_parameters,
-#             feature_fn,
-#         )
-#         stats_collector = DummyStatisticsCollector()
-#         sampler = EpisodicSampler(env_id, stats_collector, n_episodes=n_episodes, policy=pol)
-#         statistics = sampler.sample()
-#         assert isinstance(statistics, DummyStatistics)
-#         assert isinstance(statistics.samples, dict)
-#         for k in statistics.samples:
-#             for step in statistics.samples[k]:
-#                 assert isinstance(step.env_id, str)
-#                 assert isinstance(step.time_step, int)
-#                 assert isinstance(step.observation, np.ndarray)
-#                 assert isinstance(step.next_observation, np.ndarray)
-#                 assert isinstance(step.reward, float) or isinstance(step.reward, int)
-#                 assert isinstance(step.done, bool)
-#                 assert isinstance(step.info, dict)
+from tests.conftest import (
+    DummyStatistics,
+    DummyStatisticsCollector,
+)
+from tfrlrl.features.onehot import OneHotFeatureFunction
+from tfrlrl.policies.linear_soft_max import LinearSoftMax
+from tfrlrl.sampling.episodic_sampler import (
+    EpisodicSampler,
+    RayEpisodicSampler,
+)
 
 
-# class TestRayEpisodicSampler:
-#     """Class that encapsulates the unit tests for the RayEpisodicSampler class."""
+class TestEpisodicSampler:
+    """Class that encapsulates the unit tests for the EpisodicSampler class."""
 
-#     @pytest.mark.parametrize('env_id', ['FrozenLake-v1'])
-#     @given(n_episodes=st.integers(min_value=2, max_value=10))
-#     @settings(deadline=2000)
-#     def test_ray_sample_n_episodes_without_limit(self, env_id: str, n_episodes: int, test_ray_cluster):
-#         """
-#         Test that n-episodes can be sampled from the environment and that the outputs follow the expected format.
+    @pytest.mark.parametrize('env_id', ['FrozenLake-v1'])
+    @given(n_episodes=st.integers(min_value=2, max_value=10))
+    @settings(deadline=2000)
+    def test_sample_n_episodes_without_limit(self, env_id: str, n_episodes: int):
+        """
+        Test that n-episodes can be sampled from the environment and that the outputs follow the expected format.
 
-#         Args:
-#             env_id: The Gym environment ID to be used in the sampling.
-#             n_episodes: The number of episodes to sample from the environment.
-#             test_ray_cluster: Test Ray cluster.
+        Args:
+            env_id: The Gym environment ID to be used in the sampling.
+            n_episodes: The number of n_episodes to sample from the environment.
 
-#         """
-#         n_samplers = 2
-#         env = gym.make(env_id)
-#         S = env.observation_space.n
-#         A = env.action_space.n
+        """
+        env = gym.make(env_id)
+        feature_fn = OneHotFeatureFunction(env.observation_space.n, env.action_space.n)
+        policy = LinearSoftMax(env_id, feature_fn)
 
-#         feature_fn = construct_one_hot_feature_function(S=S, A=A)
-#         softmax_parameters = np.random.random(size=S * (A - 1))
-#         pol = LinearSoftMax(
-#             env_id,
-#             softmax_parameters,
-#             feature_fn,
-#         )
-#         stats_collector = DummyStatisticsCollector()
-#         sampler = RayEpisodicSampler(
-#             n_samplers,
-#             env_id,
-#             stats_collector,
-#             n_episodes=n_episodes,
-#             policy=pol,
-#         )
-#         statistics = list(sampler)
-#         assert len(statistics) == n_episodes // n_samplers
-#         for statistic in statistics:
-#             assert isinstance(statistic.samples, dict)
-#             assert len(statistic.samples) == n_samplers
-#             for k in statistic.samples:
-#                 for step in statistic.samples[k]:
-#                     assert isinstance(step.env_id, str)
-#                     assert isinstance(step.time_step, int)
-#                     assert isinstance(step.observation, np.ndarray)
-#                     assert isinstance(step.next_observation, np.ndarray)
-#                     assert isinstance(step.reward, float) or isinstance(step.reward, int)
-#                     assert isinstance(step.done, bool)
-#                     assert isinstance(step.info, dict)
+        stats_collector = DummyStatisticsCollector()
+        sampler = EpisodicSampler(env_id, stats_collector, n_episodes=n_episodes, policy=policy)
+        statistics = list(sampler)
+        assert len(statistics) == n_episodes
+        for statistic in statistics:
+            assert isinstance(statistic.samples, dict)
+            assert len(statistic.samples) == 1
+            env_id = next(iter(statistic.samples))
+            for step in statistic.samples[env_id]:
+                assert isinstance(step.env_id, str)
+                assert isinstance(step.time_step, int)
+                assert isinstance(step.observation, np.ndarray)
+                assert isinstance(step.next_observation, np.ndarray)
+                assert isinstance(step.reward, float) or isinstance(step.reward, int)
+                assert isinstance(step.done, bool)
+                assert isinstance(step.info, dict)
 
-#     @given(n_episodes=st.integers(min_value=2, max_value=10))
-#     @settings(deadline=2000)
-#     def test_ray_sample_episode_with_env_kwargs(self, n_episodes: int, test_ray_cluster):
-#         """
-#         Test that environment kwargs are correctly passed through to the environment construction.
+    @given(n_episodes=st.integers(min_value=2, max_value=10))
+    @settings(deadline=2000)
+    def test_sample_episode_with_env_kwargs(self, n_episodes: int):
+        """
+        Test that environment kwargs are correctly passed through to the environment construction.
 
-#         Uses FrozenLake-v1 with is_slippery parameter to verify kwargs functionality.
+        Uses FrozenLake-v1 with is_slippery parameter to verify kwargs functionality.
 
-#         Args:
-#             n_episodes: The number of episodes to sample from the environment.
-#             test_ray_cluster: Test Ray cluster.
+        Args:
+            n_episodes: The number of episodes to sample from the environment.
 
-#         """
-#         n_samplers = 2
-#         env_id = 'FrozenLake-v1'
-#         env = gym.make(env_id)
-#         S = env.observation_space.n
-#         A = env.action_space.n
+        """
+        env_id = 'FrozenLake-v1'
+        env = gym.make(env_id)
+        feature_fn = OneHotFeatureFunction(env.observation_space.n, env.action_space.n)
+        policy = LinearSoftMax(env_id, feature_fn)
 
-#         feature_fn = construct_one_hot_feature_function(S=S, A=A)
-#         softmax_parameters = np.random.random(size=S * (A - 1))
-#         pol = LinearSoftMax(
-#             env_id,
-#             softmax_parameters,
-#             feature_fn,
-#         )
-#         stats_collector = DummyStatisticsCollector()
-#         sampler = RayEpisodicSampler(
-#             n_samplers,
-#             env_id,
-#             stats_collector,
-#             n_episodes=n_episodes,
-#             policy=pol,
-#             is_slippery=False,
-#         )
-#         statistics = list(sampler)
-#         assert len(statistics) == n_episodes // n_samplers
-#         for statistic in statistics:
-#             assert isinstance(statistic.samples, dict)
-#             assert len(statistic.samples) == n_samplers
-#             for k in statistic.samples:
-#                 for step in statistic.samples[k]:
-#                     assert isinstance(step.env_id, str)
-#                     assert isinstance(step.time_step, int)
-#                     assert isinstance(step.observation, np.ndarray)
-#                     assert isinstance(step.next_observation, np.ndarray)
-#                     assert isinstance(step.reward, float) or isinstance(step.reward, int)
-#                     assert isinstance(step.done, bool)
-#                     assert isinstance(step.info, dict)
+        stats_collector = DummyStatisticsCollector()
+        sampler = EpisodicSampler(
+            env_id,
+            stats_collector,
+            n_episodes=n_episodes,
+            policy=policy,
+            is_slippery=False,
+        )
+        statistics = list(sampler)
+        assert len(statistics) == n_episodes
+        for statistic in statistics:
+            assert isinstance(statistic.samples, dict)
+            assert len(statistic.samples) == 1
+            env_id = next(iter(statistic.samples))
+            for step in statistic.samples[env_id]:
+                assert isinstance(step.env_id, str)
+                assert isinstance(step.time_step, int)
+                assert isinstance(step.observation, np.ndarray)
+                assert isinstance(step.next_observation, np.ndarray)
+                assert isinstance(step.reward, float) or isinstance(step.reward, int)
+                assert isinstance(step.done, bool)
+                assert isinstance(step.info, dict)
 
-#     @given(n_episodes=st.integers(min_value=2, max_value=10))
-#     @settings(deadline=2000)
-#     def test_ray_reset_allows_reuse_as_iterator(self, n_episodes: int, test_ray_cluster):
-#         """
-#         Test that the reset method allows the EpisodicSampler to be used as an iterator multiple times.
+    @given(n_episodes=st.integers(min_value=2, max_value=10))
+    @settings(deadline=2000)
+    def test_sample_episode_with_policy_update(self, n_episodes: int):
+        """
+        Test that updating the policy.
 
-#         Args:
-#             n_episodes: The number of episodes to sample from the environment.
-#             test_ray_cluster: Test Ray cluster.
+        Uses LinearSoftmaxPolicy to test update of policies.
 
-#         """
-#         n_samplers = 2
-#         env_id = 'FrozenLake-v1'
-#         env = gym.make(env_id)
-#         S = env.observation_space.n
-#         A = env.action_space.n
+        Args:
+            n_episodes: The number of episodes to sample from the environment.
 
-#         feature_fn = construct_one_hot_feature_function(S=S, A=A)
-#         softmax_parameters = np.random.random(size=S * (A - 1))
-#         pol = LinearSoftMax(
-#             env_id,
-#             softmax_parameters,
-#             feature_fn,
-#         )
-#         stats_collector = DummyStatisticsCollector()
-#         sampler = RayEpisodicSampler(
-#             n_samplers,
-#             env_id,
-#             stats_collector,
-#             n_episodes=n_episodes,
-#             policy=pol,
-#         )
+        """
+        env_id = 'FrozenLake-v1'
+        env = gym.make(env_id)
+        feature_fn = OneHotFeatureFunction(env.observation_space.n, env.action_space.n)
+        policy = LinearSoftMax(env_id, feature_fn)
 
-#         # First iteration: consume all episodes
-#         first_iteration_count = 0
-#         statistics = list(sampler)
-#         assert len(statistics) == n_episodes // n_samplers
-#         for statistic in statistics:
-#             assert isinstance(statistic.samples, dict)
-#             assert len(statistic.samples) == n_samplers
-#             for k in statistic.samples:
-#                 for step in statistic.samples[k]:
-#                     assert isinstance(step.env_id, str)
-#                     assert isinstance(step.time_step, int)
-#                     assert isinstance(step.observation, np.ndarray)
-#                     assert isinstance(step.next_observation, np.ndarray)
-#                     assert isinstance(step.reward, float) or isinstance(step.reward, int)
-#                     assert isinstance(step.done, bool)
-#                     assert isinstance(step.info, dict)
-#                 first_iteration_count += 1
+        stats_collector = DummyStatisticsCollector()
+        sampler = EpisodicSampler(
+            env_id,
+            stats_collector,
+            n_episodes=n_episodes,
+            policy=policy,
+            is_slippery=False,
+        )
+        statistics = list(sampler)
+        assert len(statistics) == n_episodes
+        for statistic in statistics:
+            assert isinstance(statistic.samples, dict)
+            assert len(statistic.samples) == 1
+            env_id = next(iter(statistic.samples))
+            for step in statistic.samples[env_id]:
+                assert isinstance(step.env_id, str)
+                assert isinstance(step.time_step, int)
+                assert isinstance(step.observation, np.ndarray)
+                assert isinstance(step.next_observation, np.ndarray)
+                assert isinstance(step.reward, float) or isinstance(step.reward, int)
+                assert isinstance(step.done, bool)
+                assert isinstance(step.info, dict)
 
-#         # Iterator should be exhausted - trying to iterate should yield no results
-#         exhausted_count = 0
-#         for _, _ in sampler:
-#             exhausted_count += 1
+        sampler.reset()
+        sampler.update(state_dict=policy.get_state())
 
-#         assert exhausted_count == 0
+        statistics = list(sampler)
+        assert len(statistics) == n_episodes
+        for statistic in statistics:
+            assert isinstance(statistic.samples, dict)
+            assert len(statistic.samples) == 1
+            env_id = next(iter(statistic.samples))
+            for step in statistic.samples[env_id]:
+                assert isinstance(step.env_id, str)
+                assert isinstance(step.time_step, int)
+                assert isinstance(step.observation, np.ndarray)
+                assert isinstance(step.next_observation, np.ndarray)
+                assert isinstance(step.reward, float) or isinstance(step.reward, int)
+                assert isinstance(step.done, bool)
+                assert isinstance(step.info, dict)
 
-#         # Reset the sampler
-#         sampler.reset()
+    @given(n_episodes=st.integers(min_value=2, max_value=10))
+    @settings(deadline=2000)
+    def test_reset_allows_reuse_as_iterator(self, n_episodes: int):
+        """
+        Test that the reset method allows the EpisodicSampler to be used as an iterator multiple times.
 
-#         # Second iteration: should work again after reset
-#         second_iteration_count = 0
-#         statistics = list(sampler)
-#         assert len(statistics) == n_episodes // n_samplers
-#         for statistic in statistics:
-#             assert isinstance(statistic.samples, dict)
-#             assert len(statistic.samples) == n_samplers
-#             for k in statistic.samples:
-#                 for step in statistic.samples[k]:
-#                     assert isinstance(step.env_id, str)
-#                     assert isinstance(step.time_step, int)
-#                     assert isinstance(step.observation, np.ndarray)
-#                     assert isinstance(step.next_observation, np.ndarray)
-#                     assert isinstance(step.reward, float) or isinstance(step.reward, int)
-#                     assert isinstance(step.done, bool)
-#                     assert isinstance(step.info, dict)
-#             second_iteration_count += 1
+        Args:
+            n_episodes: The number of episodes to sample from the environment.
 
-#     @pytest.mark.parametrize('env_id', ['FrozenLake-v1'])
-#     @given(n_episodes=st.integers(min_value=2, max_value=10))
-#     @settings(deadline=2000)
-#     def test_ray_sample_without_limits(self, env_id: str, n_episodes: int, test_ray_cluster):
-#         """
-#         Test the sample function of the EpisodicSampler class and that the outputs follow the expected format.
+        """
+        env_id = 'FrozenLake-v1'
+        env = gym.make(env_id)
+        feature_fn = OneHotFeatureFunction(env.observation_space.n, env.action_space.n)
+        policy = LinearSoftMax(env_id, feature_fn)
 
-#         Args:
-#             env_id: The Gym environment ID to be used in the sampling.
-#             n_episodes: The number of episodes to sample from the environment.
-#             test_ray_cluster: Test Ray cluster.
+        stats_collector = DummyStatisticsCollector()
+        sampler = EpisodicSampler(
+            env_id,
+            stats_collector,
+            n_episodes=n_episodes,
+            policy=policy,
+        )
+        statistics = list(sampler)
+        assert len(statistics) == n_episodes
 
-#         """
-#         n_samplers = 2
-#         env = gym.make(env_id)
-#         S = env.observation_space.n
-#         A = env.action_space.n
+        # First iteration: consume all episodes
+        first_iteration_count = 0
+        for statistic in statistics:
+            assert isinstance(statistic.samples, dict)
+            assert len(statistic.samples) == 1
+            env_id = next(iter(statistic.samples))
+            for step in statistic.samples[env_id]:
+                assert isinstance(step.env_id, str)
+                assert isinstance(step.time_step, int)
+                assert isinstance(step.observation, np.ndarray)
+                assert isinstance(step.next_observation, np.ndarray)
+                assert isinstance(step.reward, float) or isinstance(step.reward, int)
+                assert isinstance(step.done, bool)
+                assert isinstance(step.info, dict)
+            first_iteration_count += 1
 
-#         feature_fn = construct_one_hot_feature_function(S=S, A=A)
-#         softmax_parameters = np.random.random(size=S * (A - 1))
-#         pol = LinearSoftMax(
-#             env_id,
-#             softmax_parameters,
-#             feature_fn,
-#         )
-#         stats_collector = DummyStatisticsCollector()
-#         sampler = RayEpisodicSampler(
-#             n_samplers,
-#             env_id,
-#             stats_collector,
-#             n_episodes=n_episodes,
-#             policy=pol,
-#         )
-#         statistics = sampler.sample()
-#         assert isinstance(statistics, DummyStatistics)
-#         assert isinstance(statistics.samples, dict)
-#         for k in statistics.samples:
-#             for step in statistics.samples[k]:
-#                 assert isinstance(step.env_id, str)
-#                 assert isinstance(step.time_step, int)
-#                 assert isinstance(step.observation, np.ndarray)
-#                 assert isinstance(step.next_observation, np.ndarray)
-#                 assert isinstance(step.reward, float) or isinstance(step.reward, int)
-#                 assert isinstance(step.done, bool)
-#                 assert isinstance(step.info, dict)
+        assert first_iteration_count == n_episodes
+
+        # Iterator should be exhausted - trying to iterate should yield no results
+        exhausted_count = 0
+        for _, _ in sampler:
+            exhausted_count += 1
+
+        assert exhausted_count == 0
+
+        # Reset the sampler
+        sampler.reset()
+        statistics = list(sampler)
+        assert len(statistics) == n_episodes
+
+        # Second iteration: should work again after reset
+        second_iteration_count = 0
+        for statistic in statistics:
+            assert isinstance(statistic.samples, dict)
+            assert len(statistic.samples) == 1
+            env_id = next(iter(statistic.samples))
+            for step in statistic.samples[env_id]:
+                assert isinstance(step.env_id, str)
+                assert isinstance(step.time_step, int)
+                assert isinstance(step.observation, np.ndarray)
+                assert isinstance(step.next_observation, np.ndarray)
+                assert isinstance(step.reward, float) or isinstance(step.reward, int)
+                assert isinstance(step.done, bool)
+                assert isinstance(step.info, dict)
+            second_iteration_count += 1
+
+        assert second_iteration_count == n_episodes
+
+    @pytest.mark.parametrize('env_id', ['FrozenLake-v1'])
+    @given(n_episodes=st.integers(min_value=2, max_value=10))
+    @settings(deadline=2000)
+    def test_sample_without_limits(self, env_id: str, n_episodes: int):
+        """
+        Test the sample function of the EpisodicSampler class and that the outputs follow the expected format.
+
+        Args:
+            env_id: The Gym environment ID to be used in the sampling.
+            n_episodes: The number of episodes to sample from the environment.
+
+        """
+        env = gym.make(env_id)
+        feature_fn = OneHotFeatureFunction(env.observation_space.n, env.action_space.n)
+        policy = LinearSoftMax(env_id, feature_fn)
+
+        stats_collector = DummyStatisticsCollector()
+        sampler = EpisodicSampler(
+            env_id,
+            stats_collector,
+            n_episodes=n_episodes,
+            policy=policy,
+        )
+        statistics = sampler.sample()
+        assert isinstance(statistics, DummyStatistics)
+        assert isinstance(statistics.samples, dict)
+        for k in statistics.samples:
+            for step in statistics.samples[k]:
+                assert isinstance(step.env_id, str)
+                assert isinstance(step.time_step, int)
+                assert isinstance(step.observation, np.ndarray)
+                assert isinstance(step.next_observation, np.ndarray)
+                assert isinstance(step.reward, float) or isinstance(step.reward, int)
+                assert isinstance(step.done, bool)
+                assert isinstance(step.info, dict)
+
+
+class TestRayEpisodicSampler:
+    """Class that encapsulates the unit tests for the RayEpisodicSampler class."""
+
+    @pytest.mark.parametrize('env_id', ['FrozenLake-v1'])
+    @given(n_episodes=st.integers(min_value=2, max_value=10))
+    @settings(deadline=2000)
+    def test_ray_sample_n_episodes_without_limit(self, env_id: str, n_episodes: int, test_ray_cluster):
+        """
+        Test that n-episodes can be sampled from the environment and that the outputs follow the expected format.
+
+        Args:
+            env_id: The Gym environment ID to be used in the sampling.
+            n_episodes: The number of episodes to sample from the environment.
+            test_ray_cluster: Test Ray cluster.
+
+        """
+        n_samplers = 2
+        env = gym.make(env_id)
+        feature_fn = OneHotFeatureFunction(env.observation_space.n, env.action_space.n)
+        policy = LinearSoftMax(env_id, feature_fn)
+
+        stats_collector = DummyStatisticsCollector()
+        sampler = RayEpisodicSampler(
+            n_samplers,
+            env_id,
+            stats_collector,
+            n_episodes=n_episodes,
+            policy=policy,
+        )
+        statistics = list(sampler)
+        assert len(statistics) == n_episodes // n_samplers
+        for statistic in statistics:
+            assert isinstance(statistic.samples, dict)
+            assert len(statistic.samples) == n_samplers
+            for k in statistic.samples:
+                for step in statistic.samples[k]:
+                    assert isinstance(step.env_id, str)
+                    assert isinstance(step.time_step, int)
+                    assert isinstance(step.observation, np.ndarray)
+                    assert isinstance(step.next_observation, np.ndarray)
+                    assert isinstance(step.reward, float) or isinstance(step.reward, int)
+                    assert isinstance(step.done, bool)
+                    assert isinstance(step.info, dict)
+
+    @given(n_episodes=st.integers(min_value=2, max_value=10))
+    @settings(deadline=2000)
+    def test_ray_sample_episode_with_env_kwargs(self, n_episodes: int, test_ray_cluster):
+        """
+        Test that environment kwargs are correctly passed through to the environment construction.
+
+        Uses FrozenLake-v1 with is_slippery parameter to verify kwargs functionality.
+
+        Args:
+            n_episodes: The number of episodes to sample from the environment.
+            test_ray_cluster: Test Ray cluster.
+
+        """
+        n_samplers = 2
+        env_id = 'FrozenLake-v1'
+        env = gym.make(env_id)
+        feature_fn = OneHotFeatureFunction(env.observation_space.n, env.action_space.n)
+        policy = LinearSoftMax(env_id, feature_fn)
+
+        stats_collector = DummyStatisticsCollector()
+        sampler = RayEpisodicSampler(
+            n_samplers,
+            env_id,
+            stats_collector,
+            n_episodes=n_episodes,
+            policy=policy,
+            is_slippery=False,
+        )
+        statistics = list(sampler)
+        assert len(statistics) == n_episodes // n_samplers
+        for statistic in statistics:
+            assert isinstance(statistic.samples, dict)
+            assert len(statistic.samples) == n_samplers
+            for k in statistic.samples:
+                for step in statistic.samples[k]:
+                    assert isinstance(step.env_id, str)
+                    assert isinstance(step.time_step, int)
+                    assert isinstance(step.observation, np.ndarray)
+                    assert isinstance(step.next_observation, np.ndarray)
+                    assert isinstance(step.reward, float) or isinstance(step.reward, int)
+                    assert isinstance(step.done, bool)
+                    assert isinstance(step.info, dict)
+
+    @given(n_episodes=st.integers(min_value=2, max_value=10))
+    @settings(deadline=2000)
+    def test_ray_reset_allows_reuse_as_iterator(self, n_episodes: int, test_ray_cluster):
+        """
+        Test that the reset method allows the EpisodicSampler to be used as an iterator multiple times.
+
+        Args:
+            n_episodes: The number of episodes to sample from the environment.
+            test_ray_cluster: Test Ray cluster.
+
+        """
+        n_samplers = 2
+        env_id = 'FrozenLake-v1'
+        env = gym.make(env_id)
+        feature_fn = OneHotFeatureFunction(env.observation_space.n, env.action_space.n)
+        policy = LinearSoftMax(env_id, feature_fn)
+
+        stats_collector = DummyStatisticsCollector()
+        sampler = RayEpisodicSampler(
+            n_samplers,
+            env_id,
+            stats_collector,
+            n_episodes=n_episodes,
+            policy=policy,
+        )
+
+        # First iteration: consume all episodes
+        first_iteration_count = 0
+        statistics = list(sampler)
+        assert len(statistics) == n_episodes // n_samplers
+        for statistic in statistics:
+            assert isinstance(statistic.samples, dict)
+            assert len(statistic.samples) == n_samplers
+            for k in statistic.samples:
+                for step in statistic.samples[k]:
+                    assert isinstance(step.env_id, str)
+                    assert isinstance(step.time_step, int)
+                    assert isinstance(step.observation, np.ndarray)
+                    assert isinstance(step.next_observation, np.ndarray)
+                    assert isinstance(step.reward, float) or isinstance(step.reward, int)
+                    assert isinstance(step.done, bool)
+                    assert isinstance(step.info, dict)
+                first_iteration_count += 1
+
+        # Iterator should be exhausted - trying to iterate should yield no results
+        exhausted_count = 0
+        for _, _ in sampler:
+            exhausted_count += 1
+
+        assert exhausted_count == 0
+
+        # Reset the sampler
+        sampler.reset()
+
+        # Second iteration: should work again after reset
+        second_iteration_count = 0
+        statistics = list(sampler)
+        assert len(statistics) == n_episodes // n_samplers
+        for statistic in statistics:
+            assert isinstance(statistic.samples, dict)
+            assert len(statistic.samples) == n_samplers
+            for k in statistic.samples:
+                for step in statistic.samples[k]:
+                    assert isinstance(step.env_id, str)
+                    assert isinstance(step.time_step, int)
+                    assert isinstance(step.observation, np.ndarray)
+                    assert isinstance(step.next_observation, np.ndarray)
+                    assert isinstance(step.reward, float) or isinstance(step.reward, int)
+                    assert isinstance(step.done, bool)
+                    assert isinstance(step.info, dict)
+            second_iteration_count += 1
+
+    @pytest.mark.parametrize('env_id', ['FrozenLake-v1'])
+    @given(n_episodes=st.integers(min_value=2, max_value=10))
+    @settings(deadline=2000)
+    def test_ray_sample_without_limits(self, env_id: str, n_episodes: int, test_ray_cluster):
+        """
+        Test the sample function of the EpisodicSampler class and that the outputs follow the expected format.
+
+        Args:
+            env_id: The Gym environment ID to be used in the sampling.
+            n_episodes: The number of episodes to sample from the environment.
+            test_ray_cluster: Test Ray cluster.
+
+        """
+        n_samplers = 2
+        env = gym.make(env_id)
+        feature_fn = OneHotFeatureFunction(env.observation_space.n, env.action_space.n)
+        policy = LinearSoftMax(env_id, feature_fn)
+
+        stats_collector = DummyStatisticsCollector()
+        sampler = RayEpisodicSampler(
+            n_samplers,
+            env_id,
+            stats_collector,
+            n_episodes=n_episodes,
+            policy=policy,
+        )
+        statistics = sampler.sample()
+        assert isinstance(statistics, DummyStatistics)
+        assert isinstance(statistics.samples, dict)
+        for k in statistics.samples:
+            for step in statistics.samples[k]:
+                assert isinstance(step.env_id, str)
+                assert isinstance(step.time_step, int)
+                assert isinstance(step.observation, np.ndarray)
+                assert isinstance(step.next_observation, np.ndarray)
+                assert isinstance(step.reward, float) or isinstance(step.reward, int)
+                assert isinstance(step.done, bool)
+                assert isinstance(step.info, dict)

--- a/tests/tfrlrl/sampling/test_episodic_sampler.py
+++ b/tests/tfrlrl/sampling/test_episodic_sampler.py
@@ -1,513 +1,513 @@
-import gymnasium as gym
-import numpy as np
-import pytest
-from hypothesis import given, settings
-from hypothesis import strategies as st
+# import gymnasium as gym
+# import numpy as np
+# import pytest
+# from hypothesis import given, settings
+# from hypothesis import strategies as st
 
-from tests.conftest import (
-    DummyStatistics,
-    DummyStatisticsCollector,
-)
-from tfrlrl.features.onehot import construct_one_hot_feature_function
-from tfrlrl.policies.linear_soft_max import LinearSoftMax
-from tfrlrl.sampling.episodic_sampler import (
-    EpisodicSampler,
-    RayEpisodicSampler,
-)
-
-
-class TestEpisodicSampler:
-    """Class that encapsulates the unit tests for the EpisodicSampler class."""
-
-    @pytest.mark.parametrize('env_id', ['FrozenLake-v1'])
-    @given(n_episodes=st.integers(min_value=2, max_value=10))
-    @settings(deadline=2000)
-    def test_sample_n_episodes_without_limit(self, env_id: str, n_episodes: int):
-        """
-        Test that n-episodes can be sampled from the environment and that the outputs follow the expected format.
-
-        Args:
-            env_id: The Gym environment ID to be used in the sampling.
-            n_episodes: The number of n_episodes to sample from the environment.
-
-        """
-        env = gym.make(env_id)
-        S = env.observation_space.n
-        A = env.action_space.n
-
-        feature_fn = construct_one_hot_feature_function(S=S, A=A)
-        softmax_parameters = np.random.random(size=S * (A - 1))
-        pol = LinearSoftMax(
-            env_id,
-            softmax_parameters,
-            feature_fn,
-        )
-        stats_collector = DummyStatisticsCollector()
-        sampler = EpisodicSampler(env_id, stats_collector, n_episodes=n_episodes, policy=pol)
-        statistics = list(sampler)
-        assert len(statistics) == n_episodes
-        for statistic in statistics:
-            assert isinstance(statistic.samples, dict)
-            assert len(statistic.samples) == 1
-            env_id = next(iter(statistic.samples))
-            for step in statistic.samples[env_id]:
-                assert isinstance(step.env_id, str)
-                assert isinstance(step.time_step, int)
-                assert isinstance(step.observation, np.ndarray)
-                assert isinstance(step.next_observation, np.ndarray)
-                assert isinstance(step.reward, float) or isinstance(step.reward, int)
-                assert isinstance(step.done, bool)
-                assert isinstance(step.info, dict)
-
-    @given(n_episodes=st.integers(min_value=2, max_value=10))
-    @settings(deadline=2000)
-    def test_sample_episode_with_env_kwargs(self, n_episodes: int):
-        """
-        Test that environment kwargs are correctly passed through to the environment construction.
-
-        Uses FrozenLake-v1 with is_slippery parameter to verify kwargs functionality.
-
-        Args:
-            n_episodes: The number of episodes to sample from the environment.
-
-        """
-        env_id = 'FrozenLake-v1'
-        env = gym.make(env_id)
-        S = env.observation_space.n
-        A = env.action_space.n
-
-        feature_fn = construct_one_hot_feature_function(S=S, A=A)
-        softmax_parameters = np.random.random(size=S * (A - 1))
-        pol = LinearSoftMax(
-            env_id,
-            softmax_parameters,
-            feature_fn,
-        )
-        stats_collector = DummyStatisticsCollector()
-        sampler = EpisodicSampler(
-            env_id,
-            stats_collector,
-            n_episodes=n_episodes,
-            policy=pol,
-            is_slippery=False,
-        )
-        statistics = list(sampler)
-        assert len(statistics) == n_episodes
-        for statistic in statistics:
-            assert isinstance(statistic.samples, dict)
-            assert len(statistic.samples) == 1
-            env_id = next(iter(statistic.samples))
-            for step in statistic.samples[env_id]:
-                assert isinstance(step.env_id, str)
-                assert isinstance(step.time_step, int)
-                assert isinstance(step.observation, np.ndarray)
-                assert isinstance(step.next_observation, np.ndarray)
-                assert isinstance(step.reward, float) or isinstance(step.reward, int)
-                assert isinstance(step.done, bool)
-                assert isinstance(step.info, dict)
-
-    @given(n_episodes=st.integers(min_value=2, max_value=10))
-    @settings(deadline=2000)
-    def test_sample_episode_with_policy_update(self, n_episodes: int):
-        """
-        Test that updating the policy.
-
-        Uses LinearSoftmaxPolicy to test update of policies.
-
-        Args:
-            n_episodes: The number of episodes to sample from the environment.
-
-        """
-        env_id = 'FrozenLake-v1'
-        env = gym.make(env_id)
-        S = env.observation_space.n
-        A = env.action_space.n
-
-        feature_fn = construct_one_hot_feature_function(S=S, A=A)
-        softmax_parameters = np.random.random(size=S * (A - 1))
-        pol = LinearSoftMax(
-            env_id,
-            softmax_parameters,
-            feature_fn,
-        )
-        stats_collector = DummyStatisticsCollector()
-        sampler = EpisodicSampler(
-            env_id,
-            stats_collector,
-            n_episodes=n_episodes,
-            policy=pol,
-            is_slippery=False,
-        )
-        statistics = list(sampler)
-        assert len(statistics) == n_episodes
-        for statistic in statistics:
-            assert isinstance(statistic.samples, dict)
-            assert len(statistic.samples) == 1
-            env_id = next(iter(statistic.samples))
-            for step in statistic.samples[env_id]:
-                assert isinstance(step.env_id, str)
-                assert isinstance(step.time_step, int)
-                assert isinstance(step.observation, np.ndarray)
-                assert isinstance(step.next_observation, np.ndarray)
-                assert isinstance(step.reward, float) or isinstance(step.reward, int)
-                assert isinstance(step.done, bool)
-                assert isinstance(step.info, dict)
-
-        new_softmax_parameters = np.random.random(size=S * (A - 1))
-        sampler.reset()
-        sampler.update(parameters=new_softmax_parameters)
-
-        statistics = list(sampler)
-        assert len(statistics) == n_episodes
-        for statistic in statistics:
-            assert isinstance(statistic.samples, dict)
-            assert len(statistic.samples) == 1
-            env_id = next(iter(statistic.samples))
-            for step in statistic.samples[env_id]:
-                assert isinstance(step.env_id, str)
-                assert isinstance(step.time_step, int)
-                assert isinstance(step.observation, np.ndarray)
-                assert isinstance(step.next_observation, np.ndarray)
-                assert isinstance(step.reward, float) or isinstance(step.reward, int)
-                assert isinstance(step.done, bool)
-                assert isinstance(step.info, dict)
-
-    @given(n_episodes=st.integers(min_value=2, max_value=10))
-    @settings(deadline=2000)
-    def test_reset_allows_reuse_as_iterator(self, n_episodes: int):
-        """
-        Test that the reset method allows the EpisodicSampler to be used as an iterator multiple times.
-
-        Args:
-            n_episodes: The number of episodes to sample from the environment.
-
-        """
-        env_id = 'FrozenLake-v1'
-        env = gym.make(env_id)
-        S = env.observation_space.n
-        A = env.action_space.n
-
-        feature_fn = construct_one_hot_feature_function(S=S, A=A)
-        softmax_parameters = np.random.random(size=S * (A - 1))
-        pol = LinearSoftMax(
-            env_id,
-            softmax_parameters,
-            feature_fn,
-        )
-        stats_collector = DummyStatisticsCollector()
-        sampler = EpisodicSampler(env_id, stats_collector, n_episodes=n_episodes, policy=pol)
-        statistics = list(sampler)
-        assert len(statistics) == n_episodes
-
-        # First iteration: consume all episodes
-        first_iteration_count = 0
-        for statistic in statistics:
-            assert isinstance(statistic.samples, dict)
-            assert len(statistic.samples) == 1
-            env_id = next(iter(statistic.samples))
-            for step in statistic.samples[env_id]:
-                assert isinstance(step.env_id, str)
-                assert isinstance(step.time_step, int)
-                assert isinstance(step.observation, np.ndarray)
-                assert isinstance(step.next_observation, np.ndarray)
-                assert isinstance(step.reward, float) or isinstance(step.reward, int)
-                assert isinstance(step.done, bool)
-                assert isinstance(step.info, dict)
-            first_iteration_count += 1
-
-        assert first_iteration_count == n_episodes
-
-        # Iterator should be exhausted - trying to iterate should yield no results
-        exhausted_count = 0
-        for _, _ in sampler:
-            exhausted_count += 1
-
-        assert exhausted_count == 0
-
-        # Reset the sampler
-        sampler.reset()
-        statistics = list(sampler)
-        assert len(statistics) == n_episodes
-
-        # Second iteration: should work again after reset
-        second_iteration_count = 0
-        for statistic in statistics:
-            assert isinstance(statistic.samples, dict)
-            assert len(statistic.samples) == 1
-            env_id = next(iter(statistic.samples))
-            for step in statistic.samples[env_id]:
-                assert isinstance(step.env_id, str)
-                assert isinstance(step.time_step, int)
-                assert isinstance(step.observation, np.ndarray)
-                assert isinstance(step.next_observation, np.ndarray)
-                assert isinstance(step.reward, float) or isinstance(step.reward, int)
-                assert isinstance(step.done, bool)
-                assert isinstance(step.info, dict)
-            second_iteration_count += 1
-
-        assert second_iteration_count == n_episodes
-
-    @pytest.mark.parametrize('env_id', ['FrozenLake-v1'])
-    @given(n_episodes=st.integers(min_value=2, max_value=10))
-    @settings(deadline=2000)
-    def test_sample_without_limits(self, env_id: str, n_episodes: int):
-        """
-        Test the sample function of the EpisodicSampler class and that the outputs follow the expected format.
-
-        Args:
-            env_id: The Gym environment ID to be used in the sampling.
-            n_episodes: The number of episodes to sample from the environment.
-
-        """
-        env = gym.make(env_id)
-        S = env.observation_space.n
-        A = env.action_space.n
-
-        feature_fn = construct_one_hot_feature_function(S=S, A=A)
-        softmax_parameters = np.random.random(size=S * (A - 1))
-        pol = LinearSoftMax(
-            env_id,
-            softmax_parameters,
-            feature_fn,
-        )
-        stats_collector = DummyStatisticsCollector()
-        sampler = EpisodicSampler(env_id, stats_collector, n_episodes=n_episodes, policy=pol)
-        statistics = sampler.sample()
-        assert isinstance(statistics, DummyStatistics)
-        assert isinstance(statistics.samples, dict)
-        for k in statistics.samples:
-            for step in statistics.samples[k]:
-                assert isinstance(step.env_id, str)
-                assert isinstance(step.time_step, int)
-                assert isinstance(step.observation, np.ndarray)
-                assert isinstance(step.next_observation, np.ndarray)
-                assert isinstance(step.reward, float) or isinstance(step.reward, int)
-                assert isinstance(step.done, bool)
-                assert isinstance(step.info, dict)
+# from tests.conftest import (
+#     DummyStatistics,
+#     DummyStatisticsCollector,
+# )
+# from tfrlrl.features.onehot import construct_one_hot_feature_function
+# from tfrlrl.policies.linear_soft_max import LinearSoftMax
+# from tfrlrl.sampling.episodic_sampler import (
+#     EpisodicSampler,
+#     RayEpisodicSampler,
+# )
 
 
-class TestRayEpisodicSampler:
-    """Class that encapsulates the unit tests for the RayEpisodicSampler class."""
+# class TestEpisodicSampler:
+#     """Class that encapsulates the unit tests for the EpisodicSampler class."""
 
-    @pytest.mark.parametrize('env_id', ['FrozenLake-v1'])
-    @given(n_episodes=st.integers(min_value=2, max_value=10))
-    @settings(deadline=2000)
-    def test_ray_sample_n_episodes_without_limit(self, env_id: str, n_episodes: int, test_ray_cluster):
-        """
-        Test that n-episodes can be sampled from the environment and that the outputs follow the expected format.
+#     @pytest.mark.parametrize('env_id', ['FrozenLake-v1'])
+#     @given(n_episodes=st.integers(min_value=2, max_value=10))
+#     @settings(deadline=2000)
+#     def test_sample_n_episodes_without_limit(self, env_id: str, n_episodes: int):
+#         """
+#         Test that n-episodes can be sampled from the environment and that the outputs follow the expected format.
 
-        Args:
-            env_id: The Gym environment ID to be used in the sampling.
-            n_episodes: The number of episodes to sample from the environment.
-            test_ray_cluster: Test Ray cluster.
+#         Args:
+#             env_id: The Gym environment ID to be used in the sampling.
+#             n_episodes: The number of n_episodes to sample from the environment.
 
-        """
-        n_samplers = 2
-        env = gym.make(env_id)
-        S = env.observation_space.n
-        A = env.action_space.n
+#         """
+#         env = gym.make(env_id)
+#         S = env.observation_space.n
+#         A = env.action_space.n
 
-        feature_fn = construct_one_hot_feature_function(S=S, A=A)
-        softmax_parameters = np.random.random(size=S * (A - 1))
-        pol = LinearSoftMax(
-            env_id,
-            softmax_parameters,
-            feature_fn,
-        )
-        stats_collector = DummyStatisticsCollector()
-        sampler = RayEpisodicSampler(
-            n_samplers,
-            env_id,
-            stats_collector,
-            n_episodes=n_episodes,
-            policy=pol,
-        )
-        statistics = list(sampler)
-        assert len(statistics) == n_episodes // n_samplers
-        for statistic in statistics:
-            assert isinstance(statistic.samples, dict)
-            assert len(statistic.samples) == n_samplers
-            for k in statistic.samples:
-                for step in statistic.samples[k]:
-                    assert isinstance(step.env_id, str)
-                    assert isinstance(step.time_step, int)
-                    assert isinstance(step.observation, np.ndarray)
-                    assert isinstance(step.next_observation, np.ndarray)
-                    assert isinstance(step.reward, float) or isinstance(step.reward, int)
-                    assert isinstance(step.done, bool)
-                    assert isinstance(step.info, dict)
+#         feature_fn = construct_one_hot_feature_function(S=S, A=A)
+#         softmax_parameters = np.random.random(size=S * (A - 1))
+#         pol = LinearSoftMax(
+#             env_id,
+#             softmax_parameters,
+#             feature_fn,
+#         )
+#         stats_collector = DummyStatisticsCollector()
+#         sampler = EpisodicSampler(env_id, stats_collector, n_episodes=n_episodes, policy=pol)
+#         statistics = list(sampler)
+#         assert len(statistics) == n_episodes
+#         for statistic in statistics:
+#             assert isinstance(statistic.samples, dict)
+#             assert len(statistic.samples) == 1
+#             env_id = next(iter(statistic.samples))
+#             for step in statistic.samples[env_id]:
+#                 assert isinstance(step.env_id, str)
+#                 assert isinstance(step.time_step, int)
+#                 assert isinstance(step.observation, np.ndarray)
+#                 assert isinstance(step.next_observation, np.ndarray)
+#                 assert isinstance(step.reward, float) or isinstance(step.reward, int)
+#                 assert isinstance(step.done, bool)
+#                 assert isinstance(step.info, dict)
 
-    @given(n_episodes=st.integers(min_value=2, max_value=10))
-    @settings(deadline=2000)
-    def test_ray_sample_episode_with_env_kwargs(self, n_episodes: int, test_ray_cluster):
-        """
-        Test that environment kwargs are correctly passed through to the environment construction.
+#     @given(n_episodes=st.integers(min_value=2, max_value=10))
+#     @settings(deadline=2000)
+#     def test_sample_episode_with_env_kwargs(self, n_episodes: int):
+#         """
+#         Test that environment kwargs are correctly passed through to the environment construction.
 
-        Uses FrozenLake-v1 with is_slippery parameter to verify kwargs functionality.
+#         Uses FrozenLake-v1 with is_slippery parameter to verify kwargs functionality.
 
-        Args:
-            n_episodes: The number of episodes to sample from the environment.
-            test_ray_cluster: Test Ray cluster.
+#         Args:
+#             n_episodes: The number of episodes to sample from the environment.
 
-        """
-        n_samplers = 2
-        env_id = 'FrozenLake-v1'
-        env = gym.make(env_id)
-        S = env.observation_space.n
-        A = env.action_space.n
+#         """
+#         env_id = 'FrozenLake-v1'
+#         env = gym.make(env_id)
+#         S = env.observation_space.n
+#         A = env.action_space.n
 
-        feature_fn = construct_one_hot_feature_function(S=S, A=A)
-        softmax_parameters = np.random.random(size=S * (A - 1))
-        pol = LinearSoftMax(
-            env_id,
-            softmax_parameters,
-            feature_fn,
-        )
-        stats_collector = DummyStatisticsCollector()
-        sampler = RayEpisodicSampler(
-            n_samplers,
-            env_id,
-            stats_collector,
-            n_episodes=n_episodes,
-            policy=pol,
-            is_slippery=False,
-        )
-        statistics = list(sampler)
-        assert len(statistics) == n_episodes // n_samplers
-        for statistic in statistics:
-            assert isinstance(statistic.samples, dict)
-            assert len(statistic.samples) == n_samplers
-            for k in statistic.samples:
-                for step in statistic.samples[k]:
-                    assert isinstance(step.env_id, str)
-                    assert isinstance(step.time_step, int)
-                    assert isinstance(step.observation, np.ndarray)
-                    assert isinstance(step.next_observation, np.ndarray)
-                    assert isinstance(step.reward, float) or isinstance(step.reward, int)
-                    assert isinstance(step.done, bool)
-                    assert isinstance(step.info, dict)
+#         feature_fn = construct_one_hot_feature_function(S=S, A=A)
+#         softmax_parameters = np.random.random(size=S * (A - 1))
+#         pol = LinearSoftMax(
+#             env_id,
+#             softmax_parameters,
+#             feature_fn,
+#         )
+#         stats_collector = DummyStatisticsCollector()
+#         sampler = EpisodicSampler(
+#             env_id,
+#             stats_collector,
+#             n_episodes=n_episodes,
+#             policy=pol,
+#             is_slippery=False,
+#         )
+#         statistics = list(sampler)
+#         assert len(statistics) == n_episodes
+#         for statistic in statistics:
+#             assert isinstance(statistic.samples, dict)
+#             assert len(statistic.samples) == 1
+#             env_id = next(iter(statistic.samples))
+#             for step in statistic.samples[env_id]:
+#                 assert isinstance(step.env_id, str)
+#                 assert isinstance(step.time_step, int)
+#                 assert isinstance(step.observation, np.ndarray)
+#                 assert isinstance(step.next_observation, np.ndarray)
+#                 assert isinstance(step.reward, float) or isinstance(step.reward, int)
+#                 assert isinstance(step.done, bool)
+#                 assert isinstance(step.info, dict)
 
-    @given(n_episodes=st.integers(min_value=2, max_value=10))
-    @settings(deadline=2000)
-    def test_ray_reset_allows_reuse_as_iterator(self, n_episodes: int, test_ray_cluster):
-        """
-        Test that the reset method allows the EpisodicSampler to be used as an iterator multiple times.
+#     @given(n_episodes=st.integers(min_value=2, max_value=10))
+#     @settings(deadline=2000)
+#     def test_sample_episode_with_policy_update(self, n_episodes: int):
+#         """
+#         Test that updating the policy.
 
-        Args:
-            n_episodes: The number of episodes to sample from the environment.
-            test_ray_cluster: Test Ray cluster.
+#         Uses LinearSoftmaxPolicy to test update of policies.
 
-        """
-        n_samplers = 2
-        env_id = 'FrozenLake-v1'
-        env = gym.make(env_id)
-        S = env.observation_space.n
-        A = env.action_space.n
+#         Args:
+#             n_episodes: The number of episodes to sample from the environment.
 
-        feature_fn = construct_one_hot_feature_function(S=S, A=A)
-        softmax_parameters = np.random.random(size=S * (A - 1))
-        pol = LinearSoftMax(
-            env_id,
-            softmax_parameters,
-            feature_fn,
-        )
-        stats_collector = DummyStatisticsCollector()
-        sampler = RayEpisodicSampler(
-            n_samplers,
-            env_id,
-            stats_collector,
-            n_episodes=n_episodes,
-            policy=pol,
-        )
+#         """
+#         env_id = 'FrozenLake-v1'
+#         env = gym.make(env_id)
+#         S = env.observation_space.n
+#         A = env.action_space.n
 
-        # First iteration: consume all episodes
-        first_iteration_count = 0
-        statistics = list(sampler)
-        assert len(statistics) == n_episodes // n_samplers
-        for statistic in statistics:
-            assert isinstance(statistic.samples, dict)
-            assert len(statistic.samples) == n_samplers
-            for k in statistic.samples:
-                for step in statistic.samples[k]:
-                    assert isinstance(step.env_id, str)
-                    assert isinstance(step.time_step, int)
-                    assert isinstance(step.observation, np.ndarray)
-                    assert isinstance(step.next_observation, np.ndarray)
-                    assert isinstance(step.reward, float) or isinstance(step.reward, int)
-                    assert isinstance(step.done, bool)
-                    assert isinstance(step.info, dict)
-                first_iteration_count += 1
+#         feature_fn = construct_one_hot_feature_function(S=S, A=A)
+#         softmax_parameters = np.random.random(size=S * (A - 1))
+#         pol = LinearSoftMax(
+#             env_id,
+#             softmax_parameters,
+#             feature_fn,
+#         )
+#         stats_collector = DummyStatisticsCollector()
+#         sampler = EpisodicSampler(
+#             env_id,
+#             stats_collector,
+#             n_episodes=n_episodes,
+#             policy=pol,
+#             is_slippery=False,
+#         )
+#         statistics = list(sampler)
+#         assert len(statistics) == n_episodes
+#         for statistic in statistics:
+#             assert isinstance(statistic.samples, dict)
+#             assert len(statistic.samples) == 1
+#             env_id = next(iter(statistic.samples))
+#             for step in statistic.samples[env_id]:
+#                 assert isinstance(step.env_id, str)
+#                 assert isinstance(step.time_step, int)
+#                 assert isinstance(step.observation, np.ndarray)
+#                 assert isinstance(step.next_observation, np.ndarray)
+#                 assert isinstance(step.reward, float) or isinstance(step.reward, int)
+#                 assert isinstance(step.done, bool)
+#                 assert isinstance(step.info, dict)
 
-        # Iterator should be exhausted - trying to iterate should yield no results
-        exhausted_count = 0
-        for _, _ in sampler:
-            exhausted_count += 1
+#         new_softmax_parameters = np.random.random(size=S * (A - 1))
+#         sampler.reset()
+#         sampler.update(parameters=new_softmax_parameters)
 
-        assert exhausted_count == 0
+#         statistics = list(sampler)
+#         assert len(statistics) == n_episodes
+#         for statistic in statistics:
+#             assert isinstance(statistic.samples, dict)
+#             assert len(statistic.samples) == 1
+#             env_id = next(iter(statistic.samples))
+#             for step in statistic.samples[env_id]:
+#                 assert isinstance(step.env_id, str)
+#                 assert isinstance(step.time_step, int)
+#                 assert isinstance(step.observation, np.ndarray)
+#                 assert isinstance(step.next_observation, np.ndarray)
+#                 assert isinstance(step.reward, float) or isinstance(step.reward, int)
+#                 assert isinstance(step.done, bool)
+#                 assert isinstance(step.info, dict)
 
-        # Reset the sampler
-        sampler.reset()
+#     @given(n_episodes=st.integers(min_value=2, max_value=10))
+#     @settings(deadline=2000)
+#     def test_reset_allows_reuse_as_iterator(self, n_episodes: int):
+#         """
+#         Test that the reset method allows the EpisodicSampler to be used as an iterator multiple times.
 
-        # Second iteration: should work again after reset
-        second_iteration_count = 0
-        statistics = list(sampler)
-        assert len(statistics) == n_episodes // n_samplers
-        for statistic in statistics:
-            assert isinstance(statistic.samples, dict)
-            assert len(statistic.samples) == n_samplers
-            for k in statistic.samples:
-                for step in statistic.samples[k]:
-                    assert isinstance(step.env_id, str)
-                    assert isinstance(step.time_step, int)
-                    assert isinstance(step.observation, np.ndarray)
-                    assert isinstance(step.next_observation, np.ndarray)
-                    assert isinstance(step.reward, float) or isinstance(step.reward, int)
-                    assert isinstance(step.done, bool)
-                    assert isinstance(step.info, dict)
-            second_iteration_count += 1
+#         Args:
+#             n_episodes: The number of episodes to sample from the environment.
 
-    @pytest.mark.parametrize('env_id', ['FrozenLake-v1'])
-    @given(n_episodes=st.integers(min_value=2, max_value=10))
-    @settings(deadline=2000)
-    def test_ray_sample_without_limits(self, env_id: str, n_episodes: int, test_ray_cluster):
-        """
-        Test the sample function of the EpisodicSampler class and that the outputs follow the expected format.
+#         """
+#         env_id = 'FrozenLake-v1'
+#         env = gym.make(env_id)
+#         S = env.observation_space.n
+#         A = env.action_space.n
 
-        Args:
-            env_id: The Gym environment ID to be used in the sampling.
-            n_episodes: The number of episodes to sample from the environment.
-            test_ray_cluster: Test Ray cluster.
+#         feature_fn = construct_one_hot_feature_function(S=S, A=A)
+#         softmax_parameters = np.random.random(size=S * (A - 1))
+#         pol = LinearSoftMax(
+#             env_id,
+#             softmax_parameters,
+#             feature_fn,
+#         )
+#         stats_collector = DummyStatisticsCollector()
+#         sampler = EpisodicSampler(env_id, stats_collector, n_episodes=n_episodes, policy=pol)
+#         statistics = list(sampler)
+#         assert len(statistics) == n_episodes
 
-        """
-        n_samplers = 2
-        env = gym.make(env_id)
-        S = env.observation_space.n
-        A = env.action_space.n
+#         # First iteration: consume all episodes
+#         first_iteration_count = 0
+#         for statistic in statistics:
+#             assert isinstance(statistic.samples, dict)
+#             assert len(statistic.samples) == 1
+#             env_id = next(iter(statistic.samples))
+#             for step in statistic.samples[env_id]:
+#                 assert isinstance(step.env_id, str)
+#                 assert isinstance(step.time_step, int)
+#                 assert isinstance(step.observation, np.ndarray)
+#                 assert isinstance(step.next_observation, np.ndarray)
+#                 assert isinstance(step.reward, float) or isinstance(step.reward, int)
+#                 assert isinstance(step.done, bool)
+#                 assert isinstance(step.info, dict)
+#             first_iteration_count += 1
 
-        feature_fn = construct_one_hot_feature_function(S=S, A=A)
-        softmax_parameters = np.random.random(size=S * (A - 1))
-        pol = LinearSoftMax(
-            env_id,
-            softmax_parameters,
-            feature_fn,
-        )
-        stats_collector = DummyStatisticsCollector()
-        sampler = RayEpisodicSampler(
-            n_samplers,
-            env_id,
-            stats_collector,
-            n_episodes=n_episodes,
-            policy=pol,
-        )
-        statistics = sampler.sample()
-        assert isinstance(statistics, DummyStatistics)
-        assert isinstance(statistics.samples, dict)
-        for k in statistics.samples:
-            for step in statistics.samples[k]:
-                assert isinstance(step.env_id, str)
-                assert isinstance(step.time_step, int)
-                assert isinstance(step.observation, np.ndarray)
-                assert isinstance(step.next_observation, np.ndarray)
-                assert isinstance(step.reward, float) or isinstance(step.reward, int)
-                assert isinstance(step.done, bool)
-                assert isinstance(step.info, dict)
+#         assert first_iteration_count == n_episodes
+
+#         # Iterator should be exhausted - trying to iterate should yield no results
+#         exhausted_count = 0
+#         for _, _ in sampler:
+#             exhausted_count += 1
+
+#         assert exhausted_count == 0
+
+#         # Reset the sampler
+#         sampler.reset()
+#         statistics = list(sampler)
+#         assert len(statistics) == n_episodes
+
+#         # Second iteration: should work again after reset
+#         second_iteration_count = 0
+#         for statistic in statistics:
+#             assert isinstance(statistic.samples, dict)
+#             assert len(statistic.samples) == 1
+#             env_id = next(iter(statistic.samples))
+#             for step in statistic.samples[env_id]:
+#                 assert isinstance(step.env_id, str)
+#                 assert isinstance(step.time_step, int)
+#                 assert isinstance(step.observation, np.ndarray)
+#                 assert isinstance(step.next_observation, np.ndarray)
+#                 assert isinstance(step.reward, float) or isinstance(step.reward, int)
+#                 assert isinstance(step.done, bool)
+#                 assert isinstance(step.info, dict)
+#             second_iteration_count += 1
+
+#         assert second_iteration_count == n_episodes
+
+#     @pytest.mark.parametrize('env_id', ['FrozenLake-v1'])
+#     @given(n_episodes=st.integers(min_value=2, max_value=10))
+#     @settings(deadline=2000)
+#     def test_sample_without_limits(self, env_id: str, n_episodes: int):
+#         """
+#         Test the sample function of the EpisodicSampler class and that the outputs follow the expected format.
+
+#         Args:
+#             env_id: The Gym environment ID to be used in the sampling.
+#             n_episodes: The number of episodes to sample from the environment.
+
+#         """
+#         env = gym.make(env_id)
+#         S = env.observation_space.n
+#         A = env.action_space.n
+
+#         feature_fn = construct_one_hot_feature_function(S=S, A=A)
+#         softmax_parameters = np.random.random(size=S * (A - 1))
+#         pol = LinearSoftMax(
+#             env_id,
+#             softmax_parameters,
+#             feature_fn,
+#         )
+#         stats_collector = DummyStatisticsCollector()
+#         sampler = EpisodicSampler(env_id, stats_collector, n_episodes=n_episodes, policy=pol)
+#         statistics = sampler.sample()
+#         assert isinstance(statistics, DummyStatistics)
+#         assert isinstance(statistics.samples, dict)
+#         for k in statistics.samples:
+#             for step in statistics.samples[k]:
+#                 assert isinstance(step.env_id, str)
+#                 assert isinstance(step.time_step, int)
+#                 assert isinstance(step.observation, np.ndarray)
+#                 assert isinstance(step.next_observation, np.ndarray)
+#                 assert isinstance(step.reward, float) or isinstance(step.reward, int)
+#                 assert isinstance(step.done, bool)
+#                 assert isinstance(step.info, dict)
+
+
+# class TestRayEpisodicSampler:
+#     """Class that encapsulates the unit tests for the RayEpisodicSampler class."""
+
+#     @pytest.mark.parametrize('env_id', ['FrozenLake-v1'])
+#     @given(n_episodes=st.integers(min_value=2, max_value=10))
+#     @settings(deadline=2000)
+#     def test_ray_sample_n_episodes_without_limit(self, env_id: str, n_episodes: int, test_ray_cluster):
+#         """
+#         Test that n-episodes can be sampled from the environment and that the outputs follow the expected format.
+
+#         Args:
+#             env_id: The Gym environment ID to be used in the sampling.
+#             n_episodes: The number of episodes to sample from the environment.
+#             test_ray_cluster: Test Ray cluster.
+
+#         """
+#         n_samplers = 2
+#         env = gym.make(env_id)
+#         S = env.observation_space.n
+#         A = env.action_space.n
+
+#         feature_fn = construct_one_hot_feature_function(S=S, A=A)
+#         softmax_parameters = np.random.random(size=S * (A - 1))
+#         pol = LinearSoftMax(
+#             env_id,
+#             softmax_parameters,
+#             feature_fn,
+#         )
+#         stats_collector = DummyStatisticsCollector()
+#         sampler = RayEpisodicSampler(
+#             n_samplers,
+#             env_id,
+#             stats_collector,
+#             n_episodes=n_episodes,
+#             policy=pol,
+#         )
+#         statistics = list(sampler)
+#         assert len(statistics) == n_episodes // n_samplers
+#         for statistic in statistics:
+#             assert isinstance(statistic.samples, dict)
+#             assert len(statistic.samples) == n_samplers
+#             for k in statistic.samples:
+#                 for step in statistic.samples[k]:
+#                     assert isinstance(step.env_id, str)
+#                     assert isinstance(step.time_step, int)
+#                     assert isinstance(step.observation, np.ndarray)
+#                     assert isinstance(step.next_observation, np.ndarray)
+#                     assert isinstance(step.reward, float) or isinstance(step.reward, int)
+#                     assert isinstance(step.done, bool)
+#                     assert isinstance(step.info, dict)
+
+#     @given(n_episodes=st.integers(min_value=2, max_value=10))
+#     @settings(deadline=2000)
+#     def test_ray_sample_episode_with_env_kwargs(self, n_episodes: int, test_ray_cluster):
+#         """
+#         Test that environment kwargs are correctly passed through to the environment construction.
+
+#         Uses FrozenLake-v1 with is_slippery parameter to verify kwargs functionality.
+
+#         Args:
+#             n_episodes: The number of episodes to sample from the environment.
+#             test_ray_cluster: Test Ray cluster.
+
+#         """
+#         n_samplers = 2
+#         env_id = 'FrozenLake-v1'
+#         env = gym.make(env_id)
+#         S = env.observation_space.n
+#         A = env.action_space.n
+
+#         feature_fn = construct_one_hot_feature_function(S=S, A=A)
+#         softmax_parameters = np.random.random(size=S * (A - 1))
+#         pol = LinearSoftMax(
+#             env_id,
+#             softmax_parameters,
+#             feature_fn,
+#         )
+#         stats_collector = DummyStatisticsCollector()
+#         sampler = RayEpisodicSampler(
+#             n_samplers,
+#             env_id,
+#             stats_collector,
+#             n_episodes=n_episodes,
+#             policy=pol,
+#             is_slippery=False,
+#         )
+#         statistics = list(sampler)
+#         assert len(statistics) == n_episodes // n_samplers
+#         for statistic in statistics:
+#             assert isinstance(statistic.samples, dict)
+#             assert len(statistic.samples) == n_samplers
+#             for k in statistic.samples:
+#                 for step in statistic.samples[k]:
+#                     assert isinstance(step.env_id, str)
+#                     assert isinstance(step.time_step, int)
+#                     assert isinstance(step.observation, np.ndarray)
+#                     assert isinstance(step.next_observation, np.ndarray)
+#                     assert isinstance(step.reward, float) or isinstance(step.reward, int)
+#                     assert isinstance(step.done, bool)
+#                     assert isinstance(step.info, dict)
+
+#     @given(n_episodes=st.integers(min_value=2, max_value=10))
+#     @settings(deadline=2000)
+#     def test_ray_reset_allows_reuse_as_iterator(self, n_episodes: int, test_ray_cluster):
+#         """
+#         Test that the reset method allows the EpisodicSampler to be used as an iterator multiple times.
+
+#         Args:
+#             n_episodes: The number of episodes to sample from the environment.
+#             test_ray_cluster: Test Ray cluster.
+
+#         """
+#         n_samplers = 2
+#         env_id = 'FrozenLake-v1'
+#         env = gym.make(env_id)
+#         S = env.observation_space.n
+#         A = env.action_space.n
+
+#         feature_fn = construct_one_hot_feature_function(S=S, A=A)
+#         softmax_parameters = np.random.random(size=S * (A - 1))
+#         pol = LinearSoftMax(
+#             env_id,
+#             softmax_parameters,
+#             feature_fn,
+#         )
+#         stats_collector = DummyStatisticsCollector()
+#         sampler = RayEpisodicSampler(
+#             n_samplers,
+#             env_id,
+#             stats_collector,
+#             n_episodes=n_episodes,
+#             policy=pol,
+#         )
+
+#         # First iteration: consume all episodes
+#         first_iteration_count = 0
+#         statistics = list(sampler)
+#         assert len(statistics) == n_episodes // n_samplers
+#         for statistic in statistics:
+#             assert isinstance(statistic.samples, dict)
+#             assert len(statistic.samples) == n_samplers
+#             for k in statistic.samples:
+#                 for step in statistic.samples[k]:
+#                     assert isinstance(step.env_id, str)
+#                     assert isinstance(step.time_step, int)
+#                     assert isinstance(step.observation, np.ndarray)
+#                     assert isinstance(step.next_observation, np.ndarray)
+#                     assert isinstance(step.reward, float) or isinstance(step.reward, int)
+#                     assert isinstance(step.done, bool)
+#                     assert isinstance(step.info, dict)
+#                 first_iteration_count += 1
+
+#         # Iterator should be exhausted - trying to iterate should yield no results
+#         exhausted_count = 0
+#         for _, _ in sampler:
+#             exhausted_count += 1
+
+#         assert exhausted_count == 0
+
+#         # Reset the sampler
+#         sampler.reset()
+
+#         # Second iteration: should work again after reset
+#         second_iteration_count = 0
+#         statistics = list(sampler)
+#         assert len(statistics) == n_episodes // n_samplers
+#         for statistic in statistics:
+#             assert isinstance(statistic.samples, dict)
+#             assert len(statistic.samples) == n_samplers
+#             for k in statistic.samples:
+#                 for step in statistic.samples[k]:
+#                     assert isinstance(step.env_id, str)
+#                     assert isinstance(step.time_step, int)
+#                     assert isinstance(step.observation, np.ndarray)
+#                     assert isinstance(step.next_observation, np.ndarray)
+#                     assert isinstance(step.reward, float) or isinstance(step.reward, int)
+#                     assert isinstance(step.done, bool)
+#                     assert isinstance(step.info, dict)
+#             second_iteration_count += 1
+
+#     @pytest.mark.parametrize('env_id', ['FrozenLake-v1'])
+#     @given(n_episodes=st.integers(min_value=2, max_value=10))
+#     @settings(deadline=2000)
+#     def test_ray_sample_without_limits(self, env_id: str, n_episodes: int, test_ray_cluster):
+#         """
+#         Test the sample function of the EpisodicSampler class and that the outputs follow the expected format.
+
+#         Args:
+#             env_id: The Gym environment ID to be used in the sampling.
+#             n_episodes: The number of episodes to sample from the environment.
+#             test_ray_cluster: Test Ray cluster.
+
+#         """
+#         n_samplers = 2
+#         env = gym.make(env_id)
+#         S = env.observation_space.n
+#         A = env.action_space.n
+
+#         feature_fn = construct_one_hot_feature_function(S=S, A=A)
+#         softmax_parameters = np.random.random(size=S * (A - 1))
+#         pol = LinearSoftMax(
+#             env_id,
+#             softmax_parameters,
+#             feature_fn,
+#         )
+#         stats_collector = DummyStatisticsCollector()
+#         sampler = RayEpisodicSampler(
+#             n_samplers,
+#             env_id,
+#             stats_collector,
+#             n_episodes=n_episodes,
+#             policy=pol,
+#         )
+#         statistics = sampler.sample()
+#         assert isinstance(statistics, DummyStatistics)
+#         assert isinstance(statistics.samples, dict)
+#         for k in statistics.samples:
+#             for step in statistics.samples[k]:
+#                 assert isinstance(step.env_id, str)
+#                 assert isinstance(step.time_step, int)
+#                 assert isinstance(step.observation, np.ndarray)
+#                 assert isinstance(step.next_observation, np.ndarray)
+#                 assert isinstance(step.reward, float) or isinstance(step.reward, int)
+#                 assert isinstance(step.done, bool)
+#                 assert isinstance(step.info, dict)

--- a/tests/tfrlrl/sampling/test_statistics_collection.py
+++ b/tests/tfrlrl/sampling/test_statistics_collection.py
@@ -176,6 +176,5 @@ class TestEpisocidPolicyGradientStatisticsCollector:
         assert statistics.observations.shape[-1] == statistics.total_expected_rewards.shape[-1]
 
         assert len(statistics.observations.shape) == 2
-
         assert len(statistics.actions.shape) == 2
         assert len(statistics.total_expected_rewards.shape) == 1

--- a/tests/tfrlrl/sampling/test_statistics_collection.py
+++ b/tests/tfrlrl/sampling/test_statistics_collection.py
@@ -29,7 +29,7 @@ class TestEpisocidPolicyGradientStatisticsCollector:
         feature_fn = OneHotFeatureFunction(env.observation_space.n, env.action_space.n)
         policy = LinearSoftMax(env_id, feature_fn)
 
-        stats_collector = EpisocidPolicyGradientStatisticsCollector()
+        stats_collector = EpisocidPolicyGradientStatisticsCollector(env_id)
         sampler = EpisodicSampler(
             env_id,
             stats_collector,
@@ -43,24 +43,14 @@ class TestEpisocidPolicyGradientStatisticsCollector:
             pass
 
         # Verify that statistics were collected
-        assert len(stats_collector.rewards) > 0
-        assert len(stats_collector.observations) > 0
-        assert len(stats_collector.actions) > 0
-
-        assert len(stats_collector.rewards) == len(stats_collector.observations)
-        assert len(stats_collector.rewards) == len(stats_collector.actions)
+        assert len(stats_collector.steps) > 0
 
         # Reset the statistics collector
         stats_collector.reset()
 
         # Verify that statistics are cleared
-        assert len(stats_collector.rewards) == 0
-        assert len(stats_collector.observations) == 0
-        assert len(stats_collector.actions) == 0
-
-        assert stats_collector.rewards == []
-        assert stats_collector.observations == []
-        assert stats_collector.actions == []
+        assert len(stats_collector.steps) == 0
+        assert stats_collector.steps == []
 
     @pytest.mark.parametrize('env_id', ['FrozenLake-v1'])
     @given(n_episodes=st.integers(min_value=1, max_value=5))
@@ -81,7 +71,7 @@ class TestEpisocidPolicyGradientStatisticsCollector:
         feature_fn = OneHotFeatureFunction(env.observation_space.n, env.action_space.n)
         policy = LinearSoftMax(env_id, feature_fn)
 
-        stats_collector = EpisocidPolicyGradientStatisticsCollector()
+        stats_collector = EpisocidPolicyGradientStatisticsCollector(env_id)
         sampler = EpisodicSampler(
             env_id,
             stats_collector,
@@ -97,12 +87,6 @@ class TestEpisocidPolicyGradientStatisticsCollector:
             assert isinstance(statistics.observations, np.ndarray)
             assert isinstance(statistics.actions, np.ndarray)
             assert isinstance(statistics.total_expected_rewards, np.ndarray)
-
-            print('dddd')
-            print(statistics.observations.shape)
-            print(statistics.actions.shape)
-            print(statistics.total_expected_rewards.shape)
-
             assert statistics.observations.shape[-1] == statistics.actions.shape[-1]
             assert statistics.observations.shape[-1] == statistics.total_expected_rewards.shape[-1]
 
@@ -122,7 +106,7 @@ class TestEpisocidPolicyGradientStatisticsCollector:
         feature_fn = OneHotFeatureFunction(env.observation_space.n, env.action_space.n)
         policy = LinearSoftMax(env_id, feature_fn)
 
-        stats_collector = EpisocidPolicyGradientStatisticsCollector()
+        stats_collector = EpisocidPolicyGradientStatisticsCollector(env_id)
         sampler = EpisodicSampler(
             env_id,
             stats_collector,
@@ -160,7 +144,7 @@ class TestEpisocidPolicyGradientStatisticsCollector:
         feature_fn = OneHotFeatureFunction(env.observation_space.n, env.action_space.n)
         policy = LinearSoftMax(env_id, feature_fn)
 
-        stats_collector = EpisocidPolicyGradientStatisticsCollector()
+        stats_collector = EpisocidPolicyGradientStatisticsCollector(env_id)
         sampler = EpisodicSampler(
             env_id,
             stats_collector,
@@ -181,5 +165,5 @@ class TestEpisocidPolicyGradientStatisticsCollector:
         assert statistics.observations.shape[-1] == statistics.total_expected_rewards.shape[-1]
 
         assert len(statistics.observations.shape) == 2
-        assert len(statistics.actions.shape) == 2
+        assert len(statistics.actions.shape) == 1
         assert len(statistics.total_expected_rewards.shape) == 1

--- a/tests/tfrlrl/sampling/test_statistics_collection.py
+++ b/tests/tfrlrl/sampling/test_statistics_collection.py
@@ -1,5 +1,3 @@
-# """Tests for statistics collection classes."""
-
 import gymnasium as gym
 import numpy as np
 import pytest

--- a/tests/tfrlrl/sampling/test_statistics_collection.py
+++ b/tests/tfrlrl/sampling/test_statistics_collection.py
@@ -177,8 +177,5 @@ class TestEpisocidPolicyGradientStatisticsCollector:
 
         assert len(statistics.observations.shape) == 2
 
-        if env_id == 'InvertedPendulum-v5':
-            assert len(statistics.actions.shape) == 2
-        else:
-            assert len(statistics.actions.shape) == 1
+        assert len(statistics.actions.shape) == 2
         assert len(statistics.total_expected_rewards.shape) == 1

--- a/tests/tfrlrl/sampling/test_statistics_collection.py
+++ b/tests/tfrlrl/sampling/test_statistics_collection.py
@@ -1,212 +1,212 @@
-"""Tests for statistics collection classes."""
+# """Tests for statistics collection classes."""
 
-import gymnasium as gym
-import numpy as np
-import pytest
-from hypothesis import given, settings
-from hypothesis import strategies as st
+# import gymnasium as gym
+# import numpy as np
+# import pytest
+# from hypothesis import given, settings
+# from hypothesis import strategies as st
 
-from tfrlrl.features.onehot import construct_one_hot_feature_function
-from tfrlrl.policies.linear_soft_max import LinearSoftMax
-from tfrlrl.sampling.episodic_sampler import EpisodicSampler
-from tfrlrl.sampling.statistics_collection import EpisocidPolicyGradientStatisticsCollector
+# from tfrlrl.features.onehot import construct_one_hot_feature_function
+# from tfrlrl.policies.linear_soft_max import LinearSoftMax
+# from tfrlrl.sampling.episodic_sampler import EpisodicSampler
+# from tfrlrl.sampling.statistics_collection import EpisocidPolicyGradientStatisticsCollector
 
 
-class TestEpisocidPolicyGradientStatisticsCollector:
-    """Tests for the EpisocidPolicyGradientStatisticsCollector class."""
+# class TestEpisocidPolicyGradientStatisticsCollector:
+#     """Tests for the EpisocidPolicyGradientStatisticsCollector class."""
 
-    @pytest.mark.parametrize('env_id', ['FrozenLake-v1'])
-    @given(n_episodes=st.integers(min_value=1, max_value=5))
-    @settings(deadline=5000)
-    def test_reset_clears_statistics(self, env_id: str, n_episodes: int):
-        """
-        Test that the reset method clears out all collected statistics.
+#     @pytest.mark.parametrize('env_id', ['FrozenLake-v1'])
+#     @given(n_episodes=st.integers(min_value=1, max_value=5))
+#     @settings(deadline=5000)
+#     def test_reset_clears_statistics(self, env_id: str, n_episodes: int):
+#         """
+#         Test that the reset method clears out all collected statistics.
 
-        :param env_id: The Gym environment ID to be used in testing.
-        :param n_episodes: The number of episodes to sample before testing reset.
-        """
-        env = gym.make(env_id)
-        S = env.observation_space.n
-        A = env.action_space.n
+#         :param env_id: The Gym environment ID to be used in testing.
+#         :param n_episodes: The number of episodes to sample before testing reset.
+#         """
+#         env = gym.make(env_id)
+#         S = env.observation_space.n
+#         A = env.action_space.n
 
-        feature_fn = construct_one_hot_feature_function(S=S, A=A)
-        softmax_parameters = np.random.random(size=S * (A - 1))
-        pol = LinearSoftMax(
-            env_id,
-            softmax_parameters,
-            feature_fn,
-        )
+#         feature_fn = construct_one_hot_feature_function(S=S, A=A)
+#         softmax_parameters = np.random.random(size=S * (A - 1))
+#         pol = LinearSoftMax(
+#             env_id,
+#             softmax_parameters,
+#             feature_fn,
+#         )
 
-        stats_collector = EpisocidPolicyGradientStatisticsCollector()
-        sampler = EpisodicSampler(
-            env_id,
-            stats_collector,
-            n_episodes=n_episodes,
-            policy=pol,
-            is_slippery=False,
-        )
+#         stats_collector = EpisocidPolicyGradientStatisticsCollector()
+#         sampler = EpisodicSampler(
+#             env_id,
+#             stats_collector,
+#             n_episodes=n_episodes,
+#             policy=pol,
+#             is_slippery=False,
+#         )
 
-        # Collect some episodes
-        for _ in sampler:
-            pass
+#         # Collect some episodes
+#         for _ in sampler:
+#             pass
 
-        # Verify that statistics were collected
-        assert len(stats_collector.rewards) > 0
-        assert len(stats_collector.observations) > 0
-        assert len(stats_collector.actions) > 0
+#         # Verify that statistics were collected
+#         assert len(stats_collector.rewards) > 0
+#         assert len(stats_collector.observations) > 0
+#         assert len(stats_collector.actions) > 0
 
-        assert len(stats_collector.rewards) == len(stats_collector.observations)
-        assert len(stats_collector.rewards) == len(stats_collector.actions)
+#         assert len(stats_collector.rewards) == len(stats_collector.observations)
+#         assert len(stats_collector.rewards) == len(stats_collector.actions)
 
-        # Reset the statistics collector
-        stats_collector.reset()
+#         # Reset the statistics collector
+#         stats_collector.reset()
 
-        # Verify that statistics are cleared
-        assert len(stats_collector.rewards) == 0
-        assert len(stats_collector.observations) == 0
-        assert len(stats_collector.actions) == 0
+#         # Verify that statistics are cleared
+#         assert len(stats_collector.rewards) == 0
+#         assert len(stats_collector.observations) == 0
+#         assert len(stats_collector.actions) == 0
 
-        assert stats_collector.rewards == []
-        assert stats_collector.observations == []
-        assert stats_collector.actions == []
+#         assert stats_collector.rewards == []
+#         assert stats_collector.observations == []
+#         assert stats_collector.actions == []
 
-    @pytest.mark.parametrize('env_id', ['FrozenLake-v1'])
-    @given(n_episodes=st.integers(min_value=1, max_value=5))
-    @settings(deadline=5000)
-    def test_aggregate_statistics_return_types_and_dimensions(self, env_id: str, n_episodes: int):
-        """
-        Test that aggregate_statistics returns two numpy arrays with expected dimensions.
+#     @pytest.mark.parametrize('env_id', ['FrozenLake-v1'])
+#     @given(n_episodes=st.integers(min_value=1, max_value=5))
+#     @settings(deadline=5000)
+#     def test_aggregate_statistics_return_types_and_dimensions(self, env_id: str, n_episodes: int):
+#         """
+#         Test that aggregate_statistics returns two numpy arrays with expected dimensions.
 
-        The first array should have length equal to the number of sampled steps,
-        and the second should have length equal to the number of policy parameters.
+#         The first array should have length equal to the number of sampled steps,
+#         and the second should have length equal to the number of policy parameters.
 
-        :param env_id: The Gym environment ID to be used in testing.
-        :param n_episodes: The number of episodes to sample.
-        """
-        env = gym.make(env_id)
-        S = env.observation_space.n
-        A = env.action_space.n
+#         :param env_id: The Gym environment ID to be used in testing.
+#         :param n_episodes: The number of episodes to sample.
+#         """
+#         env = gym.make(env_id)
+#         S = env.observation_space.n
+#         A = env.action_space.n
 
-        # Verify dimensions
-        n_params = S * (A - 1)  # Number of policy parameters
+#         # Verify dimensions
+#         n_params = S * (A - 1)  # Number of policy parameters
 
-        feature_fn = construct_one_hot_feature_function(S=S, A=A)
-        softmax_parameters = np.random.random(size=n_params)
-        pol = LinearSoftMax(
-            env_id,
-            softmax_parameters,
-            feature_fn,
-        )
+#         feature_fn = construct_one_hot_feature_function(S=S, A=A)
+#         softmax_parameters = np.random.random(size=n_params)
+#         pol = LinearSoftMax(
+#             env_id,
+#             softmax_parameters,
+#             feature_fn,
+#         )
 
-        stats_collector = EpisocidPolicyGradientStatisticsCollector()
-        sampler = EpisodicSampler(
-            env_id,
-            stats_collector,
-            n_episodes=n_episodes,
-            policy=pol,
-            is_slippery=False,
-        )
+#         stats_collector = EpisocidPolicyGradientStatisticsCollector()
+#         sampler = EpisodicSampler(
+#             env_id,
+#             stats_collector,
+#             n_episodes=n_episodes,
+#             policy=pol,
+#             is_slippery=False,
+#         )
 
-        # Collect episodes
-        for statistics in sampler:
-            # Verify return types
-            assert isinstance(statistics.total_reward, np.int64)
-            assert isinstance(statistics.observations, np.ndarray)
-            assert isinstance(statistics.actions, np.ndarray)
-            assert isinstance(statistics.total_expected_rewards, np.ndarray)
+#         # Collect episodes
+#         for statistics in sampler:
+#             # Verify return types
+#             assert isinstance(statistics.total_reward, np.int64)
+#             assert isinstance(statistics.observations, np.ndarray)
+#             assert isinstance(statistics.actions, np.ndarray)
+#             assert isinstance(statistics.total_expected_rewards, np.ndarray)
 
-            assert statistics.observations.shape[-1] == statistics.actions.shape[-1]
-            assert statistics.observations.shape[-1] == statistics.total_expected_rewards.shape[-1]
+#             assert statistics.observations.shape[-1] == statistics.actions.shape[-1]
+#             assert statistics.observations.shape[-1] == statistics.total_expected_rewards.shape[-1]
 
-    @pytest.mark.parametrize('env_id', ['FrozenLake-v1'])
-    @given(n_episodes=st.integers(min_value=2, max_value=5))
-    @settings(deadline=5000)
-    def test_reset_and_reuse(self, env_id: str, n_episodes: int):
-        """
-        Test that after reset, the collector can be reused for new episodes.
+#     @pytest.mark.parametrize('env_id', ['FrozenLake-v1'])
+#     @given(n_episodes=st.integers(min_value=2, max_value=5))
+#     @settings(deadline=5000)
+#     def test_reset_and_reuse(self, env_id: str, n_episodes: int):
+#         """
+#         Test that after reset, the collector can be reused for new episodes.
 
-        :param env_id: The Gym environment ID to be used in testing.
-        :param n_episodes: The number of episodes to sample in each iteration.
-        """
-        env = gym.make(env_id)
-        S = env.observation_space.n
-        A = env.action_space.n
+#         :param env_id: The Gym environment ID to be used in testing.
+#         :param n_episodes: The number of episodes to sample in each iteration.
+#         """
+#         env = gym.make(env_id)
+#         S = env.observation_space.n
+#         A = env.action_space.n
 
-        feature_fn = construct_one_hot_feature_function(S=S, A=A)
-        softmax_parameters = np.random.random(size=S * (A - 1))
-        pol = LinearSoftMax(
-            env_id,
-            softmax_parameters,
-            feature_fn,
-        )
+#         feature_fn = construct_one_hot_feature_function(S=S, A=A)
+#         softmax_parameters = np.random.random(size=S * (A - 1))
+#         pol = LinearSoftMax(
+#             env_id,
+#             softmax_parameters,
+#             feature_fn,
+#         )
 
-        stats_collector = EpisocidPolicyGradientStatisticsCollector()
-        sampler = EpisodicSampler(
-            env_id,
-            stats_collector,
-            n_episodes=n_episodes,
-            policy=pol,
-            is_slippery=False,
-        )
+#         stats_collector = EpisocidPolicyGradientStatisticsCollector()
+#         sampler = EpisodicSampler(
+#             env_id,
+#             stats_collector,
+#             n_episodes=n_episodes,
+#             policy=pol,
+#             is_slippery=False,
+#         )
 
-        # First collection
-        statistics1 = [x for x in sampler]
+#         # First collection
+#         statistics1 = [x for x in sampler]
 
-        # Reset everything
-        sampler.reset()
+#         # Reset everything
+#         sampler.reset()
 
-        # Second collection
-        statistics2 = [x for x in sampler]
+#         # Second collection
+#         statistics2 = [x for x in sampler]
 
-        # Verify both collections produced valid results
-        assert len(statistics1) == n_episodes
-        assert len(statistics2) == n_episodes
+#         # Verify both collections produced valid results
+#         assert len(statistics1) == n_episodes
+#         assert len(statistics2) == n_episodes
 
-    @pytest.mark.parametrize('env_id', ['FrozenLake-v1'])
-    @given(n_episodes=st.integers(min_value=1, max_value=5))
-    @settings(deadline=5000)
-    def test_merge_statistics(self, env_id: str, n_episodes: int):
-        """
-        Test that merge_statistics returns two numpy arrays with expected dimensions.
+#     @pytest.mark.parametrize('env_id', ['FrozenLake-v1'])
+#     @given(n_episodes=st.integers(min_value=1, max_value=5))
+#     @settings(deadline=5000)
+#     def test_merge_statistics(self, env_id: str, n_episodes: int):
+#         """
+#         Test that merge_statistics returns two numpy arrays with expected dimensions.
 
-        :param env_id: The Gym environment ID to be used in testing.
-        :param n_episodes: The number of episodes to sample.
-        """
-        env = gym.make(env_id)
-        S = env.observation_space.n
-        A = env.action_space.n
+#         :param env_id: The Gym environment ID to be used in testing.
+#         :param n_episodes: The number of episodes to sample.
+#         """
+#         env = gym.make(env_id)
+#         S = env.observation_space.n
+#         A = env.action_space.n
 
-        # Verify dimensions
-        n_params = S * (A - 1)  # Number of policy parameters
+#         # Verify dimensions
+#         n_params = S * (A - 1)  # Number of policy parameters
 
-        feature_fn = construct_one_hot_feature_function(S=S, A=A)
-        softmax_parameters = np.random.random(size=n_params)
-        pol = LinearSoftMax(
-            env_id,
-            softmax_parameters,
-            feature_fn,
-        )
+#         feature_fn = construct_one_hot_feature_function(S=S, A=A)
+#         softmax_parameters = np.random.random(size=n_params)
+#         pol = LinearSoftMax(
+#             env_id,
+#             softmax_parameters,
+#             feature_fn,
+#         )
 
-        stats_collector = EpisocidPolicyGradientStatisticsCollector()
-        sampler = EpisodicSampler(
-            env_id,
-            stats_collector,
-            n_episodes=n_episodes,
-            policy=pol,
-            is_slippery=False,
-        )
-        statistics = sampler.sample()
+#         stats_collector = EpisocidPolicyGradientStatisticsCollector()
+#         sampler = EpisodicSampler(
+#             env_id,
+#             stats_collector,
+#             n_episodes=n_episodes,
+#             policy=pol,
+#             is_slippery=False,
+#         )
+#         statistics = sampler.sample()
 
-        # Verify return types
-        assert isinstance(statistics.total_reward, np.ndarray)
-        assert isinstance(statistics.observations, np.ndarray)
-        assert isinstance(statistics.actions, np.ndarray)
-        assert isinstance(statistics.total_expected_rewards, np.ndarray)
+#         # Verify return types
+#         assert isinstance(statistics.total_reward, np.ndarray)
+#         assert isinstance(statistics.observations, np.ndarray)
+#         assert isinstance(statistics.actions, np.ndarray)
+#         assert isinstance(statistics.total_expected_rewards, np.ndarray)
 
-        assert len(statistics.total_reward) == n_episodes
-        assert statistics.observations.shape[-1] == statistics.actions.shape[-1]
-        assert statistics.observations.shape[-1] == statistics.total_expected_rewards.shape[-1]
+#         assert len(statistics.total_reward) == n_episodes
+#         assert statistics.observations.shape[-1] == statistics.actions.shape[-1]
+#         assert statistics.observations.shape[-1] == statistics.total_expected_rewards.shape[-1]
 
-        assert len(statistics.observations.shape) == 2
-        assert len(statistics.actions.shape) == 2
-        assert len(statistics.total_expected_rewards.shape) == 1
+#         assert len(statistics.observations.shape) == 2
+#         assert len(statistics.actions.shape) == 2
+#         assert len(statistics.total_expected_rewards.shape) == 1

--- a/tests/tfrlrl/sampling/test_statistics_collection.py
+++ b/tests/tfrlrl/sampling/test_statistics_collection.py
@@ -1,212 +1,182 @@
 # """Tests for statistics collection classes."""
 
-# import gymnasium as gym
-# import numpy as np
-# import pytest
-# from hypothesis import given, settings
-# from hypothesis import strategies as st
+import gymnasium as gym
+import numpy as np
+import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
 
-# from tfrlrl.features.onehot import construct_one_hot_feature_function
-# from tfrlrl.policies.linear_soft_max import LinearSoftMax
-# from tfrlrl.sampling.episodic_sampler import EpisodicSampler
-# from tfrlrl.sampling.statistics_collection import EpisocidPolicyGradientStatisticsCollector
+from tfrlrl.features.onehot import OneHotFeatureFunction
+from tfrlrl.policies.linear_soft_max import LinearSoftMax
+from tfrlrl.sampling.episodic_sampler import EpisodicSampler
+from tfrlrl.sampling.statistics_collection import EpisocidPolicyGradientStatisticsCollector
 
 
-# class TestEpisocidPolicyGradientStatisticsCollector:
-#     """Tests for the EpisocidPolicyGradientStatisticsCollector class."""
+class TestEpisocidPolicyGradientStatisticsCollector:
+    """Tests for the EpisocidPolicyGradientStatisticsCollector class."""
 
-#     @pytest.mark.parametrize('env_id', ['FrozenLake-v1'])
-#     @given(n_episodes=st.integers(min_value=1, max_value=5))
-#     @settings(deadline=5000)
-#     def test_reset_clears_statistics(self, env_id: str, n_episodes: int):
-#         """
-#         Test that the reset method clears out all collected statistics.
+    @pytest.mark.parametrize('env_id', ['FrozenLake-v1'])
+    @given(n_episodes=st.integers(min_value=1, max_value=5))
+    @settings(deadline=5000)
+    def test_reset_clears_statistics(self, env_id: str, n_episodes: int):
+        """
+        Test that the reset method clears out all collected statistics.
 
-#         :param env_id: The Gym environment ID to be used in testing.
-#         :param n_episodes: The number of episodes to sample before testing reset.
-#         """
-#         env = gym.make(env_id)
-#         S = env.observation_space.n
-#         A = env.action_space.n
+        Args:
+            env_id: The Gym environment ID to be used in testing.
+            n_episodes: The number of episodes to sample before testing reset.
 
-#         feature_fn = construct_one_hot_feature_function(S=S, A=A)
-#         softmax_parameters = np.random.random(size=S * (A - 1))
-#         pol = LinearSoftMax(
-#             env_id,
-#             softmax_parameters,
-#             feature_fn,
-#         )
+        """
+        env = gym.make(env_id)
+        feature_fn = OneHotFeatureFunction(env.observation_space.n, env.action_space.n)
+        policy = LinearSoftMax(env_id, feature_fn)
 
-#         stats_collector = EpisocidPolicyGradientStatisticsCollector()
-#         sampler = EpisodicSampler(
-#             env_id,
-#             stats_collector,
-#             n_episodes=n_episodes,
-#             policy=pol,
-#             is_slippery=False,
-#         )
+        stats_collector = EpisocidPolicyGradientStatisticsCollector()
+        sampler = EpisodicSampler(
+            env_id,
+            stats_collector,
+            n_episodes=n_episodes,
+            policy=policy,
+            is_slippery=False,
+        )
 
-#         # Collect some episodes
-#         for _ in sampler:
-#             pass
+        # Collect some episodes
+        for _ in sampler:
+            pass
 
-#         # Verify that statistics were collected
-#         assert len(stats_collector.rewards) > 0
-#         assert len(stats_collector.observations) > 0
-#         assert len(stats_collector.actions) > 0
+        # Verify that statistics were collected
+        assert len(stats_collector.rewards) > 0
+        assert len(stats_collector.observations) > 0
+        assert len(stats_collector.actions) > 0
 
-#         assert len(stats_collector.rewards) == len(stats_collector.observations)
-#         assert len(stats_collector.rewards) == len(stats_collector.actions)
+        assert len(stats_collector.rewards) == len(stats_collector.observations)
+        assert len(stats_collector.rewards) == len(stats_collector.actions)
 
-#         # Reset the statistics collector
-#         stats_collector.reset()
+        # Reset the statistics collector
+        stats_collector.reset()
 
-#         # Verify that statistics are cleared
-#         assert len(stats_collector.rewards) == 0
-#         assert len(stats_collector.observations) == 0
-#         assert len(stats_collector.actions) == 0
+        # Verify that statistics are cleared
+        assert len(stats_collector.rewards) == 0
+        assert len(stats_collector.observations) == 0
+        assert len(stats_collector.actions) == 0
 
-#         assert stats_collector.rewards == []
-#         assert stats_collector.observations == []
-#         assert stats_collector.actions == []
+        assert stats_collector.rewards == []
+        assert stats_collector.observations == []
+        assert stats_collector.actions == []
 
-#     @pytest.mark.parametrize('env_id', ['FrozenLake-v1'])
-#     @given(n_episodes=st.integers(min_value=1, max_value=5))
-#     @settings(deadline=5000)
-#     def test_aggregate_statistics_return_types_and_dimensions(self, env_id: str, n_episodes: int):
-#         """
-#         Test that aggregate_statistics returns two numpy arrays with expected dimensions.
+    @pytest.mark.parametrize('env_id', ['FrozenLake-v1'])
+    @given(n_episodes=st.integers(min_value=1, max_value=5))
+    @settings(deadline=5000)
+    def test_aggregate_statistics_return_types_and_dimensions(self, env_id: str, n_episodes: int):
+        """
+        Test that aggregate_statistics returns two numpy arrays with expected dimensions.
 
-#         The first array should have length equal to the number of sampled steps,
-#         and the second should have length equal to the number of policy parameters.
+        The first array should have length equal to the number of sampled steps,
+        and the second should have length equal to the number of policy parameters.
 
-#         :param env_id: The Gym environment ID to be used in testing.
-#         :param n_episodes: The number of episodes to sample.
-#         """
-#         env = gym.make(env_id)
-#         S = env.observation_space.n
-#         A = env.action_space.n
+        Args:
+            env_id: The Gym environment ID to be used in testing.
+            n_episodes: The number of episodes to sample.
 
-#         # Verify dimensions
-#         n_params = S * (A - 1)  # Number of policy parameters
+        """
+        env = gym.make(env_id)
+        feature_fn = OneHotFeatureFunction(env.observation_space.n, env.action_space.n)
+        policy = LinearSoftMax(env_id, feature_fn)
 
-#         feature_fn = construct_one_hot_feature_function(S=S, A=A)
-#         softmax_parameters = np.random.random(size=n_params)
-#         pol = LinearSoftMax(
-#             env_id,
-#             softmax_parameters,
-#             feature_fn,
-#         )
+        stats_collector = EpisocidPolicyGradientStatisticsCollector()
+        sampler = EpisodicSampler(
+            env_id,
+            stats_collector,
+            n_episodes=n_episodes,
+            policy=policy,
+            is_slippery=False,
+        )
 
-#         stats_collector = EpisocidPolicyGradientStatisticsCollector()
-#         sampler = EpisodicSampler(
-#             env_id,
-#             stats_collector,
-#             n_episodes=n_episodes,
-#             policy=pol,
-#             is_slippery=False,
-#         )
+        # Collect episodes
+        for statistics in sampler:
+            # Verify return types
+            assert isinstance(statistics.total_reward, np.int64)
+            assert isinstance(statistics.observations, np.ndarray)
+            assert isinstance(statistics.actions, np.ndarray)
+            assert isinstance(statistics.total_expected_rewards, np.ndarray)
 
-#         # Collect episodes
-#         for statistics in sampler:
-#             # Verify return types
-#             assert isinstance(statistics.total_reward, np.int64)
-#             assert isinstance(statistics.observations, np.ndarray)
-#             assert isinstance(statistics.actions, np.ndarray)
-#             assert isinstance(statistics.total_expected_rewards, np.ndarray)
+            assert statistics.observations.shape[-1] == statistics.actions.shape[-1]
+            assert statistics.observations.shape[-1] == statistics.total_expected_rewards.shape[-1]
 
-#             assert statistics.observations.shape[-1] == statistics.actions.shape[-1]
-#             assert statistics.observations.shape[-1] == statistics.total_expected_rewards.shape[-1]
+    @pytest.mark.parametrize('env_id', ['FrozenLake-v1'])
+    @given(n_episodes=st.integers(min_value=2, max_value=5))
+    @settings(deadline=5000)
+    def test_reset_and_reuse(self, env_id: str, n_episodes: int):
+        """
+        Test that after reset, the collector can be reused for new episodes.
 
-#     @pytest.mark.parametrize('env_id', ['FrozenLake-v1'])
-#     @given(n_episodes=st.integers(min_value=2, max_value=5))
-#     @settings(deadline=5000)
-#     def test_reset_and_reuse(self, env_id: str, n_episodes: int):
-#         """
-#         Test that after reset, the collector can be reused for new episodes.
+        Args:
+            env_id: The Gym environment ID to be used in testing.
+            n_episodes: The number of episodes to sample in each iteration.
 
-#         :param env_id: The Gym environment ID to be used in testing.
-#         :param n_episodes: The number of episodes to sample in each iteration.
-#         """
-#         env = gym.make(env_id)
-#         S = env.observation_space.n
-#         A = env.action_space.n
+        """
+        env = gym.make(env_id)
+        feature_fn = OneHotFeatureFunction(env.observation_space.n, env.action_space.n)
+        policy = LinearSoftMax(env_id, feature_fn)
 
-#         feature_fn = construct_one_hot_feature_function(S=S, A=A)
-#         softmax_parameters = np.random.random(size=S * (A - 1))
-#         pol = LinearSoftMax(
-#             env_id,
-#             softmax_parameters,
-#             feature_fn,
-#         )
+        stats_collector = EpisocidPolicyGradientStatisticsCollector()
+        sampler = EpisodicSampler(
+            env_id,
+            stats_collector,
+            n_episodes=n_episodes,
+            policy=policy,
+            is_slippery=False,
+        )
 
-#         stats_collector = EpisocidPolicyGradientStatisticsCollector()
-#         sampler = EpisodicSampler(
-#             env_id,
-#             stats_collector,
-#             n_episodes=n_episodes,
-#             policy=pol,
-#             is_slippery=False,
-#         )
+        # First collection
+        statistics1 = [x for x in sampler]
 
-#         # First collection
-#         statistics1 = [x for x in sampler]
+        # Reset everything
+        sampler.reset()
 
-#         # Reset everything
-#         sampler.reset()
+        # Second collection
+        statistics2 = [x for x in sampler]
 
-#         # Second collection
-#         statistics2 = [x for x in sampler]
+        # Verify both collections produced valid results
+        assert len(statistics1) == n_episodes
+        assert len(statistics2) == n_episodes
 
-#         # Verify both collections produced valid results
-#         assert len(statistics1) == n_episodes
-#         assert len(statistics2) == n_episodes
+    @pytest.mark.parametrize('env_id', ['FrozenLake-v1'])
+    @given(n_episodes=st.integers(min_value=1, max_value=5))
+    @settings(deadline=5000)
+    def test_merge_statistics(self, env_id: str, n_episodes: int):
+        """
+        Test that merge_statistics returns two numpy arrays with expected dimensions.
 
-#     @pytest.mark.parametrize('env_id', ['FrozenLake-v1'])
-#     @given(n_episodes=st.integers(min_value=1, max_value=5))
-#     @settings(deadline=5000)
-#     def test_merge_statistics(self, env_id: str, n_episodes: int):
-#         """
-#         Test that merge_statistics returns two numpy arrays with expected dimensions.
+        Args:
+            env_id: The Gym environment ID to be used in testing.
+            n_episodes: The number of episodes to sample.
 
-#         :param env_id: The Gym environment ID to be used in testing.
-#         :param n_episodes: The number of episodes to sample.
-#         """
-#         env = gym.make(env_id)
-#         S = env.observation_space.n
-#         A = env.action_space.n
+        """
+        env = gym.make(env_id)
+        feature_fn = OneHotFeatureFunction(env.observation_space.n, env.action_space.n)
+        policy = LinearSoftMax(env_id, feature_fn)
 
-#         # Verify dimensions
-#         n_params = S * (A - 1)  # Number of policy parameters
+        stats_collector = EpisocidPolicyGradientStatisticsCollector()
+        sampler = EpisodicSampler(
+            env_id,
+            stats_collector,
+            n_episodes=n_episodes,
+            policy=policy,
+            is_slippery=False,
+        )
+        statistics = sampler.sample()
 
-#         feature_fn = construct_one_hot_feature_function(S=S, A=A)
-#         softmax_parameters = np.random.random(size=n_params)
-#         pol = LinearSoftMax(
-#             env_id,
-#             softmax_parameters,
-#             feature_fn,
-#         )
+        # Verify return types
+        assert isinstance(statistics.total_reward, np.ndarray)
+        assert isinstance(statistics.observations, np.ndarray)
+        assert isinstance(statistics.actions, np.ndarray)
+        assert isinstance(statistics.total_expected_rewards, np.ndarray)
 
-#         stats_collector = EpisocidPolicyGradientStatisticsCollector()
-#         sampler = EpisodicSampler(
-#             env_id,
-#             stats_collector,
-#             n_episodes=n_episodes,
-#             policy=pol,
-#             is_slippery=False,
-#         )
-#         statistics = sampler.sample()
+        assert len(statistics.total_reward) == n_episodes
+        assert statistics.observations.shape[-1] == statistics.actions.shape[-1]
+        assert statistics.observations.shape[-1] == statistics.total_expected_rewards.shape[-1]
 
-#         # Verify return types
-#         assert isinstance(statistics.total_reward, np.ndarray)
-#         assert isinstance(statistics.observations, np.ndarray)
-#         assert isinstance(statistics.actions, np.ndarray)
-#         assert isinstance(statistics.total_expected_rewards, np.ndarray)
-
-#         assert len(statistics.total_reward) == n_episodes
-#         assert statistics.observations.shape[-1] == statistics.actions.shape[-1]
-#         assert statistics.observations.shape[-1] == statistics.total_expected_rewards.shape[-1]
-
-#         assert len(statistics.observations.shape) == 2
-#         assert len(statistics.actions.shape) == 2
-#         assert len(statistics.total_expected_rewards.shape) == 1
+        assert len(statistics.observations.shape) == 2
+        assert len(statistics.actions.shape) == 2
+        assert len(statistics.total_expected_rewards.shape) == 1

--- a/tests/tfrlrl/sampling/test_statistics_collection.py
+++ b/tests/tfrlrl/sampling/test_statistics_collection.py
@@ -37,7 +37,7 @@ class TestEpisocidPolicyGradientStatisticsCollector:
             feature_fn,
         )
 
-        stats_collector = EpisocidPolicyGradientStatisticsCollector(pol)
+        stats_collector = EpisocidPolicyGradientStatisticsCollector()
         sampler = EpisodicSampler(
             env_id,
             stats_collector,
@@ -52,16 +52,23 @@ class TestEpisocidPolicyGradientStatisticsCollector:
 
         # Verify that statistics were collected
         assert len(stats_collector.rewards) > 0
-        assert len(stats_collector.log_pol_grads) > 0
+        assert len(stats_collector.observations) > 0
+        assert len(stats_collector.actions) > 0
+
+        assert len(stats_collector.rewards) == len(stats_collector.observations)
+        assert len(stats_collector.rewards) == len(stats_collector.actions)
 
         # Reset the statistics collector
         stats_collector.reset()
 
         # Verify that statistics are cleared
         assert len(stats_collector.rewards) == 0
-        assert len(stats_collector.log_pol_grads) == 0
+        assert len(stats_collector.observations) == 0
+        assert len(stats_collector.actions) == 0
+
         assert stats_collector.rewards == []
-        assert stats_collector.log_pol_grads == []
+        assert stats_collector.observations == []
+        assert stats_collector.actions == []
 
     @pytest.mark.parametrize('env_id', ['FrozenLake-v1'])
     @given(n_episodes=st.integers(min_value=1, max_value=5))
@@ -91,7 +98,7 @@ class TestEpisocidPolicyGradientStatisticsCollector:
             feature_fn,
         )
 
-        stats_collector = EpisocidPolicyGradientStatisticsCollector(pol)
+        stats_collector = EpisocidPolicyGradientStatisticsCollector()
         sampler = EpisodicSampler(
             env_id,
             stats_collector,
@@ -104,11 +111,12 @@ class TestEpisocidPolicyGradientStatisticsCollector:
         for statistics in sampler:
             # Verify return types
             assert isinstance(statistics.total_reward, np.int64)
-            assert isinstance(statistics.episode_gradient, np.ndarray)
+            assert isinstance(statistics.observations, np.ndarray)
+            assert isinstance(statistics.actions, np.ndarray)
+            assert isinstance(statistics.total_expected_rewards, np.ndarray)
 
-            # Episode gradient should have length equal to number of policy parameters
-            assert statistics.episode_gradient.shape == (n_params, 1)
-            assert len(statistics.episode_gradient) == n_params
+            assert statistics.observations.shape[-1] == statistics.actions.shape[-1]
+            assert statistics.observations.shape[-1] == statistics.total_expected_rewards.shape[-1]
 
     @pytest.mark.parametrize('env_id', ['FrozenLake-v1'])
     @given(n_episodes=st.integers(min_value=2, max_value=5))
@@ -132,7 +140,7 @@ class TestEpisocidPolicyGradientStatisticsCollector:
             feature_fn,
         )
 
-        stats_collector = EpisocidPolicyGradientStatisticsCollector(pol)
+        stats_collector = EpisocidPolicyGradientStatisticsCollector()
         sampler = EpisodicSampler(
             env_id,
             stats_collector,
@@ -153,8 +161,6 @@ class TestEpisocidPolicyGradientStatisticsCollector:
         # Verify both collections produced valid results
         assert len(statistics1) == n_episodes
         assert len(statistics2) == n_episodes
-        for i in range(n_episodes):
-            assert statistics1[i].episode_gradient.shape == statistics2[i].episode_gradient.shape
 
     @pytest.mark.parametrize('env_id', ['FrozenLake-v1'])
     @given(n_episodes=st.integers(min_value=1, max_value=5))
@@ -181,7 +187,7 @@ class TestEpisocidPolicyGradientStatisticsCollector:
             feature_fn,
         )
 
-        stats_collector = EpisocidPolicyGradientStatisticsCollector(pol)
+        stats_collector = EpisocidPolicyGradientStatisticsCollector()
         sampler = EpisodicSampler(
             env_id,
             stats_collector,
@@ -193,7 +199,14 @@ class TestEpisocidPolicyGradientStatisticsCollector:
 
         # Verify return types
         assert isinstance(statistics.total_reward, np.ndarray)
-        assert isinstance(statistics.episode_gradient, np.ndarray)
+        assert isinstance(statistics.observations, np.ndarray)
+        assert isinstance(statistics.actions, np.ndarray)
+        assert isinstance(statistics.total_expected_rewards, np.ndarray)
 
         assert len(statistics.total_reward) == n_episodes
-        assert statistics.episode_gradient.shape == (n_params, n_episodes)
+        assert statistics.observations.shape[-1] == statistics.actions.shape[-1]
+        assert statistics.observations.shape[-1] == statistics.total_expected_rewards.shape[-1]
+
+        assert len(statistics.observations.shape) == 2
+        assert len(statistics.actions.shape) == 2
+        assert len(statistics.total_expected_rewards.shape) == 1

--- a/tests/tfrlrl/sampling/test_statistics_collection.py
+++ b/tests/tfrlrl/sampling/test_statistics_collection.py
@@ -98,6 +98,11 @@ class TestEpisocidPolicyGradientStatisticsCollector:
             assert isinstance(statistics.actions, np.ndarray)
             assert isinstance(statistics.total_expected_rewards, np.ndarray)
 
+            print('dddd')
+            print(statistics.observations.shape)
+            print(statistics.actions.shape)
+            print(statistics.total_expected_rewards.shape)
+
             assert statistics.observations.shape[-1] == statistics.actions.shape[-1]
             assert statistics.observations.shape[-1] == statistics.total_expected_rewards.shape[-1]
 

--- a/tests/tfrlrl/sampling/test_statistics_collection.py
+++ b/tests/tfrlrl/sampling/test_statistics_collection.py
@@ -5,6 +5,7 @@ from hypothesis import given, settings
 from hypothesis import strategies as st
 
 from tfrlrl.features.onehot import OneHotFeatureFunction
+from tfrlrl.policies.dense_neural_network import DenseNetworkPolicy
 from tfrlrl.policies.linear_soft_max import LinearSoftMax
 from tfrlrl.sampling.episodic_sampler import EpisodicSampler
 from tfrlrl.sampling.statistics_collection import EpisocidPolicyGradientStatisticsCollector
@@ -128,7 +129,7 @@ class TestEpisocidPolicyGradientStatisticsCollector:
         assert len(statistics1) == n_episodes
         assert len(statistics2) == n_episodes
 
-    @pytest.mark.parametrize('env_id', ['FrozenLake-v1'])
+    @pytest.mark.parametrize('env_id', ['FrozenLake-v1', 'InvertedPendulum-v5'])
     @given(n_episodes=st.integers(min_value=1, max_value=5))
     @settings(deadline=5000)
     def test_merge_statistics(self, env_id: str, n_episodes: int):
@@ -141,8 +142,18 @@ class TestEpisocidPolicyGradientStatisticsCollector:
 
         """
         env = gym.make(env_id)
-        feature_fn = OneHotFeatureFunction(env.observation_space.n, env.action_space.n)
-        policy = LinearSoftMax(env_id, feature_fn)
+
+        if env_id == 'InvertedPendulum-v5':
+            hidden_space_dims = [16, 32]
+            policy = DenseNetworkPolicy(
+                env_id=env_id,
+                hidden_space_dims=hidden_space_dims,
+            )
+            env_kwargs = {}
+        else:
+            feature_fn = OneHotFeatureFunction(env.observation_space.n, env.action_space.n)
+            policy = LinearSoftMax(env_id, feature_fn)
+            env_kwargs = {'is_slippery': False}
 
         stats_collector = EpisocidPolicyGradientStatisticsCollector(env_id)
         sampler = EpisodicSampler(
@@ -150,7 +161,7 @@ class TestEpisocidPolicyGradientStatisticsCollector:
             stats_collector,
             n_episodes=n_episodes,
             policy=policy,
-            is_slippery=False,
+            **env_kwargs,
         )
         statistics = sampler.sample()
 
@@ -165,5 +176,9 @@ class TestEpisocidPolicyGradientStatisticsCollector:
         assert statistics.observations.shape[-1] == statistics.total_expected_rewards.shape[-1]
 
         assert len(statistics.observations.shape) == 2
-        assert len(statistics.actions.shape) == 1
+
+        if env_id == 'InvertedPendulum-v5':
+            assert len(statistics.actions.shape) == 2
+        else:
+            assert len(statistics.actions.shape) == 1
         assert len(statistics.total_expected_rewards.shape) == 1

--- a/tests/tfrlrl/training_algorithms/test_sgd.py
+++ b/tests/tfrlrl/training_algorithms/test_sgd.py
@@ -1,4 +1,7 @@
+import copy
+
 import gymnasium as gym
+import numpy as np
 import pytest
 from hypothesis import given, settings
 from hypothesis import strategies as st
@@ -65,6 +68,59 @@ class TestTrainPolicyGradient:
 
         # Verify that the returned policy is the same object that was passed in
         assert trained_policy is policy
+
+    @pytest.mark.parametrize('env_id', ['FrozenLake-v1'])
+    @given(
+        n_iterations=st.integers(min_value=2, max_value=5),
+        n_episodes=st.integers(min_value=10, max_value=100),
+        alpha=st.floats(min_value=0.001, max_value=0.01),
+    )
+    @settings(deadline=5000)
+    def test_train_policy_gradient_updates_policy(
+        self,
+        env_id: str,
+        n_iterations: int,
+        n_episodes: int,
+        alpha: float,
+    ):
+        """
+        Test that train_policy_gradient executes successfully and updates the policy.
+
+        Args:
+            env_id: The Gym environment ID to be used in training.
+            n_iterations: The number of policy updates to perform.
+            n_episodes: The number of episodes to sample during each policy update.
+            alpha: The initial step size for stochastic gradient ascent.
+
+        """
+        env = gym.make(env_id)
+
+        feature_fn = OneHotFeatureFunction(env.observation_space.n, env.action_space.n)
+        policy = LinearSoftMax(env_id, feature_fn)
+
+        original_paramters = copy.deepcopy(list(policy.get_parameters()))
+
+        # Train the policy - We set reward_schedule to ensure the policy is updated.
+        trained_policy = train_policy_gradient(
+            env_id=env_id,
+            policy=policy,
+            n_iterations=n_iterations,
+            n_episodes=n_episodes,
+            alpha=alpha,
+            is_slippery=False,
+            reward_schedule=(1, 1, 1),
+        )
+
+        # Verify that a policy is returned
+        assert trained_policy is not None
+        assert isinstance(trained_policy, LinearSoftMax)
+
+        # Verify that the returned policy is the same object that was passed in
+        assert trained_policy is policy
+
+        updated_parameters = list(policy.get_parameters())
+        parameter_diff = original_paramters[0].detach().numpy() - updated_parameters[0].detach().numpy()
+        assert np.sum(np.abs(parameter_diff)) > 0
 
     @pytest.mark.slow
     @pytest.mark.parametrize('env_id', ['FrozenLake-v1', 'InvertedPendulum-v5'])

--- a/tests/tfrlrl/training_algorithms/test_sgd.py
+++ b/tests/tfrlrl/training_algorithms/test_sgd.py
@@ -69,11 +69,11 @@ class TestTrainPolicyGradient:
     @pytest.mark.slow
     @pytest.mark.parametrize('env_id', ['FrozenLake-v1', 'InvertedPendulum-v5'])
     @given(
-        n_iterations=st.integers(min_value=2, max_value=10),
-        n_episodes=st.integers(min_value=10, max_value=100),
+        n_iterations=st.integers(min_value=2, max_value=5),
+        n_episodes=st.integers(min_value=10, max_value=20),
         alpha=st.floats(min_value=0.0001, max_value=0.001),
     )
-    @settings(deadline=5000)
+    @settings(deadline=7000)
     def test_ray_train_policy_gradient_returns_policy(
         self,
         env_id: str,

--- a/tests/tfrlrl/training_algorithms/test_sgd.py
+++ b/tests/tfrlrl/training_algorithms/test_sgd.py
@@ -1,15 +1,18 @@
+import gymnasium as gym
 import pytest
 from hypothesis import given, settings
 from hypothesis import strategies as st
 
+from tfrlrl.features.onehot import OneHotFeatureFunction
 from tfrlrl.policies.dense_neural_network import DenseNetworkPolicy
+from tfrlrl.policies.linear_soft_max import LinearSoftMax
 from tfrlrl.training_algorithms.sgd import train_policy_gradient
 
 
 class TestTrainPolicyGradient:
-    """Class that encapsulates the unit tests for the train_policy_gradient function."""
+    """Unit tests for the train_policy_gradient function."""
 
-    @pytest.mark.parametrize('env_id', ['InvertedPendulum-v5'])
+    @pytest.mark.parametrize('env_id', ['FrozenLake-v1', 'InvertedPendulum-v5'])
     @given(
         n_iterations=st.integers(min_value=2, max_value=10),
         n_episodes=st.integers(min_value=10, max_value=100),
@@ -33,10 +36,16 @@ class TestTrainPolicyGradient:
             alpha: The initial step size for stochastic gradient ascent.
 
         """
-        policy = DenseNetworkPolicy(
-            env_id=env_id,
-            hidden_space_dims=[16, 32],
-        )
+        env = gym.make(env_id)
+
+        if env_id == 'InvertedPendulum-v5':
+            policy = DenseNetworkPolicy(
+                env_id=env_id,
+                hidden_space_dims=[16, 32],
+            )
+        else:
+            feature_fn = OneHotFeatureFunction(env.observation_space.n, env.action_space.n)
+            policy = LinearSoftMax(env_id, feature_fn)
 
         # Train the policy
         trained_policy = train_policy_gradient(
@@ -49,12 +58,15 @@ class TestTrainPolicyGradient:
 
         # Verify that a policy is returned
         assert trained_policy is not None
-        assert isinstance(trained_policy, DenseNetworkPolicy)
+        if env_id == 'InvertedPendulum-v5':
+            assert isinstance(trained_policy, DenseNetworkPolicy)
+        else:
+            assert isinstance(trained_policy, LinearSoftMax)
 
         # Verify that the returned policy is the same object that was passed in
         assert trained_policy is policy
 
-    @pytest.mark.parametrize('env_id', ['InvertedPendulum-v5'])
+    @pytest.mark.parametrize('env_id', ['FrozenLake-v1', 'InvertedPendulum-v5'])
     @given(
         n_iterations=st.integers(min_value=2, max_value=10),
         n_episodes=st.integers(min_value=10, max_value=100),
@@ -80,11 +92,16 @@ class TestTrainPolicyGradient:
             test_ray_cluster: Test Ray cluster.
 
         """
+        env = gym.make(env_id)
         n_samplers = 2
-        policy = DenseNetworkPolicy(
-            env_id=env_id,
-            hidden_space_dims=[16, 32],
-        )
+        if env_id == 'InvertedPendulum-v5':
+            policy = DenseNetworkPolicy(
+                env_id=env_id,
+                hidden_space_dims=[16, 32],
+            )
+        else:
+            feature_fn = OneHotFeatureFunction(env.observation_space.n, env.action_space.n)
+            policy = LinearSoftMax(env_id, feature_fn)
 
         # Train the policy
         trained_policy = train_policy_gradient(
@@ -98,7 +115,10 @@ class TestTrainPolicyGradient:
 
         # Verify that a policy is returned
         assert trained_policy is not None
-        assert isinstance(trained_policy, DenseNetworkPolicy)
+        if env_id == 'InvertedPendulum-v5':
+            assert isinstance(trained_policy, DenseNetworkPolicy)
+        else:
+            assert isinstance(trained_policy, LinearSoftMax)
 
         # Verify that the returned policy is the same object that was passed in
         assert trained_policy is policy

--- a/tests/tfrlrl/training_algorithms/test_sgd.py
+++ b/tests/tfrlrl/training_algorithms/test_sgd.py
@@ -9,6 +9,8 @@ from hypothesis import strategies as st
 from tfrlrl.features.onehot import OneHotFeatureFunction
 from tfrlrl.policies.dense_neural_network import DenseNetworkPolicy
 from tfrlrl.policies.linear_soft_max import LinearSoftMax
+from tfrlrl.sampling.episodic_sampler import EpisodicSampler
+from tfrlrl.sampling.statistics_collection import EpisocidPolicyGradientStatisticsCollector
 from tfrlrl.training_algorithms.sgd import train_policy_gradient
 
 
@@ -121,6 +123,39 @@ class TestTrainPolicyGradient:
         updated_parameters = list(policy.get_parameters())
         parameter_diff = original_paramters[0].detach().numpy() - updated_parameters[0].detach().numpy()
         assert np.sum(np.abs(parameter_diff)) > 0
+
+    def test_frozen_lake_regression_test(self):
+        """Perform a regression test to ensure that a policy can still be optimised on FrozenLake."""
+        env_id = 'FrozenLake-v1'
+        n_iterations = 100
+        n_episodes = 100
+        alpha = 1.0
+
+        env = gym.make(env_id)
+
+        feature_fn = OneHotFeatureFunction(env.observation_space.n, env.action_space.n)
+        policy = LinearSoftMax(env_id, feature_fn)
+
+        trained_policy = train_policy_gradient(
+            env_id=env_id,
+            policy=policy,
+            n_iterations=n_iterations,
+            n_episodes=n_episodes,
+            alpha=alpha,
+            is_slippery=False,
+        )
+
+        statistics_collector = EpisocidPolicyGradientStatisticsCollector(env_id)
+        sampler = EpisodicSampler(
+            env_id=env_id,
+            n_episodes=n_episodes,
+            policy=trained_policy,
+            statistics_collector=statistics_collector,
+            is_slippery=False,
+        )
+
+        statistics = sampler.sample()
+        assert np.average(statistics.total_reward) > 0.8
 
     @pytest.mark.slow
     @pytest.mark.parametrize('env_id', ['FrozenLake-v1', 'InvertedPendulum-v5'])

--- a/tests/tfrlrl/training_algorithms/test_sgd.py
+++ b/tests/tfrlrl/training_algorithms/test_sgd.py
@@ -1,22 +1,19 @@
-import gymnasium as gym
-import numpy as np
 import pytest
 from hypothesis import given, settings
 from hypothesis import strategies as st
 
-from tfrlrl.features.onehot import construct_one_hot_feature_function
-from tfrlrl.policies.linear_soft_max import LinearSoftMax
+from tfrlrl.policies.dense_neural_network import DenseNetworkPolicy
 from tfrlrl.training_algorithms.sgd import train_policy_gradient
 
 
 class TestTrainPolicyGradient:
     """Class that encapsulates the unit tests for the train_policy_gradient function."""
 
-    @pytest.mark.parametrize('env_id', ['FrozenLake-v1'])
+    @pytest.mark.parametrize('env_id', ['InvertedPendulum-v5'])
     @given(
         n_iterations=st.integers(min_value=2, max_value=10),
         n_episodes=st.integers(min_value=10, max_value=100),
-        alpha=st.floats(min_value=1.0, max_value=10.0),
+        alpha=st.floats(min_value=0.0001, max_value=0.001),
     )
     @settings(deadline=5000)
     def test_train_policy_gradient_returns_policy(
@@ -29,52 +26,39 @@ class TestTrainPolicyGradient:
         """
         Test that train_policy_gradient executes successfully and returns a policy.
 
-        :param env_id: The Gym environment ID to be used in training.
-        :param n_iterations: The number of policy updates to perform.
-        :param n_episodes: The number of episodes to sample during each policy update.
-        :param alpha: The initial step size for stochastic gradient ascent.
+        Args:
+            env_id: The Gym environment ID to be used in training.
+            n_iterations: The number of policy updates to perform.
+            n_episodes: The number of episodes to sample during each policy update.
+            alpha: The initial step size for stochastic gradient ascent.
+
         """
-        env = gym.make(env_id)
-        S = env.observation_space.n
-        A = env.action_space.n
-
-        feature_fn = construct_one_hot_feature_function(S=S, A=A)
-        softmax_parameters = np.random.random(size=S * (A - 1))
-        pol = LinearSoftMax(
-            env_id,
-            softmax_parameters,
-            feature_fn,
+        policy = DenseNetworkPolicy(
+            env_id=env_id,
+            hidden_space_dims=[16, 32],
         )
-
-        # Store initial parameters to verify they change during training
-        initial_parameters = pol.get_parameters().copy()
 
         # Train the policy
         trained_policy = train_policy_gradient(
             env_id=env_id,
-            policy=pol,
+            policy=policy,
             n_iterations=n_iterations,
             n_episodes=n_episodes,
             alpha=alpha,
-            is_slippery=False,
         )
 
         # Verify that a policy is returned
         assert trained_policy is not None
-        assert isinstance(trained_policy, LinearSoftMax)
+        assert isinstance(trained_policy, DenseNetworkPolicy)
 
         # Verify that the returned policy is the same object that was passed in
-        assert trained_policy is pol
+        assert trained_policy is policy
 
-        # Verify that the policy parameters have been updated during training
-        final_parameters = trained_policy.get_parameters()
-        assert initial_parameters.shape == final_parameters.shape
-
-    @pytest.mark.parametrize('env_id', ['FrozenLake-v1'])
+    @pytest.mark.parametrize('env_id', ['InvertedPendulum-v5'])
     @given(
         n_iterations=st.integers(min_value=2, max_value=10),
         n_episodes=st.integers(min_value=10, max_value=100),
-        alpha=st.floats(min_value=1.0, max_value=10.0),
+        alpha=st.floats(min_value=0.0001, max_value=0.001),
     )
     @settings(deadline=5000)
     def test_ray_train_policy_gradient_returns_policy(
@@ -88,46 +72,33 @@ class TestTrainPolicyGradient:
         """
         Test that train_policy_gradient executes successfully and returns a policy.
 
-        :param env_id: The Gym environment ID to be used in training.
-        :param n_iterations: The number of policy updates to perform.
-        :param n_episodes: The number of episodes to sample during each policy update.
-        :param alpha: The initial step size for stochastic gradient ascent.
-        :param test_ray_cluster: Test Ray cluster.
+        Args:
+            env_id: The Gym environment ID to be used in training.
+            n_iterations: The number of policy updates to perform.
+            n_episodes: The number of episodes to sample during each policy update.
+            alpha: The initial step size for stochastic gradient ascent.
+            test_ray_cluster: Test Ray cluster.
+
         """
         n_samplers = 2
-        env = gym.make(env_id)
-        S = env.observation_space.n
-        A = env.action_space.n
-
-        feature_fn = construct_one_hot_feature_function(S=S, A=A)
-        softmax_parameters = np.random.random(size=S * (A - 1))
-        pol = LinearSoftMax(
-            env_id,
-            softmax_parameters,
-            feature_fn,
+        policy = DenseNetworkPolicy(
+            env_id=env_id,
+            hidden_space_dims=[16, 32],
         )
-
-        # Store initial parameters to verify they change during training
-        initial_parameters = pol.get_parameters().copy()
 
         # Train the policy
         trained_policy = train_policy_gradient(
             env_id=env_id,
-            policy=pol,
+            policy=policy,
             n_iterations=n_iterations,
             n_episodes=n_episodes,
             alpha=alpha,
             n_samplers=n_samplers,
-            is_slippery=False,
         )
 
         # Verify that a policy is returned
         assert trained_policy is not None
-        assert isinstance(trained_policy, LinearSoftMax)
+        assert isinstance(trained_policy, DenseNetworkPolicy)
 
         # Verify that the returned policy is the same object that was passed in
-        assert trained_policy is pol
-
-        # Verify that the policy parameters have been updated during training
-        final_parameters = trained_policy.get_parameters()
-        assert initial_parameters.shape == final_parameters.shape
+        assert trained_policy is policy

--- a/tests/tfrlrl/training_algorithms/test_sgd.py
+++ b/tests/tfrlrl/training_algorithms/test_sgd.py
@@ -66,6 +66,7 @@ class TestTrainPolicyGradient:
         # Verify that the returned policy is the same object that was passed in
         assert trained_policy is policy
 
+    @pytest.mark.slow
     @pytest.mark.parametrize('env_id', ['FrozenLake-v1', 'InvertedPendulum-v5'])
     @given(
         n_iterations=st.integers(min_value=2, max_value=10),

--- a/tests/tfrlrl/training_algorithms/test_sgd.py
+++ b/tests/tfrlrl/training_algorithms/test_sgd.py
@@ -14,9 +14,9 @@ class TestTrainPolicyGradient:
 
     @pytest.mark.parametrize('env_id', ['FrozenLake-v1', 'InvertedPendulum-v5'])
     @given(
-        n_iterations=st.integers(min_value=2, max_value=10),
+        n_iterations=st.integers(min_value=2, max_value=5),
         n_episodes=st.integers(min_value=10, max_value=100),
-        alpha=st.floats(min_value=0.0001, max_value=0.001),
+        alpha=st.floats(min_value=0.00001, max_value=0.0001),
     )
     @settings(deadline=5000)
     def test_train_policy_gradient_returns_policy(


### PR DESCRIPTION
This PR does the following:

- Adds support for PyTorch policies.
- Adds two instances of such policies, a linear soft-max policy for discrete action spaces and a dense policy for continuous action spaces. 
- Updates feature functions to be callable classes. 
- Updates data models and sampling to ensure consistent data sizes throughout sampling and policy updates. 
- Update docstrings to follow goole standards.