### PR TITLE
Feat/add baselines

### DIFF
--- a/src/tfrlrl/baselines/__init__.py
+++ b/src/tfrlrl/baselines/__init__.py
@@ -1,0 +1,1 @@
+"""Package for baseline algorithms in tfrlrl, i.e. variance reduction techniques."""

--- a/src/tfrlrl/baselines/linear.py
+++ b/src/tfrlrl/baselines/linear.py
@@ -34,8 +34,8 @@ class LinearBaseline(Baseline):
     def calculate_features(self, observation_matrix: npt.ArrayLike, time_steps: npt.ArrayLike) -> npt.ArrayLike:
         """Calculate baseline features for the given observations."""
         o = np.clip(observation_matrix, -10, 10)
-        al = time_steps.reshape(-1, 1) / 100.0
-        return np.concatenate([o, o**2, al, al**2, al**3, np.ones((time_steps.shape[0], 1))], axis=1)
+        al = time_steps.reshape(1, -1) / 100.0
+        return np.concatenate([o, o**2, al, al**2, al**3, np.ones((1, time_steps.shape[0]))], axis=0)
 
     def calculate_baseline(
         self, observation_matrix: npt.ArrayLike, time_steps: npt.ArrayLike, feature_matrix: npt.ArrayLike = None
@@ -52,8 +52,8 @@ class LinearBaseline(Baseline):
         reg_coeff = self._reg_coeff
         for _ in range(5):
             self._coeffs = np.linalg.lstsq(
-                np.dot(feature_matrix.T, feature_matrix) + reg_coeff * np.identity(feature_matrix.shape[1]),
-                np.dot(feature_matrix.T, regressand),
+                np.dot(feature_matrix, feature_matrix.T) + reg_coeff * np.identity(feature_matrix.shape[1]),
+                np.dot(feature_matrix, regressand.T),
             )[0]
             if not np.any(np.isnan(self._coeffs)):
                 break

--- a/src/tfrlrl/baselines/linear.py
+++ b/src/tfrlrl/baselines/linear.py
@@ -1,4 +1,5 @@
 from abc import abstractmethod
+from typing import Any
 
 import numpy as np
 import numpy.typing as npt
@@ -17,6 +18,48 @@ class Baseline:
         """Fit the baseline on the given examples."""
         ...
 
+    @abstractmethod
+    def get_state(self) -> dict[str, Any]:
+        """
+        Get the state dictionary of the baseline clase.
+
+        Return the state dictionary of the baseline. This follows the same terminology as PyTorch, though baselines
+        as not implemented through PyTorch. This is just a convention. The state dictionary returned by this function
+        should contain the information necessary to reinstantiate the baseline class.
+
+        Returns:
+            The current state dictionary of the baseline class.
+
+        """
+        ...
+
+    @abstractmethod
+    def set_state(self, state_dict: dict[str, Any]) -> None:
+        """
+        Set the state dictionary of the baseline clase.
+
+        Set the state dictionary of the baseline. This follows the same terminology as PyTorch, though baselines
+        as not implemented through PyTorch. This is just a convention. The state dictionary returned by this function
+        should contain the information necessary to reinstantiate the baseline class.
+
+        Args:
+            state_dict: The state dictionary to be assigned to the baseline.
+
+        """
+        ...
+
+    @abstractmethod
+    def update(self, state_dict, **kwargs) -> None:
+        """
+        Update the baseline.
+
+        Args:
+            state_dict: The state dictionary to be assigned to the baseline.
+            kwargs: Optional keyword-arguments for the policy update.
+
+        """
+        ...
+
 
 class LinearBaseline(Baseline):
     """
@@ -28,8 +71,53 @@ class LinearBaseline(Baseline):
 
     def __init__(self, reg_coeff=1e-5, coeffs: npt.ArrayLike = None):
         """Class constructor."""
-        self.reg_coeff = reg_coeff
+        self._reg_coeff = reg_coeff
         self._coeffs = coeffs
+
+    def get_state(self) -> dict[str, Any]:
+        """
+        Get the state dictionary of the baseline clase.
+
+        Return the state dictionary of the baseline. This follows the same terminology as PyTorch, though baselines
+        as not implemented through PyTorch. This is just a convention. The state dictionary returned by this function
+        should contain the information necessary to reinstantiate the baseline class.
+
+        Returns:
+            The current state dictionary of the baseline class.
+
+        """
+        return {
+            'reg_coeff': self._reg_coeff,
+            'coeffs': self._coeffs,
+        }
+
+    @abstractmethod
+    def set_state(self, state_dict: dict[str, Any]) -> None:
+        """
+        Set the state dictionary of the baseline clase.
+
+        Set the state dictionary of the baseline. This follows the same terminology as PyTorch, though baselines
+        as not implemented through PyTorch. This is just a convention. The state dictionary returned by this function
+        should contain the information necessary to reinstantiate the baseline class.
+
+        Args:
+            state_dict: The state dictionary to be assigned to the baseline.
+
+        """
+        self._reg_coeff = state_dict['reg_coeff']
+        self._coeffs = state_dict['coeffs']
+
+    @abstractmethod
+    def update(self, state_dict, **kwargs) -> None:
+        """
+        Update the baseline.
+
+        Args:
+            state_dict: The state dictionary to be assigned to the baseline.
+            kwargs: Optional keyword-arguments for the policy update.
+
+        """
+        self.set_state(state_dict)
 
     def calculate_features(self, observation_matrix: npt.ArrayLike, time_steps: npt.ArrayLike) -> npt.ArrayLike:
         """
@@ -82,7 +170,7 @@ class LinearBaseline(Baseline):
         reg_coeff = self._reg_coeff
         for _ in range(5):
             self._coeffs = np.linalg.lstsq(
-                np.dot(feature_matrix, feature_matrix.T) + reg_coeff * np.identity(feature_matrix.shape[1]),
+                np.dot(feature_matrix, feature_matrix.T) + reg_coeff * np.identity(feature_matrix.shape[0]),
                 np.dot(feature_matrix, regressand.T),
             )[0]
             if not np.any(np.isnan(self._coeffs)):

--- a/src/tfrlrl/baselines/linear.py
+++ b/src/tfrlrl/baselines/linear.py
@@ -26,13 +26,18 @@ class LinearBaseline(Baseline):
     ......
     """
 
-    def __init__(self, reg_coeff=1e-5):
+    def __init__(self, reg_coeff=1e-5, coeffs: npt.ArrayLike = None):
         """Class constructor."""
         self.reg_coeff = reg_coeff
-        self._coeffs = None
+        self._coeffs = coeffs
 
     def calculate_features(self, observation_matrix: npt.ArrayLike, time_steps: npt.ArrayLike) -> npt.ArrayLike:
-        """Calculate baseline features for the given observations."""
+        """
+        Calculate baseline features for the given observations.
+
+        param: observation_matrix: An [n_obs, n_steps] NumPy matrix of observations.
+        param: time_steps: An [n_steps] NumPy matrix of the time steps corresponding to the given observations.
+        """
         o = np.clip(observation_matrix, -10, 10)
         al = time_steps.reshape(1, -1) / 100.0
         return np.concatenate([o, o**2, al, al**2, al**3, np.ones((1, time_steps.shape[0]))], axis=0)
@@ -40,15 +45,28 @@ class LinearBaseline(Baseline):
     def calculate_baseline(
         self, observation_matrix: npt.ArrayLike, time_steps: npt.ArrayLike, feature_matrix: npt.ArrayLike = None
     ) -> npt.ArrayLike:
-        """Calculate the baseline for the given examples."""
+        """
+        Calculate the baseline for the given examples.
+
+        param: observation_matrix: An [n_obs, n_steps] NumPy matrix of observations.
+        param: time_steps: An [n_steps] NumPy matrix of the time steps corresponding to the given observations.
+        param: feature_matrix: A pre-calculated [2 * n_obs + 4, n_steps] feature matrix. If provided the features
+        will not be calculated again.
+        """
         if self._coeffs is None:
             return np.zeros(time_steps.shape[0])
         if feature_matrix is None:
             feature_matrix = self.calculate_features(observation_matrix, time_steps)
-        return np.dot(feature_matrix, self._coeffs)
+        return np.dot(self._coeffs, feature_matrix)
 
     def fit(self, feature_matrix: npt.ArrayLike, regressand: npt.ArrayLike) -> None:
-        """Fit the baseline on the given examples."""
+        """
+        Fit the baseline on the given examples.
+
+        param: feature_matrix: A pre-calculated [2 * n_obs + 4, n_steps] feature matrix. If provided the features
+        will not be calculated again.
+        param: regressand: A pre-calculated [n_steps] vector of the regressand.
+        """
         reg_coeff = self._reg_coeff
         for _ in range(5):
             self._coeffs = np.linalg.lstsq(

--- a/src/tfrlrl/baselines/linear.py
+++ b/src/tfrlrl/baselines/linear.py
@@ -1,0 +1,60 @@
+from abc import abstractmethod
+
+import numpy as np
+import numpy.typing as npt
+
+
+class Baseline:
+    """A base class for baseline algorithms, which are used to reduce the variance of policy graident methods."""
+
+    @abstractmethod
+    def calculate_baseline(self):
+        """Calculate the baseline for the given examples."""
+        ...
+
+    @abstractmethod
+    def fit(self):
+        """Fit the baseline on the given examples."""
+        ...
+
+
+class LinearBaseline:
+    """
+    A linear baseline class.
+
+    This class uses a linear function for the baseline calculation. It uses the same features are given in
+    ......
+    """
+
+    def __init__(self, reg_coeff=1e-5):
+        """Class constructor."""
+        self.reg_coeff = reg_coeff
+        self._coeffs = None
+
+    def calculate_features(self, observation_matrix: npt.ArrayLike, time_steps: npt.ArrayLike) -> npt.ArrayLike:
+        """Calculate baseline features for the given observations."""
+        o = np.clip(observation_matrix, -10, 10)
+        al = time_steps.reshape(-1, 1) / 100.0
+        return np.concatenate([o, o**2, al, al**2, al**3, np.ones((time_steps.shape[0], 1))], axis=1)
+
+    def calculate_baseline(
+        self, observation_matrix: npt.ArrayLike, time_steps: npt.ArrayLike, feature_matrix: npt.ArrayLike = None
+    ) -> npt.ArrayLike:
+        """Calculate the baseline for the given examples."""
+        if self._coeffs is None:
+            return np.zeros(time_steps.shape[0])
+        if feature_matrix is None:
+            feature_matrix = self.calculate_features(observation_matrix, time_steps)
+        return np.dot(feature_matrix, self._coeffs)
+
+    def fit(self, feature_matrix: npt.ArrayLike, regressand: npt.ArrayLike) -> None:
+        """Fit the baseline on the given examples."""
+        reg_coeff = self._reg_coeff
+        for _ in range(5):
+            self._coeffs = np.linalg.lstsq(
+                np.dot(feature_matrix.T, feature_matrix) + reg_coeff * np.identity(feature_matrix.shape[1]),
+                np.dot(feature_matrix.T, regressand),
+            )[0]
+            if not np.any(np.isnan(self._coeffs)):
+                break
+            reg_coeff *= 10

--- a/src/tfrlrl/baselines/linear.py
+++ b/src/tfrlrl/baselines/linear.py
@@ -1,12 +1,36 @@
 from abc import abstractmethod
 from typing import Any
 
+import gymnasium as gym
 import numpy as np
 import numpy.typing as npt
 
 
+class BaselineException(Exception):
+    """Custom exception to encompass errors raised by the baselines."""
+
+    pass
+
+
 class Baseline:
     """A base class for baseline algorithms, which are used to reduce the variance of policy graident methods."""
+
+    def __init__(self, env_id: str):
+        """
+        Initialise the base baseline class.
+
+        Args:
+            env_id: The I.D. of the environment from which to collect statistics.
+
+        """
+        env = gym.make(env_id)
+        if not self.valid_environment(env):
+            raise BaselineException('Can not use baseline class on environment: (%s, %s)', type(self).__name__, env_id)
+
+    @abstractmethod
+    def valid_environment(self, env: gym.Env) -> bool:
+        """Determine whether the baseline class can be used in the given environment."""
+        ...
 
     @abstractmethod
     def calculate_baseline(self, observation_matrix: npt.ArrayLike, time_steps: npt.ArrayLike) -> npt.ArrayLike:
@@ -29,8 +53,8 @@ class Baseline:
         Fit the baseline on the given examples.
 
         Args:
-            feature_matrix: A pre-calculated [2 * n_obs + 4, n_steps] feature matrix. If provided the features
-            will not be calculated again.
+            feature_matrix: A pre-calculated [n_steps,  n_f] feature matrix, in which n_f is the number of features in
+            the baseline.
             regressand: A pre-calculated [n_steps] vector of the regressand.
 
         """
@@ -67,13 +91,12 @@ class Baseline:
         ...
 
     @abstractmethod
-    def update(self, state_dict, **kwargs) -> None:
+    def update(self, state_dict) -> None:
         """
         Update the baseline.
 
         Args:
             state_dict: The state dictionary to be assigned to the baseline.
-            kwargs: Optional keyword-arguments for the policy update.
 
         """
         ...
@@ -83,12 +106,19 @@ class LinearBaseline(Baseline):
     """
     A linear baseline class.
 
-    This class uses a linear function for the baseline calculation. It uses the same features are given in
-    ......
+    This class uses a linear function for the baseline calculation. It uses the same features are given in the paper,
+    Benchmarking Deep Reinforcement Learning for Continuous Control by Yan Duan et. al. (See section 2 of the appendix
+     of the paper.) In particular, the features of the linear predictor are of the form:
+
+        baseline(o) = (o, o^^2, 0.01 * t, (0.01 * t)^2, (0.01 * t)^3, 1)
+
+    in which o is the observation, t is the time step and o^^2 should be read as the element-wise product.
+
     """
 
-    def __init__(self, reg_coeff=1e-5, coeffs: npt.ArrayLike = None):
+    def __init__(self, env_id: str, reg_coeff=1e-5, coeffs: npt.ArrayLike = None):
         """Class constructor."""
+        super().__init__(env_id=env_id)
         self._reg_coeff = reg_coeff
         self._coeffs = coeffs
 
@@ -126,13 +156,17 @@ class LinearBaseline(Baseline):
         self._coeffs = state_dict['coeffs']
 
     @abstractmethod
-    def update(self, state_dict, **kwargs) -> None:
+    def valid_environment(self, env: gym.Env) -> bool:
+        """Determine whether the baseline class can be used in the given environment."""
+        return isinstance(env.observation_space, gym.spaces.Box)
+
+    @abstractmethod
+    def update(self, state_dict) -> None:
         """
         Update the baseline.
 
         Args:
             state_dict: The state dictionary to be assigned to the baseline.
-            kwargs: Optional keyword-arguments for the policy update.
 
         """
         self.set_state(state_dict)
@@ -180,8 +214,7 @@ class LinearBaseline(Baseline):
         Fit the baseline on the given examples.
 
         Args:
-            feature_matrix: A pre-calculated [2 * n_obs + 4, n_steps] feature matrix. If provided the features
-            will not be calculated again.
+            feature_matrix: A pre-calculated [2 * n_obs + 4, n_steps] feature matrix.
             regressand: A pre-calculated [n_steps] vector of the regressand.
 
         """

--- a/src/tfrlrl/baselines/linear.py
+++ b/src/tfrlrl/baselines/linear.py
@@ -18,7 +18,7 @@ class Baseline:
         ...
 
 
-class LinearBaseline:
+class LinearBaseline(Baseline):
     """
     A linear baseline class.
 

--- a/src/tfrlrl/baselines/linear.py
+++ b/src/tfrlrl/baselines/linear.py
@@ -35,8 +35,13 @@ class LinearBaseline(Baseline):
         """
         Calculate baseline features for the given observations.
 
-        param: observation_matrix: An [n_obs, n_steps] NumPy matrix of observations.
-        param: time_steps: An [n_steps] NumPy matrix of the time steps corresponding to the given observations.
+        Args:
+            observation_matrix: An [n_obs, n_steps] NumPy matrix of observations.
+            time_steps: An [n_steps] NumPy matrix of the time steps corresponding to the given observations.
+
+        Returns:
+            A NumPy array containing the baseline features for the given observations.
+
         """
         o = np.clip(observation_matrix, -10, 10)
         al = time_steps.reshape(1, -1) / 100.0
@@ -48,10 +53,15 @@ class LinearBaseline(Baseline):
         """
         Calculate the baseline for the given examples.
 
-        param: observation_matrix: An [n_obs, n_steps] NumPy matrix of observations.
-        param: time_steps: An [n_steps] NumPy matrix of the time steps corresponding to the given observations.
-        param: feature_matrix: A pre-calculated [2 * n_obs + 4, n_steps] feature matrix. If provided the features
-        will not be calculated again.
+        Args:
+            observation_matrix: An [n_obs, n_steps] NumPy matrix of observations.
+            time_steps: An [n_steps] NumPy matrix of the time steps corresponding to the given observations.
+            feature_matrix: A pre-calculated [2 * n_obs + 4, n_steps] feature matrix. If provided the features
+            will not be calculated again.
+
+        Returns:
+            The baselines for the given observations.
+
         """
         if self._coeffs is None:
             return np.zeros(time_steps.shape[0])
@@ -63,9 +73,11 @@ class LinearBaseline(Baseline):
         """
         Fit the baseline on the given examples.
 
-        param: feature_matrix: A pre-calculated [2 * n_obs + 4, n_steps] feature matrix. If provided the features
-        will not be calculated again.
-        param: regressand: A pre-calculated [n_steps] vector of the regressand.
+        Args:
+            feature_matrix: A pre-calculated [2 * n_obs + 4, n_steps] feature matrix. If provided the features
+            will not be calculated again.
+            regressand: A pre-calculated [n_steps] vector of the regressand.
+
         """
         reg_coeff = self._reg_coeff
         for _ in range(5):

--- a/src/tfrlrl/baselines/linear.py
+++ b/src/tfrlrl/baselines/linear.py
@@ -9,13 +9,31 @@ class Baseline:
     """A base class for baseline algorithms, which are used to reduce the variance of policy graident methods."""
 
     @abstractmethod
-    def calculate_baseline(self):
-        """Calculate the baseline for the given examples."""
+    def calculate_baseline(self, observation_matrix: npt.ArrayLike, time_steps: npt.ArrayLike) -> npt.ArrayLike:
+        """
+        Calculate the baseline for the given examples.
+
+        Args:
+            observation_matrix: An [n_obs, n_steps] NumPy matrix of observations.
+            time_steps: An [n_steps] NumPy matrix of the time steps corresponding to the given observations.
+
+        Returns:
+            The baselines for the given observations.
+
+        """
         ...
 
     @abstractmethod
-    def fit(self):
-        """Fit the baseline on the given examples."""
+    def fit(self, feature_matrix: npt.ArrayLike, regressand: npt.ArrayLike) -> None:
+        """
+        Fit the baseline on the given examples.
+
+        Args:
+            feature_matrix: A pre-calculated [2 * n_obs + 4, n_steps] feature matrix. If provided the features
+            will not be calculated again.
+            regressand: A pre-calculated [n_steps] vector of the regressand.
+
+        """
         ...
 
     @abstractmethod

--- a/src/tfrlrl/data_models/statistics.py
+++ b/src/tfrlrl/data_models/statistics.py
@@ -1,6 +1,12 @@
 from dataclasses import dataclass
 
 
+class StatisticsException(Exception):
+    """Custom exception to encompass errors raised during statistics collection."""
+
+    pass
+
+
 @dataclass
 class BaseStatistics:
     """A base class for statistics collected from a statistics collector."""

--- a/src/tfrlrl/policies/base.py
+++ b/src/tfrlrl/policies/base.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Any, Generator, Tuple, Union
+from typing import Any, Dict, Generator, Tuple, Union
 
 import gymnasium as gym
 from numpy.typing import ArrayLike
@@ -39,12 +39,12 @@ class BasePolicy(ABC):
         ...
 
     @abstractmethod
-    def update(self, **kwargs) -> None:
+    def update(self, state_dict: Dict[str, Any]) -> None:
         """
         Update the policy using the keyword arguments provided.
 
         Args:
-            kwargs: Keyward arguments passed to the policy update.
+            state_dict: The state dictionary for the policy.
 
         """
         ...
@@ -90,11 +90,15 @@ class UniformActionSamplingPolicy(BasePolicy):
         """
         return self._env.action_space.sample()
 
-    def update(self, **kwargs) -> None:
+    def update(self, _: Dict[str, Any]) -> None:
         """
         Update the policy.
 
         This is a dummy function, as there is nothing to update in this policy.
+
+        Args:
+            state_dict: The state dictionary for the policy.
+
         """
         pass
 
@@ -155,13 +159,12 @@ class BasePyTorchPolicy(BasePolicy):
         """
         self.network.load_state_dict(state_dict)
 
-    def update(self, state_dict, **kwargs) -> None:
+    def update(self, state_dict) -> None:
         """
         Update the policy.
 
         Args:
             state_dict: The state dictionary to be assigned to the policy's Pytorch network.
-            kwargs: Optional keyword-arguments for the policy update.
 
         """
         self.set_state(state_dict)

--- a/src/tfrlrl/sampling/episodic_sampler.py
+++ b/src/tfrlrl/sampling/episodic_sampler.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Any, Dict, Optional
 
 import ray
 
@@ -64,15 +64,22 @@ class EpisodicSampler:
         self._statistics_collector.reset()
         self._n_episodes_taken = 0
 
-    def update(self, **kwargs) -> None:
+    def update(self, policy_state_dict: Dict[str, Any], baseline_state_dict: Optional[Dict[str, Any]] = None) -> None:
         """
         Update the the sampler, e.g., the policy used for action selection.
 
         Args:
-            kwargs: The keyword arguments to be passed to the sampler update.
+            policy_state_dict: The state dictionary of the policy.
+            baseline_state_dict: The state dictionary of the baseline.
 
         """
-        self._sampler.update(**kwargs)
+        self._sampler.update(
+            policy_state_dict=policy_state_dict,
+        )
+        if baseline_state_dict is not None:
+            self._statistics_collector.update(
+                baseline_state_dict=baseline_state_dict,
+            )
 
     def sample(self) -> BaseStatistics:
         """Sample all episodes from the sampler and merge the statistics."""
@@ -138,15 +145,24 @@ class RayEpisodicSampler:
         """Reset all samplers."""
         ray.get([env.reset.remote() for env in self.samplers])
 
-    def update(self, **kwargs) -> None:
+    def update(self, policy_state_dict: Dict[str, Any], baseline_state_dict: Optional[Dict[str, Any]] = None) -> None:
         """
         Update the the sampler, e.g., the policy used for action selection.
 
         Args:
-            kwargs: Keyword arguments to be passed to the sampler updated.
+            policy_state_dict: The state dictionary of the policy.
+            baseline_state_dict: The state dictionary of the baseline.
 
         """
-        ray.get([env.update.remote(**kwargs) for env in self.samplers])
+        ray.get(
+            [
+                env.update.remote(
+                    policy_state_dict=policy_state_dict,
+                    baseline_state_dict=baseline_state_dict,
+                )
+                for env in self.samplers
+            ]
+        )
 
     def sample(self) -> BaseStatistics:
         """Sample all episodes from the sampler and merge the statistics."""

--- a/src/tfrlrl/sampling/sampler.py
+++ b/src/tfrlrl/sampling/sampler.py
@@ -1,5 +1,5 @@
 import uuid
-from typing import Dict, Optional, Tuple, Union
+from typing import Any, Dict, Optional, Tuple, Union
 
 import gymnasium as gym
 from numpy.typing import NDArray
@@ -81,12 +81,14 @@ class Sampler:
         if self._n_steps_taken is not None:
             self._n_steps_taken = 0
 
-    def update(self, **kwargs) -> None:
+    def update(self, policy_state_dict: Dict[str, Any]) -> None:
         """
         Update the sampler, e.g. the policy used for action selection.
 
         Args:
-            kwargs: Keyword arguments passed to the policy update.
+            policy_state_dict: The state dictionary for the policy.
 
         """
-        self._policy.update(**kwargs)
+        self._policy.update(
+            state_dict=policy_state_dict,
+        )

--- a/src/tfrlrl/sampling/statistics_collection.py
+++ b/src/tfrlrl/sampling/statistics_collection.py
@@ -1,11 +1,15 @@
+import logging
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import List
 
 import numpy as np
 
+from tfrlrl.baselines.linear import Baseline
 from tfrlrl.data_models.statistics import BaseStatistics
 from tfrlrl.data_models.step import construct_step_dataclasses
+
+logger = logging.getLogger(__name__)
 
 
 class BaseStatisticsCollector(ABC):
@@ -47,6 +51,7 @@ class EpisocidPolicyGradientStatisticsCollector(BaseStatisticsCollector):
     """
     Statistics collector for episodic-level statistics collection.
 
+<<<<<<< HEAD
     This class can be used to collect statistics for episodes sampled from environments. In
     particular, it collects the actions, observations and total future rewards for all of the
     steps in an episode.

--- a/src/tfrlrl/sampling/statistics_collection.py
+++ b/src/tfrlrl/sampling/statistics_collection.py
@@ -6,8 +6,10 @@ from typing import List
 import numpy as np
 
 from tfrlrl.baselines.linear import Baseline
-from tfrlrl.data_models.statistics import BaseStatistics, StatisticsException
+from tfrlrl.data_models.statistics import BaseStatistics
 from tfrlrl.data_models.step import construct_step_dataclasses
+from tfrlrl.data_models.statistics import BaseStatistics
+from tfrlrl.sampling.utils import merge_optional_statistics
 
 logger = logging.getLogger(__name__)
 
@@ -138,19 +140,11 @@ class EpisocidPolicyGradientStatisticsCollector(BaseStatisticsCollector):
             An instance of the EpisodePolicyGradientStatistics dataclass.
 
         """
-        baseline_features = [x.baseline_features for x in statistics]
-        baseline_targets = [x.baseline_targets for x in statistics]
-
-        if any([x is None for x in baseline_features]) and any([x is not None for x in baseline_features]):
-            raise StatisticsException('All baseline features should either be None or a NumPy array.')
-        if any([x is None for x in baseline_targets]) and any([x is not None for x in baseline_targets]):
-            raise StatisticsException('All baseline features should either be None or a NumPy array.')
-
         return EpisodePolicyGradientStatistics(
             total_reward=np.array([x.total_reward for x in statistics]),
             observations=np.concatenate([x.observations for x in statistics], axis=-1),
             actions=np.concatenate([x.actions for x in statistics], axis=-1),
             total_expected_rewards=np.concatenate([x.total_expected_rewards for x in statistics]),
-            baseline_features=baseline_features or None,
-            baseline_targets=baseline_targets or None,
+            baseline_features=merge_optional_statistics(statistics, 'baseline_features', 1),
+            baseline_targets=merge_optional_statistics(statistics, 'baseline_targets', 0),
         )

--- a/src/tfrlrl/sampling/statistics_collection.py
+++ b/src/tfrlrl/sampling/statistics_collection.py
@@ -45,6 +45,8 @@ class EpisodePolicyGradientStatistics(BaseStatistics):
     observations: np.ndarray
     actions: np.ndarray
     total_expected_rewards: np.ndarray
+    baseline_features: np.ndarray = None
+    baseline_targets: np.ndarray = None
 
 
 class EpisocidPolicyGradientStatisticsCollector(BaseStatisticsCollector):
@@ -101,17 +103,28 @@ class EpisocidPolicyGradientStatisticsCollector(BaseStatisticsCollector):
             An instance of the EpisodePolicyGradientStatistics dataclass.
 
         """
-
         steps = self.steps_cls(sample_steps=self.steps)
 
         T = steps.rewards.size
         total_expected_rewards = np.matmul(steps.rewards, np.tril(np.ones(T))) / T
+
+        baseline_features = None
+        if self.baseline is not None:
+            baseline_features = self.baseline.calculate_features(steps.observations, np.arange(T))
+            logger.debug('Substracting baseline from total expected rewards.')
+            total_expected_rewards -= self.baseline.calculate_baseline(
+                steps.observations,
+                np.arange(T),
+                feature_matrix=baseline_features,
+            )
 
         return EpisodePolicyGradientStatistics(
             total_reward=np.sum(steps.rewards),
             observations=steps.observations,
             actions=steps.actions,
             total_expected_rewards=total_expected_rewards,
+            baseline_features=baseline_features,
+            baseline_targets=None if self.baseline is None else total_expected_rewards,
         )
 
     @classmethod

--- a/src/tfrlrl/sampling/statistics_collection.py
+++ b/src/tfrlrl/sampling/statistics_collection.py
@@ -51,7 +51,6 @@ class EpisocidPolicyGradientStatisticsCollector(BaseStatisticsCollector):
     """
     Statistics collector for episodic-level statistics collection.
 
-<<<<<<< HEAD
     This class can be used to collect statistics for episodes sampled from environments. In
     particular, it collects the actions, observations and total future rewards for all of the
     steps in an episode.
@@ -102,6 +101,7 @@ class EpisocidPolicyGradientStatisticsCollector(BaseStatisticsCollector):
             An instance of the EpisodePolicyGradientStatistics dataclass.
 
         """
+
         steps = self.steps_cls(sample_steps=self.steps)
 
         T = steps.rewards.size

--- a/src/tfrlrl/sampling/statistics_collection.py
+++ b/src/tfrlrl/sampling/statistics_collection.py
@@ -6,7 +6,7 @@ from typing import List
 import numpy as np
 
 from tfrlrl.baselines.linear import Baseline
-from tfrlrl.data_models.statistics import BaseStatistics
+from tfrlrl.data_models.statistics import BaseStatistics, StatisticsException
 from tfrlrl.data_models.step import construct_step_dataclasses
 
 logger = logging.getLogger(__name__)
@@ -138,9 +138,19 @@ class EpisocidPolicyGradientStatisticsCollector(BaseStatisticsCollector):
             An instance of the EpisodePolicyGradientStatistics dataclass.
 
         """
+        baseline_features = [x.baseline_features for x in statistics]
+        baseline_targets = [x.baseline_targets for x in statistics]
+
+        if any([x is None for x in baseline_features]) and any([x is not None for x in baseline_features]):
+            raise StatisticsException('All baseline features should either be None or a NumPy array.')
+        if any([x is None for x in baseline_targets]) and any([x is not None for x in baseline_targets]):
+            raise StatisticsException('All baseline features should either be None or a NumPy array.')
+
         return EpisodePolicyGradientStatistics(
             total_reward=np.array([x.total_reward for x in statistics]),
             observations=np.concatenate([x.observations for x in statistics], axis=-1),
             actions=np.concatenate([x.actions for x in statistics], axis=-1),
             total_expected_rewards=np.concatenate([x.total_expected_rewards for x in statistics]),
+            baseline_features=baseline_features or None,
+            baseline_targets=baseline_targets or None,
         )

--- a/src/tfrlrl/sampling/statistics_collection.py
+++ b/src/tfrlrl/sampling/statistics_collection.py
@@ -1,14 +1,13 @@
 import logging
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import List
+from typing import List, Optional
 
 import numpy as np
 
 from tfrlrl.baselines.linear import Baseline
 from tfrlrl.data_models.statistics import BaseStatistics
 from tfrlrl.data_models.step import construct_step_dataclasses
-from tfrlrl.data_models.statistics import BaseStatistics
 from tfrlrl.sampling.utils import merge_optional_statistics
 
 logger = logging.getLogger(__name__)
@@ -62,20 +61,24 @@ class EpisocidPolicyGradientStatisticsCollector(BaseStatisticsCollector):
     Attributes:
         steps_cls: A dataclass for aggregating a collection of steps.
         steps: The collection of steps collected to date.
+        baseline: An instance of a baseline class, if one was given during class construction.
 
     """
 
-    def __init__(self, env_id: str):
+    def __init__(self, env_id: str, baseline: Optional[Baseline] = None):
         """
         Initialise the policy-gradients statistics collector.
 
         Args:
             env_id: The I.D. of the environment from which to collect statistics.
+            baseline: If given, an instance of the baseline class, which will be used for
+            variance reduction when estimating policy gradients.
 
         """
         _, _, self.steps_cls = construct_step_dataclasses(
             env_id,
         )
+        self.baseline = baseline
         self.steps = []
 
     def reset(self) -> None:

--- a/src/tfrlrl/sampling/statistics_collection.py
+++ b/src/tfrlrl/sampling/statistics_collection.py
@@ -1,7 +1,7 @@
 import logging
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import List, Optional
+from typing import Any, Dict, List, Optional
 
 import numpy as np
 
@@ -11,31 +11,6 @@ from tfrlrl.data_models.step import construct_step_dataclasses
 from tfrlrl.sampling.utils import merge_optional_statistics
 
 logger = logging.getLogger(__name__)
-
-
-class BaseStatisticsCollector(ABC):
-    """Base class for collecting statistics during sampling."""
-
-    @abstractmethod
-    def reset(self):
-        """Reset the statistics in the collector."""
-        ...
-
-    @abstractmethod
-    def collect_step_statistics(self, sample) -> None:
-        """Collect statistics from a sample step."""
-        ...
-
-    @abstractmethod
-    def aggregate_statistics(self) -> BaseStatistics:
-        """Aggregate the statistics collected by the collector."""
-        ...
-
-    @classmethod
-    @abstractmethod
-    def merge_statistics(cls) -> BaseStatistics:
-        """Merge the statistics collected by different aggregations of statistics collector(s)."""
-        ...
 
 
 @dataclass
@@ -50,6 +25,82 @@ class EpisodePolicyGradientStatistics(BaseStatistics):
     baseline_targets: np.ndarray = None
 
 
+class BaseStatisticsCollector(ABC):
+    """
+    Base class for collecting statistics during sampling.
+
+    Attributes:
+        steps_cls: A dataclass for aggregating a collection of steps.
+        baseline: An instance of a baseline class, if one was given during class construction.
+
+    """
+
+    def __init__(self, env_id: str, baseline: Optional[Baseline] = None):
+        """
+        Initialise the base statistics collector.
+
+        Args:
+            env_id: The I.D. of the environment from which to collect statistics.
+            baseline: If given, an instance of the baseline class, which will be used for
+            variance reduction when estimating policy gradients.
+
+        """
+        _, _, self.steps_cls = construct_step_dataclasses(
+            env_id,
+        )
+        self.baseline = baseline
+
+    def update(self, baseline_state_dict: Optional[Dict[str, Any]] = None) -> None:
+        """
+        Update the the statistic collector, e.g., the baseline calculations.
+
+        Args:
+            baseline_state_dict: The state dictionary of the baseline.
+
+        """
+        if baseline_state_dict is not None:
+            self.baseline.update(state_dict=baseline_state_dict)
+
+    @abstractmethod
+    def reset(self) -> None:
+        """Reset the statistics in the collector."""
+        ...
+
+    @abstractmethod
+    def collect_step_statistics(self, sample) -> None:
+        """
+        Collect statistics for the given step sample.
+
+        This function collects the statistics for the given step sample.
+
+        Args:
+            sample: The step sample from which to calculate the statistics.
+
+        """
+        ...
+
+    @abstractmethod
+    def aggregate_statistics(self) -> BaseStatistics:
+        """
+        Aggregate the statistics collected to date.
+
+        This function calculates the total future rewards of the observed examples. If a baseline
+        is specified, then the baselines will be calculated and subtracted from the total future
+        rewards.
+
+        Returns:
+            An instance of the EpisodePolicyGradientStatistics dataclass.
+
+        """
+        ...
+
+    @classmethod
+    @abstractmethod
+    def merge_statistics(cls, statistics: List[BaseStatistics]) -> BaseStatistics:
+        """Merge the statistics collected by different aggregations of statistics collector(s)."""
+        ...
+
+
 class EpisocidPolicyGradientStatisticsCollector(BaseStatisticsCollector):
     """
     Statistics collector for episodic-level statistics collection.
@@ -60,8 +111,8 @@ class EpisocidPolicyGradientStatisticsCollector(BaseStatisticsCollector):
 
     Attributes:
         steps_cls: A dataclass for aggregating a collection of steps.
-        steps: The collection of steps collected to date.
         baseline: An instance of a baseline class, if one was given during class construction.
+        steps: The collection of steps collected to date.
 
     """
 
@@ -75,10 +126,10 @@ class EpisocidPolicyGradientStatisticsCollector(BaseStatisticsCollector):
             variance reduction when estimating policy gradients.
 
         """
-        _, _, self.steps_cls = construct_step_dataclasses(
-            env_id,
+        super().__init__(
+            env_id=env_id,
+            baseline=baseline,
         )
-        self.baseline = baseline
         self.steps = []
 
     def reset(self) -> None:
@@ -101,8 +152,9 @@ class EpisocidPolicyGradientStatisticsCollector(BaseStatisticsCollector):
         """
         Aggregate the statistics collected to date.
 
-        This function calculates the policy gradient from the collected episode. It then returns this
-        gradient and the rewards.
+        This function calculates the total future rewards of the observed examples. If a baseline
+        is specified, then the baselines will be calculated and subtracted from the total future
+        rewards.
 
         Returns:
             An instance of the EpisodePolicyGradientStatistics dataclass.

--- a/src/tfrlrl/sampling/utils.py
+++ b/src/tfrlrl/sampling/utils.py
@@ -12,11 +12,17 @@ def merge_optional_statistics(
     """
     Merge the optional statistic from the given list of statistics and merge them.
 
-    :param statistics: A list of statistics from which to retrieve an optional statistics and merge them.
-    :param attribute: The (optional) statistic from the statistics class that is to be retrieved and merged.
-    :param concatenate_axis: The axis along which to merge the statistic.
-    :return: The merged statistics or None.
-    :raises: This function raises a StatisticsException exception if some, but not all, of the statistics are present.
+    Args:
+        statistics: A list of statistics from which to retrieve an optional statistics and merge them.
+        attribute: The (optional) statistic from the statistics class that is to be retrieved and merged.
+        concatenate_axis: The axis along which to merge the statistic.
+
+    Returns:
+        The merged statistics or None.
+
+    Raises:
+        This function raises a StatisticsException exception if some, but not all, of the statistics are present.
+
     """
     attributes = [getattr(x, attribute) for x in statistics]
     if any([x is None for x in attributes]) and any([x is not None for x in attributes]):

--- a/src/tfrlrl/sampling/utils.py
+++ b/src/tfrlrl/sampling/utils.py
@@ -1,0 +1,28 @@
+from typing import List
+
+import numpy as np
+import numpy.typing as npt
+
+from tfrlrl.data_models.statistics import BaseStatistics, StatisticsException
+
+
+def merge_optional_statistics(
+    statistics: List[BaseStatistics], attribute: str, concatenate_axis: int = 0
+) -> npt.ArrayLike:
+    """
+    Merge the optional statistic from the given list of statistics and merge them.
+
+    :param statistics: A list of statistics from which to retrieve an optional statistics and merge them.
+    :param attribute: The (optional) statistic from the statistics class that is to be retrieved and merged.
+    :param concatenate_axis: The axis along which to merge the statistic.
+    :return: The merged statistics or None.
+    :raises: This function raises a StatisticsException exception if some, but not all, of the statistics are present.
+    """
+    attributes = [getattr(x, attribute) for x in statistics]
+    if any([x is None for x in attributes]) and any([x is not None for x in attributes]):
+        raise StatisticsException('All baseline features should either be None or a NumPy array.')
+    if all([x is not None for x in attributes]):
+        attributes = np.concatenate(attributes, axis=concatenate_axis)
+    else:
+        attributes = None
+    return attributes

--- a/src/tfrlrl/training_algorithms/sgd.py
+++ b/src/tfrlrl/training_algorithms/sgd.py
@@ -1,6 +1,7 @@
 """Stochastic Gradient Descent training algorithm."""
 
 import logging
+from typing import Optional
 
 import numpy as np
 import ray
@@ -14,6 +15,7 @@ from torch.optim import (
 )
 
 from tfrlrl import settings
+from tfrlrl.baselines.linear import Baseline
 from tfrlrl.policies.base import BasePyTorchPolicy
 from tfrlrl.sampling.episodic_sampler import (
     EpisodicSampler,
@@ -31,6 +33,7 @@ def train_policy_gradient(
     n_episodes: int,
     alpha: float,
     n_samplers: int = 1,
+    baseline: Optional[Baseline] = None,
     **kwargs,
 ) -> BasePyTorchPolicy:
     """
@@ -43,13 +46,17 @@ def train_policy_gradient(
         n_episodes: The number of episodes to sample during each policy update.
         alpha: The initial step size to take in stochastic gradient ascent.
         n_samplers: The number of samplers to used to sample from the environment.
+        baseline: An instance of a baseline class, if one is given.
         kwargs: Additional keyword arguments to pass to the EpisodicSampler (e.g., is_slippery).
 
     Returns:
         The trained policy.
 
     """
-    statistics_collector = EpisocidPolicyGradientStatisticsCollector(env_id)
+    statistics_collector = EpisocidPolicyGradientStatisticsCollector(
+        env_id,
+        baseline=baseline,
+    )
     optimizer = SGD(policy.get_parameters(), lr=alpha)
 
     if n_samplers > 1:
@@ -93,7 +100,13 @@ def train_policy_gradient(
             logger.info('Policy update: %s', n)
             logger.info('Average total episodic reward: %s', np.average(statistics.total_reward))
 
+        if baseline:
+            baseline.fit(statistics.baseline_features, statistics.baseline_targets)
+
         sampler.reset()
-        sampler.update(state_dict=policy.get_state())
+        sampler.update(
+            policy_state_dict=policy.get_state(),
+            baseline_state_dict=baseline.get_state() if baseline else None,
+        )
 
     return policy

--- a/tests/tfrlrl/baselines/__init__.py
+++ b/tests/tfrlrl/baselines/__init__.py
@@ -1,0 +1,1 @@
+"""Package for baseline algorithms in tfrlrl, i.e. variance reduction techniques."""

--- a/tests/tfrlrl/baselines/test_linear.py
+++ b/tests/tfrlrl/baselines/test_linear.py
@@ -31,7 +31,7 @@ class TestLinearBaseline:
             n_steps: The number of time steps.
 
         """
-        baseline = LinearBaseline()
+        baseline = LinearBaseline(env_id)
 
         # Create random observations with correct shape
         observation_matrix = np.random.randn(obs_dim, n_steps)
@@ -46,13 +46,14 @@ class TestLinearBaseline:
             f'Feature matrix shape {features.shape} does not match expected shape {expected_shape}'
         )
 
+    @pytest.mark.parametrize('env_id', ['CartPole-v1', 'MountainCar-v0'])
     @given(
         n_steps=st.integers(min_value=5, max_value=50),
         obs_dim=st.integers(min_value=1, max_value=10),
         seed=st.integers(min_value=0, max_value=10000),
     )
     @settings(deadline=2000)
-    def test_calculate_features_observation_clipping(self, n_steps: int, obs_dim: int, seed: int):
+    def test_calculate_features_observation_clipping(self, env_id: str, n_steps: int, obs_dim: int, seed: int):
         """
         Test that observations are clipped to the range [-10, 10] in the feature calculation.
 
@@ -60,13 +61,14 @@ class TestLinearBaseline:
         being included in the feature matrix.
 
         Args:
+            env_id: The Gymnasium environment ID used for baseline initialisation.
             n_steps: The number of time steps.
             obs_dim: The dimensionality of the observation space.
             seed: Random seed for reproducibility.
 
         """
         np.random.seed(seed)
-        baseline = LinearBaseline()
+        baseline = LinearBaseline(env_id)
 
         # Create observations with values outside [-10, 10] range
         observation_matrix = np.random.uniform(low=-100, high=100, size=(obs_dim, n_steps))
@@ -89,9 +91,10 @@ class TestLinearBaseline:
         assert np.all(observation_squared_features >= 0), 'Some squared observation features are negative'
         assert np.all(observation_squared_features <= 100), 'Some squared observation features are above 100'
 
+    @pytest.mark.parametrize('env_id', ['CartPole-v1', 'MountainCar-v0'])
     @given(obs_dim=st.integers(min_value=1, max_value=10))
     @settings(deadline=2000)
-    def test_calculate_features_time_step_normalization(self, obs_dim: int):
+    def test_calculate_features_time_step_normalization(self, env_id: str, obs_dim: int):
         """
         Test that time steps are correctly normalized by 100.0 in the feature calculation.
 
@@ -102,10 +105,11 @@ class TestLinearBaseline:
         - Column 2*obs_dim + 3: 1.0 (constant)
 
         Args:
+            env_id: The Gymnasium environment ID used for baseline initialisation.
             obs_dim: The dimensionality of the observation space.
 
         """
-        baseline = LinearBaseline()
+        baseline = LinearBaseline(env_id)
 
         # Create specific time steps to test normalization
         time_steps = np.array([0, 50, 100, 200])
@@ -175,7 +179,7 @@ class TestLinearBaseline:
             n_steps: The number of steps to sample from the environment.
 
         """
-        baseline = LinearBaseline()
+        baseline = LinearBaseline(env_id)
         env = gym.make(env_id)
 
         # Determine observation dimension based on environment
@@ -254,7 +258,7 @@ class TestLinearBaseline:
         feature_dim = 2 * obs_dim + 4
         if coeffs == 'random':
             coeffs = np.random.randn(feature_dim)
-        baseline = LinearBaseline(coeffs=coeffs)
+        baseline = LinearBaseline(env_id, coeffs=coeffs)
 
         # Sample steps from the environment
         sampler = Sampler(env_id, n_steps=n_steps)

--- a/tests/tfrlrl/baselines/test_linear.py
+++ b/tests/tfrlrl/baselines/test_linear.py
@@ -260,8 +260,11 @@ class TestLinearBaseline:
 
         features = baseline.calculate_features(observation_matrix, time_steps_array)
         baseline_values = baseline.calculate_baseline(observation_matrix, time_steps_array)
+
+        # Verify shape of baseline
         assert baseline_values.shape == (n_steps,)
 
+        # Varify value of baseline
         if coeffs is None:
             np.testing.assert_allclose(
                 baseline_values,

--- a/tests/tfrlrl/baselines/test_linear.py
+++ b/tests/tfrlrl/baselines/test_linear.py
@@ -1,0 +1,214 @@
+import gymnasium as gym
+import numpy as np
+import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from tfrlrl.baselines.linear import LinearBaseline
+from tfrlrl.sampling.sampler import Sampler
+
+
+class TestLinearBaseline:
+    """Class that encapsulates the unit tests for the LinearBaseline class."""
+
+    @pytest.mark.parametrize('env_id,obs_dim', [('CartPole-v1', 4), ('MountainCar-v0', 2)])
+    @given(n_steps=st.integers(min_value=5, max_value=100))
+    @settings(deadline=2000)
+    def test_calculate_features_output_shape(self, env_id: str, obs_dim: int, n_steps: int):
+        """
+        Test that calculate_features returns a feature matrix with the correct shape.
+
+        The feature matrix should have shape (n_steps, 2*obs_dim + 4) where:
+        - obs_dim features for original observations
+        - obs_dim features for squared observations
+        - 3 features for time step polynomial (t/100, (t/100)^2, (t/100)^3)
+        - 1 constant feature (ones)
+
+        :param env_id: The Gymnasium environment ID.
+        :param obs_dim: The dimensionality of the observation space.
+        :param n_steps: The number of time steps.
+        """
+        baseline = LinearBaseline()
+
+        # Create random observations with correct shape
+        observation_matrix = np.random.randn(n_steps, obs_dim)
+        time_steps = np.arange(n_steps)
+
+        # Calculate features
+        features = baseline.calculate_features(observation_matrix, time_steps)
+
+        # Verify shape
+        expected_shape = (n_steps, 2 * obs_dim + 4)
+        assert features.shape == expected_shape, (
+            f'Feature matrix shape {features.shape} does not match expected shape {expected_shape}'
+        )
+
+    @given(
+        n_steps=st.integers(min_value=5, max_value=50),
+        obs_dim=st.integers(min_value=1, max_value=10),
+        seed=st.integers(min_value=0, max_value=10000),
+    )
+    @settings(deadline=2000)
+    def test_calculate_features_observation_clipping(self, n_steps: int, obs_dim: int, seed: int):
+        """
+        Test that observations are clipped to the range [-10, 10] in the feature calculation.
+
+        This test verifies that extreme observation values are properly clipped before
+        being included in the feature matrix.
+
+        :param n_steps: The number of time steps.
+        :param obs_dim: The dimensionality of the observation space.
+        :param seed: Random seed for reproducibility.
+        """
+        np.random.seed(seed)
+        baseline = LinearBaseline()
+
+        # Create observations with values outside [-10, 10] range
+        observation_matrix = np.random.uniform(low=-100, high=100, size=(n_steps, obs_dim))
+        time_steps = np.arange(n_steps)
+
+        # Calculate features
+        features = baseline.calculate_features(observation_matrix, time_steps)
+
+        # Extract observation features (first 2*obs_dim columns)
+        # First obs_dim columns are clipped observations
+        # Next obs_dim columns are clipped observations squared
+        observation_features = features[:, :obs_dim]
+        observation_squared_features = features[:, obs_dim : 2 * obs_dim]
+
+        # Verify that observation features are clipped to [-10, 10]
+        assert np.all(observation_features >= -10), 'Some observation features are below -10'
+        assert np.all(observation_features <= 10), 'Some observation features are above 10'
+
+        # Verify that squared observation features are in [0, 100]
+        assert np.all(observation_squared_features >= 0), 'Some squared observation features are negative'
+        assert np.all(observation_squared_features <= 100), 'Some squared observation features are above 100'
+
+    @given(obs_dim=st.integers(min_value=1, max_value=10))
+    @settings(deadline=2000)
+    def test_calculate_features_time_step_normalization(self, obs_dim: int):
+        """
+        Test that time steps are correctly normalized by 100.0 in the feature calculation.
+
+        The feature matrix should contain time step features as:
+        - Column 2*obs_dim: t/100
+        - Column 2*obs_dim + 1: (t/100)^2
+        - Column 2*obs_dim + 2: (t/100)^3
+        - Column 2*obs_dim + 3: 1.0 (constant)
+
+        :param obs_dim: The dimensionality of the observation space.
+        """
+        baseline = LinearBaseline()
+
+        # Create specific time steps to test normalization
+        time_steps = np.array([0, 50, 100, 200])
+        n_steps = len(time_steps)
+
+        # Create dummy observations (values don't matter for this test)
+        observation_matrix = np.zeros((n_steps, obs_dim))
+
+        # Calculate features
+        features = baseline.calculate_features(observation_matrix, time_steps)
+
+        # Extract time step features (columns 2*obs_dim to 2*obs_dim + 3)
+        time_feature_t1 = features[:, 2 * obs_dim]  # t/100
+        time_feature_t2 = features[:, 2 * obs_dim + 1]  # (t/100)^2
+        time_feature_t3 = features[:, 2 * obs_dim + 2]  # (t/100)^3
+        constant_feature = features[:, 2 * obs_dim + 3]  # constant (ones)
+
+        # Expected normalized time steps
+        expected_t1 = time_steps / 100.0
+        expected_t2 = (time_steps / 100.0) ** 2
+        expected_t3 = (time_steps / 100.0) ** 3
+
+        # Verify time step normalization
+        np.testing.assert_allclose(
+            time_feature_t1,
+            expected_t1,
+            rtol=1e-6,
+            atol=1e-9,
+            err_msg='Linear time feature (t/100) does not match expected values',
+        )
+        np.testing.assert_allclose(
+            time_feature_t2,
+            expected_t2,
+            rtol=1e-6,
+            atol=1e-9,
+            err_msg='Quadratic time feature (t/100)^2 does not match expected values',
+        )
+        np.testing.assert_allclose(
+            time_feature_t3,
+            expected_t3,
+            rtol=1e-6,
+            atol=1e-9,
+            err_msg='Cubic time feature (t/100)^3 does not match expected values',
+        )
+
+        # Verify constant feature is all ones
+        np.testing.assert_allclose(
+            constant_feature,
+            np.ones(n_steps),
+            rtol=1e-6,
+            atol=1e-9,
+            err_msg='Constant feature should be all ones',
+        )
+
+    @pytest.mark.parametrize('env_id', ['CartPole-v1', 'MountainCar-v0'])
+    @given(n_steps=st.integers(min_value=10, max_value=50))
+    @settings(deadline=2000)
+    def test_calculate_features_with_sampled_episodes(self, env_id: str, n_steps: int):
+        """
+        Test calculate_features with real episode data sampled from a Gymnasium environment.
+
+        This integration test verifies that the feature calculation works correctly
+        with actual environment observations and time steps.
+
+        :param env_id: The Gymnasium environment ID to sample from.
+        :param n_steps: The number of steps to sample from the environment.
+        """
+        baseline = LinearBaseline()
+        env = gym.make(env_id)
+
+        # Determine observation dimension based on environment
+        if hasattr(env.observation_space, 'n'):
+            # Discrete observation space (like FrozenLake)
+            raise EnvironmentError('Linear baseline can only be used on continuous observation spaces.')
+        else:
+            # Box observation space (like CartPole)
+            obs_dim = env.observation_space.shape[0]
+
+        # Sample steps from the environment
+        sampler = Sampler(env_id, n_steps=n_steps)
+        observations = []
+        time_steps = []
+
+        for sample in sampler:
+            observations.append(sample.observation)
+            time_steps.append(sample.time_step)
+
+        # Convert to numpy arrays
+        observation_matrix = np.concatenate(observations, axis=1).T
+        time_steps_array = np.array(time_steps)
+
+        # Calculate features
+        features = baseline.calculate_features(observation_matrix, time_steps_array)
+
+        # Verify shape
+        expected_shape = (n_steps, 2 * obs_dim + 4)
+        assert features.shape == expected_shape, (
+            f'Feature matrix shape {features.shape} does not match expected shape {expected_shape}'
+        )
+
+        # Verify no NaN or Inf values in features
+        assert not np.any(np.isnan(features)), 'Feature matrix contains NaN values'
+        assert not np.any(np.isinf(features)), 'Feature matrix contains infinite values'
+
+        # Verify constant column is all ones
+        constant_column = features[:, -1]
+        np.testing.assert_allclose(
+            constant_column,
+            np.ones(n_steps),
+            rtol=1e-6,
+            atol=1e-9,
+            err_msg='Constant feature column should be all ones',
+        )

--- a/tests/tfrlrl/baselines/test_linear.py
+++ b/tests/tfrlrl/baselines/test_linear.py
@@ -1,5 +1,6 @@
 import gymnasium as gym
 import numpy as np
+import numpy.typing as npt
 import pytest
 from hypothesis import given, settings
 from hypothesis import strategies as st
@@ -211,4 +212,83 @@ class TestLinearBaseline:
             rtol=1e-6,
             atol=1e-9,
             err_msg='Constant feature column should be all ones',
+        )
+
+    @pytest.mark.parametrize('env_id', ['CartPole-v1', 'MountainCar-v0'])
+    @pytest.mark.parametrize('coeffs', [None, 'random'])
+    @given(n_steps=st.integers(min_value=10, max_value=50))
+    @settings(deadline=2000)
+    def test_calculate_baseline_with_sampled_episodes(self, env_id: str, n_steps: int, coeffs: npt.ArrayLike):
+        """
+        Test calculate_baseline with real episode data sampled from a Gymnasium environment.
+
+        This integration test verifies that the baseline calculation works correctly
+        with actual environment observations and time steps, both before and after
+        setting coefficients.
+
+        :param env_id: The Gymnasium environment ID to sample from.
+        :param n_steps: The number of steps to sample from the environment.
+        :param coeffs: The coefficients of the baseline.
+        """
+        env = gym.make(env_id)
+
+        # Determine observation dimension based on environment
+        if hasattr(env.observation_space, 'n'):
+            # Discrete observation space
+            raise EnvironmentError('Linear baseline can only be used on continuous observation spaces.')
+        else:
+            # Box observation space
+            obs_dim = env.observation_space.shape[0]
+
+        feature_dim = 2 * obs_dim + 4
+        if coeffs == 'random':
+            coeffs = np.random.randn(feature_dim)
+        baseline = LinearBaseline(coeffs=coeffs)
+
+        # Sample steps from the environment
+        sampler = Sampler(env_id, n_steps=n_steps)
+        observations = []
+        time_steps = []
+
+        for sample in sampler:
+            observations.append(sample.observation)
+            time_steps.append(sample.time_step)
+
+        # Convert to numpy arrays with shape (obs_dim, n_steps)
+        observation_matrix = np.concatenate(observations, axis=1)
+        time_steps_array = np.array(time_steps)
+
+        features = baseline.calculate_features(observation_matrix, time_steps_array)
+        baseline_values = baseline.calculate_baseline(observation_matrix, time_steps_array)
+        assert baseline_values.shape == (n_steps,)
+
+        if coeffs is None:
+            np.testing.assert_allclose(
+                baseline_values,
+                np.zeros(n_steps),
+                rtol=1e-6,
+                atol=1e-9,
+            )
+        else:
+            np.testing.assert_allclose(
+                baseline_values,
+                np.dot(coeffs, features),
+                rtol=1e-6,
+                atol=1e-9,
+            )
+
+        # Verify no NaN or Inf values
+        assert not np.any(np.isnan(baseline_values))
+        assert not np.any(np.isinf(baseline_values))
+
+        # Verify baseline is the same when using pre-calculated features.
+        np.testing.assert_allclose(
+            baseline.calculate_baseline(observation_matrix, time_steps_array),
+            baseline.calculate_baseline(
+                observation_matrix,
+                time_steps_array,
+                feature_matrix=features,
+            ),
+            rtol=1e-6,
+            atol=1e-9,
         )

--- a/tests/tfrlrl/baselines/test_linear.py
+++ b/tests/tfrlrl/baselines/test_linear.py
@@ -25,9 +25,11 @@ class TestLinearBaseline:
         - 3 features for time step polynomial (t/100, (t/100)^2, (t/100)^3)
         - 1 constant feature (ones)
 
-        :param env_id: The Gymnasium environment ID.
-        :param obs_dim: The dimensionality of the observation space.
-        :param n_steps: The number of time steps.
+        Args:
+            env_id: The Gymnasium environment ID.
+            obs_dim: The dimensionality of the observation space.
+            n_steps: The number of time steps.
+
         """
         baseline = LinearBaseline()
 
@@ -57,9 +59,11 @@ class TestLinearBaseline:
         This test verifies that extreme observation values are properly clipped before
         being included in the feature matrix.
 
-        :param n_steps: The number of time steps.
-        :param obs_dim: The dimensionality of the observation space.
-        :param seed: Random seed for reproducibility.
+        Args:
+            n_steps: The number of time steps.
+            obs_dim: The dimensionality of the observation space.
+            seed: Random seed for reproducibility.
+
         """
         np.random.seed(seed)
         baseline = LinearBaseline()
@@ -97,7 +101,9 @@ class TestLinearBaseline:
         - Column 2*obs_dim + 2: (t/100)^3
         - Column 2*obs_dim + 3: 1.0 (constant)
 
-        :param obs_dim: The dimensionality of the observation space.
+        Args:
+            obs_dim: The dimensionality of the observation space.
+
         """
         baseline = LinearBaseline()
 
@@ -164,8 +170,10 @@ class TestLinearBaseline:
         This integration test verifies that the feature calculation works correctly
         with actual environment observations and time steps.
 
-        :param env_id: The Gymnasium environment ID to sample from.
-        :param n_steps: The number of steps to sample from the environment.
+        Args:
+            env_id: The Gymnasium environment ID to sample from.
+            n_steps: The number of steps to sample from the environment.
+
         """
         baseline = LinearBaseline()
         env = gym.make(env_id)
@@ -226,9 +234,12 @@ class TestLinearBaseline:
         with actual environment observations and time steps, both before and after
         setting coefficients.
 
-        :param env_id: The Gymnasium environment ID to sample from.
-        :param n_steps: The number of steps to sample from the environment.
-        :param coeffs: The coefficients of the baseline.
+
+        Args:
+            env_id: The Gymnasium environment ID to sample from.
+            n_steps: The number of steps to sample from the environment.
+            coeffs: The coefficients of the baseline.
+
         """
         env = gym.make(env_id)
 

--- a/tests/tfrlrl/baselines/test_linear.py
+++ b/tests/tfrlrl/baselines/test_linear.py
@@ -18,7 +18,7 @@ class TestLinearBaseline:
         """
         Test that calculate_features returns a feature matrix with the correct shape.
 
-        The feature matrix should have shape (n_steps, 2*obs_dim + 4) where:
+        The feature matrix should have shape (2*obs_dim + 4, n_steps) where:
         - obs_dim features for original observations
         - obs_dim features for squared observations
         - 3 features for time step polynomial (t/100, (t/100)^2, (t/100)^3)
@@ -31,14 +31,14 @@ class TestLinearBaseline:
         baseline = LinearBaseline()
 
         # Create random observations with correct shape
-        observation_matrix = np.random.randn(n_steps, obs_dim)
+        observation_matrix = np.random.randn(obs_dim, n_steps)
         time_steps = np.arange(n_steps)
 
         # Calculate features
         features = baseline.calculate_features(observation_matrix, time_steps)
 
         # Verify shape
-        expected_shape = (n_steps, 2 * obs_dim + 4)
+        expected_shape = (2 * obs_dim + 4, n_steps)
         assert features.shape == expected_shape, (
             f'Feature matrix shape {features.shape} does not match expected shape {expected_shape}'
         )
@@ -64,7 +64,7 @@ class TestLinearBaseline:
         baseline = LinearBaseline()
 
         # Create observations with values outside [-10, 10] range
-        observation_matrix = np.random.uniform(low=-100, high=100, size=(n_steps, obs_dim))
+        observation_matrix = np.random.uniform(low=-100, high=100, size=(obs_dim, n_steps))
         time_steps = np.arange(n_steps)
 
         # Calculate features
@@ -73,8 +73,8 @@ class TestLinearBaseline:
         # Extract observation features (first 2*obs_dim columns)
         # First obs_dim columns are clipped observations
         # Next obs_dim columns are clipped observations squared
-        observation_features = features[:, :obs_dim]
-        observation_squared_features = features[:, obs_dim : 2 * obs_dim]
+        observation_features = features[:obs_dim, :]
+        observation_squared_features = features[obs_dim : 2 * obs_dim, :]
 
         # Verify that observation features are clipped to [-10, 10]
         assert np.all(observation_features >= -10), 'Some observation features are below -10'
@@ -105,16 +105,16 @@ class TestLinearBaseline:
         n_steps = len(time_steps)
 
         # Create dummy observations (values don't matter for this test)
-        observation_matrix = np.zeros((n_steps, obs_dim))
+        observation_matrix = np.zeros((obs_dim, n_steps))
 
         # Calculate features
         features = baseline.calculate_features(observation_matrix, time_steps)
 
         # Extract time step features (columns 2*obs_dim to 2*obs_dim + 3)
-        time_feature_t1 = features[:, 2 * obs_dim]  # t/100
-        time_feature_t2 = features[:, 2 * obs_dim + 1]  # (t/100)^2
-        time_feature_t3 = features[:, 2 * obs_dim + 2]  # (t/100)^3
-        constant_feature = features[:, 2 * obs_dim + 3]  # constant (ones)
+        time_feature_t1 = features[2 * obs_dim, :]  # t/100
+        time_feature_t2 = features[2 * obs_dim + 1, :]  # (t/100)^2
+        time_feature_t3 = features[2 * obs_dim + 2, :]  # (t/100)^3
+        constant_feature = features[2 * obs_dim + 3, :]  # constant (ones)
 
         # Expected normalized time steps
         expected_t1 = time_steps / 100.0
@@ -187,14 +187,14 @@ class TestLinearBaseline:
             time_steps.append(sample.time_step)
 
         # Convert to numpy arrays
-        observation_matrix = np.concatenate(observations, axis=1).T
+        observation_matrix = np.concatenate(observations, axis=1)
         time_steps_array = np.array(time_steps)
 
         # Calculate features
         features = baseline.calculate_features(observation_matrix, time_steps_array)
 
         # Verify shape
-        expected_shape = (n_steps, 2 * obs_dim + 4)
+        expected_shape = (2 * obs_dim + 4, n_steps)
         assert features.shape == expected_shape, (
             f'Feature matrix shape {features.shape} does not match expected shape {expected_shape}'
         )
@@ -204,7 +204,7 @@ class TestLinearBaseline:
         assert not np.any(np.isinf(features)), 'Feature matrix contains infinite values'
 
         # Verify constant column is all ones
-        constant_column = features[:, -1]
+        constant_column = features[-1, :]
         np.testing.assert_allclose(
             constant_column,
             np.ones(n_steps),

--- a/tests/tfrlrl/sampling/test_episodic_sampler.py
+++ b/tests/tfrlrl/sampling/test_episodic_sampler.py
@@ -133,7 +133,7 @@ class TestEpisodicSampler:
                 assert isinstance(step.info, dict)
 
         sampler.reset()
-        sampler.update(state_dict=policy.get_state())
+        sampler.update(policy_state_dict=policy.get_state())
 
         statistics = list(sampler)
         assert len(statistics) == n_episodes

--- a/tests/tfrlrl/sampling/test_statistics_collection.py
+++ b/tests/tfrlrl/sampling/test_statistics_collection.py
@@ -4,10 +4,10 @@ import pytest
 from hypothesis import given, settings
 from hypothesis import strategies as st
 
+from tfrlrl.baselines.linear import LinearBaseline
 from tfrlrl.data_models.statistics import StatisticsException
 from tfrlrl.features.onehot import OneHotFeatureFunction
 from tfrlrl.policies.dense_neural_network import DenseNetworkPolicy
-from tfrlrl.baselines.linear import LinearBaseline
 from tfrlrl.policies.linear_soft_max import LinearSoftMax
 from tfrlrl.sampling.episodic_sampler import EpisodicSampler
 from tfrlrl.sampling.statistics_collection import EpisocidPolicyGradientStatisticsCollector
@@ -92,7 +92,10 @@ class TestEpisocidPolicyGradientStatisticsCollector:
             baseline = LinearBaseline()
         else:
             baseline = None
-        stats_collector = EpisocidPolicyGradientStatisticsCollector(baseline=baseline)
+        stats_collector = EpisocidPolicyGradientStatisticsCollector(
+            env_id=env_id,
+            baseline=baseline,
+        )
         sampler = EpisodicSampler(
             env_id,
             stats_collector,
@@ -190,14 +193,9 @@ class TestEpisocidPolicyGradientStatisticsCollector:
         :param n_episodes: The number of episodes to sample.
         """
         env = gym.make(env_id)
-        S = env.observation_space.n
-        A = env.action_space.n
 
         # Test currently works only for discrete observations spaces.
         n_dim = 1
-
-        # Verify dimensions
-        n_params = S * (A - 1)  # Number of policy parameters
 
         env = gym.make(env_id)
         feature_fn = OneHotFeatureFunction(env.observation_space.n, env.action_space.n)
@@ -208,7 +206,7 @@ class TestEpisocidPolicyGradientStatisticsCollector:
         else:
             baseline = None
         stats_collector = EpisocidPolicyGradientStatisticsCollector(
-            pol,
+            env_id=env_id,
             baseline=baseline,
         )
         sampler = EpisodicSampler(
@@ -222,10 +220,7 @@ class TestEpisocidPolicyGradientStatisticsCollector:
 
         # Verify return types
         assert isinstance(statistics.total_reward, np.ndarray)
-        assert isinstance(statistics.episode_gradient, np.ndarray)
-
         assert len(statistics.total_reward) == n_episodes
-        assert statistics.episode_gradient.shape == (n_params, n_episodes)
 
         if include_baseline:
             assert isinstance(statistics.baseline_features, np.ndarray)
@@ -238,7 +233,6 @@ class TestEpisocidPolicyGradientStatisticsCollector:
             assert statistics.baseline_targets is None
 
     @pytest.mark.parametrize('env_id', ['FrozenLake-v1'])
->>>>>>> da40c98 (remove duplication in merge_statistics)
     @given(n_episodes=st.integers(min_value=1, max_value=5))
     @settings(deadline=5000)
     def test_merge_statistics_with_inconsistent_baseline_statistics(self, env_id: str, n_episodes: int):
@@ -277,7 +271,6 @@ class TestEpisocidPolicyGradientStatisticsCollector:
             **env_kwargs,
         )
         statistics1 = sampler1.sample()
-
 
         stats_collector2 = EpisocidPolicyGradientStatisticsCollector(
             env_id=env_id,

--- a/tests/tfrlrl/sampling/test_statistics_collection.py
+++ b/tests/tfrlrl/sampling/test_statistics_collection.py
@@ -89,7 +89,7 @@ class TestEpisocidPolicyGradientStatisticsCollector:
         policy = LinearSoftMax(env_id, feature_fn)
 
         if include_baseline:
-            baseline = LinearBaseline()
+            baseline = LinearBaseline(env_id=env_id)
         else:
             baseline = None
         stats_collector = EpisocidPolicyGradientStatisticsCollector(
@@ -151,7 +151,7 @@ class TestEpisocidPolicyGradientStatisticsCollector:
             policy = LinearSoftMax(env_id, feature_fn)
 
         if include_baseline:
-            baseline = LinearBaseline()
+            baseline = LinearBaseline(env_id=env_id)
         else:
             baseline = None
 
@@ -198,9 +198,11 @@ class TestEpisocidPolicyGradientStatisticsCollector:
         """
         Test that merge_statistics returns statistics with expected dimensions.
 
-        :param env_id: The Gym environment ID to be used in testing.
-        :param include_baseline: A Boolean indicating whether to include a baseline class in the statistics collection.
-        :param n_episodes: The number of episodes to sample.
+        Args:
+            env_id: The Gym environment ID to be used in testing.
+            include_baseline: A Boolean indicating whether to include a baseline class in the statistics collection.
+            n_episodes: The number of episodes to sample.
+
         """
         env = gym.make(env_id)
 
@@ -216,7 +218,7 @@ class TestEpisocidPolicyGradientStatisticsCollector:
             policy = LinearSoftMax(env_id, feature_fn)
 
         if include_baseline:
-            baseline = LinearBaseline()
+            baseline = LinearBaseline(env_id=env_id)
         else:
             baseline = None
         stats_collector = EpisocidPolicyGradientStatisticsCollector(
@@ -245,15 +247,26 @@ class TestEpisocidPolicyGradientStatisticsCollector:
             assert statistics.baseline_features is None
             assert statistics.baseline_targets is None
 
-    @pytest.mark.parametrize('env_id', ['FrozenLake-v1'])
+    @pytest.mark.parametrize(
+        'env_id, include_baseline',
+        [
+            (
+                'InvertedPendulum-v5',
+                True,
+            ),
+        ],
+    )
     @given(n_episodes=st.integers(min_value=1, max_value=5))
     @settings(deadline=5000)
-    def test_merge_statistics_with_inconsistent_baseline_statistics(self, env_id: str, n_episodes: int):
+    def test_merge_statistics_with_inconsistent_baseline_statistics(
+        self, env_id: str, include_baseline: bool, n_episodes: int
+    ):
         """
         Test that merge_statistics raises an error when merging inconsistent baseline statistics.
 
         Args:
             env_id: The Gym environment ID to be used in testing.
+            include_baseline: A Boolean indicating whether to include a baseline class in the statistics collection.
             n_episodes: The number of episodes to sample.
 
         """
@@ -271,7 +284,11 @@ class TestEpisocidPolicyGradientStatisticsCollector:
             policy = LinearSoftMax(env_id, feature_fn)
             env_kwargs = {'is_slippery': False}
 
-        baseline = LinearBaseline()
+        if include_baseline:
+            baseline = LinearBaseline(env_id=env_id)
+        else:
+            baseline = None
+
         stats_collector1 = EpisocidPolicyGradientStatisticsCollector(
             env_id=env_id,
             baseline=baseline,

--- a/tests/tfrlrl/sampling/test_statistics_collection.py
+++ b/tests/tfrlrl/sampling/test_statistics_collection.py
@@ -4,6 +4,7 @@ import pytest
 from hypothesis import given, settings
 from hypothesis import strategies as st
 
+from tfrlrl.data_models.statistics import StatisticsException
 from tfrlrl.features.onehot import OneHotFeatureFunction
 from tfrlrl.policies.dense_neural_network import DenseNetworkPolicy
 from tfrlrl.baselines.linear import LinearBaseline
@@ -54,12 +55,22 @@ class TestEpisocidPolicyGradientStatisticsCollector:
         assert len(stats_collector.steps) == 0
         assert stats_collector.steps == []
 
-    @pytest.mark.parametrize('env_id', ['FrozenLake-v1'])
-    @pytest.mark.parametrize('include_baseline', [True, False])
+    @pytest.mark.parametrize(
+        'env_id, include_baseline',
+        [
+            (
+                'FrozenLake-v1',
+                False,
+            ),
+        ],
+    )
     @given(n_episodes=st.integers(min_value=1, max_value=5))
     @settings(deadline=5000)
     def test_aggregate_statistics_return_types_and_dimensions(
-        self, env_id: str, n_episodes: int, include_baseline: bool
+        self,
+        env_id: str,
+        include_baseline: bool,
+        n_episodes: int,
     ):
         """
         Test that aggregate_statistics returns two numpy arrays with expected dimensions.
@@ -70,6 +81,7 @@ class TestEpisocidPolicyGradientStatisticsCollector:
         Args:
             env_id: The Gym environment ID to be used in testing.
             n_episodes: The number of episodes to sample.
+            include_baseline: A Boolean indicating whether to include a baseline class in the statistics collection.
 
         """
         env = gym.make(env_id)
@@ -99,16 +111,24 @@ class TestEpisocidPolicyGradientStatisticsCollector:
             assert statistics.observations.shape[-1] == statistics.actions.shape[-1]
             assert statistics.observations.shape[-1] == statistics.total_expected_rewards.shape[-1]
 
-    @pytest.mark.parametrize('env_id', ['FrozenLake-v1'])
-    @pytest.mark.parametrize('include_baseline', [True, False])
+    @pytest.mark.parametrize(
+        'env_id, include_baseline',
+        [
+            (
+                'FrozenLake-v1',
+                False,
+            ),
+        ],
+    )
     @given(n_episodes=st.integers(min_value=2, max_value=5))
     @settings(deadline=5000)
-    def test_reset_and_reuse(self, env_id: str, n_episodes: int, include_baseline: bool):
+    def test_reset_and_reuse(self, env_id: str, include_baseline: bool, n_episodes: int):
         """
         Test that after reset, the collector can be reused for new episodes.
 
         Args:
             env_id: The Gym environment ID to be used in testing.
+            include_baseline: A Boolean indicating whether to include a baseline class in the statistics collection.
             n_episodes: The number of episodes to sample in each iteration.
 
         """
@@ -146,12 +166,84 @@ class TestEpisocidPolicyGradientStatisticsCollector:
         assert len(statistics1) == n_episodes
         assert len(statistics2) == n_episodes
 
-    @pytest.mark.parametrize('env_id', ['FrozenLake-v1', 'InvertedPendulum-v5'])
+    @pytest.mark.parametrize(
+        'env_id, include_baseline',
+        [
+            (
+                'FrozenLake-v1',
+                False,
+            ),
+            (
+                'FrozenLake-v1',
+                True,
+            ),
+        ],
+    )
     @given(n_episodes=st.integers(min_value=1, max_value=5))
     @settings(deadline=5000)
-    def test_merge_statistics(self, env_id: str, n_episodes: int):
+    def test_merge_statistics(self, env_id: str, include_baseline: bool, n_episodes: int):
         """
-        Test that merge_statistics returns two numpy arrays with expected dimensions.
+        Test that merge_statistics returns statistics with expected dimensions.
+
+        :param env_id: The Gym environment ID to be used in testing.
+        :param include_baseline: A Boolean indicating whether to include a baseline class in the statistics collection.
+        :param n_episodes: The number of episodes to sample.
+        """
+        env = gym.make(env_id)
+        S = env.observation_space.n
+        A = env.action_space.n
+
+        # Test currently works only for discrete observations spaces.
+        n_dim = 1
+
+        # Verify dimensions
+        n_params = S * (A - 1)  # Number of policy parameters
+
+        env = gym.make(env_id)
+        feature_fn = OneHotFeatureFunction(env.observation_space.n, env.action_space.n)
+        pol = LinearSoftMax(env_id, feature_fn)
+
+        if include_baseline:
+            baseline = LinearBaseline()
+        else:
+            baseline = None
+        stats_collector = EpisocidPolicyGradientStatisticsCollector(
+            pol,
+            baseline=baseline,
+        )
+        sampler = EpisodicSampler(
+            env_id,
+            stats_collector,
+            n_episodes=n_episodes,
+            policy=pol,
+            is_slippery=False,
+        )
+        statistics = sampler.sample()
+
+        # Verify return types
+        assert isinstance(statistics.total_reward, np.ndarray)
+        assert isinstance(statistics.episode_gradient, np.ndarray)
+
+        assert len(statistics.total_reward) == n_episodes
+        assert statistics.episode_gradient.shape == (n_params, n_episodes)
+
+        if include_baseline:
+            assert isinstance(statistics.baseline_features, np.ndarray)
+            assert isinstance(statistics.baseline_targets, np.ndarray)
+
+            assert statistics.baseline_features.shape[0] == (2 * n_dim) + 4
+            assert statistics.baseline_features.shape[1] == statistics.baseline_targets.shape[0]
+        else:
+            assert statistics.baseline_features is None
+            assert statistics.baseline_targets is None
+
+    @pytest.mark.parametrize('env_id', ['FrozenLake-v1'])
+>>>>>>> da40c98 (remove duplication in merge_statistics)
+    @given(n_episodes=st.integers(min_value=1, max_value=5))
+    @settings(deadline=5000)
+    def test_merge_statistics_with_inconsistent_baseline_statistics(self, env_id: str, n_episodes: int):
+        """
+        Test that merge_statistics raises an error when merging inconsistent baseline statistics.
 
         Args:
             env_id: The Gym environment ID to be used in testing.
@@ -172,26 +264,32 @@ class TestEpisocidPolicyGradientStatisticsCollector:
             policy = LinearSoftMax(env_id, feature_fn)
             env_kwargs = {'is_slippery': False}
 
-        stats_collector = EpisocidPolicyGradientStatisticsCollector(env_id)
-        sampler = EpisodicSampler(
+        baseline = LinearBaseline()
+        stats_collector1 = EpisocidPolicyGradientStatisticsCollector(
+            env_id=env_id,
+            baseline=baseline,
+        )
+        sampler1 = EpisodicSampler(
             env_id,
-            stats_collector,
+            stats_collector1,
             n_episodes=n_episodes,
             policy=policy,
             **env_kwargs,
         )
-        statistics = sampler.sample()
+        statistics1 = sampler1.sample()
 
-        # Verify return types
-        assert isinstance(statistics.total_reward, np.ndarray)
-        assert isinstance(statistics.observations, np.ndarray)
-        assert isinstance(statistics.actions, np.ndarray)
-        assert isinstance(statistics.total_expected_rewards, np.ndarray)
 
-        assert len(statistics.total_reward) == n_episodes
-        assert statistics.observations.shape[-1] == statistics.actions.shape[-1]
-        assert statistics.observations.shape[-1] == statistics.total_expected_rewards.shape[-1]
+        stats_collector2 = EpisocidPolicyGradientStatisticsCollector(
+            env_id=env_id,
+        )
+        sampler2 = EpisodicSampler(
+            env_id,
+            stats_collector2,
+            n_episodes=n_episodes,
+            policy=policy,
+            **env_kwargs,
+        )
+        statistics2 = sampler2.sample()
 
-        assert len(statistics.observations.shape) == 2
-        assert len(statistics.actions.shape) == 2
-        assert len(statistics.total_expected_rewards.shape) == 1
+        with pytest.raises(StatisticsException):
+            EpisocidPolicyGradientStatisticsCollector.merge_statistics([statistics1, statistics2])

--- a/tests/tfrlrl/sampling/test_statistics_collection.py
+++ b/tests/tfrlrl/sampling/test_statistics_collection.py
@@ -121,6 +121,10 @@ class TestEpisocidPolicyGradientStatisticsCollector:
                 'FrozenLake-v1',
                 False,
             ),
+            (
+                'InvertedPendulum-v5',
+                True,
+            ),
         ],
     )
     @given(n_episodes=st.integers(min_value=2, max_value=5))
@@ -136,8 +140,15 @@ class TestEpisocidPolicyGradientStatisticsCollector:
 
         """
         env = gym.make(env_id)
-        feature_fn = OneHotFeatureFunction(env.observation_space.n, env.action_space.n)
-        policy = LinearSoftMax(env_id, feature_fn)
+
+        if env_id == 'InvertedPendulum-v5':
+            policy = DenseNetworkPolicy(
+                env_id=env_id,
+                hidden_space_dims=[16, 32],
+            )
+        else:
+            feature_fn = OneHotFeatureFunction(env.observation_space.n, env.action_space.n)
+            policy = LinearSoftMax(env_id, feature_fn)
 
         if include_baseline:
             baseline = LinearBaseline()
@@ -153,7 +164,6 @@ class TestEpisocidPolicyGradientStatisticsCollector:
             stats_collector,
             n_episodes=n_episodes,
             policy=policy,
-            is_slippery=False,
         )
 
         # First collection
@@ -177,7 +187,7 @@ class TestEpisocidPolicyGradientStatisticsCollector:
                 False,
             ),
             (
-                'FrozenLake-v1',
+                'InvertedPendulum-v5',
                 True,
             ),
         ],
@@ -194,12 +204,16 @@ class TestEpisocidPolicyGradientStatisticsCollector:
         """
         env = gym.make(env_id)
 
-        # Test currently works only for discrete observations spaces.
-        n_dim = 1
+        if env_id == 'InvertedPendulum-v5':
+            n_dim = 4
 
-        env = gym.make(env_id)
-        feature_fn = OneHotFeatureFunction(env.observation_space.n, env.action_space.n)
-        pol = LinearSoftMax(env_id, feature_fn)
+            policy = DenseNetworkPolicy(
+                env_id=env_id,
+                hidden_space_dims=[16, 32],
+            )
+        else:
+            feature_fn = OneHotFeatureFunction(env.observation_space.n, env.action_space.n)
+            policy = LinearSoftMax(env_id, feature_fn)
 
         if include_baseline:
             baseline = LinearBaseline()
@@ -213,8 +227,7 @@ class TestEpisocidPolicyGradientStatisticsCollector:
             env_id,
             stats_collector,
             n_episodes=n_episodes,
-            policy=pol,
-            is_slippery=False,
+            policy=policy,
         )
         statistics = sampler.sample()
 

--- a/tests/tfrlrl/sampling/test_statistics_collection.py
+++ b/tests/tfrlrl/sampling/test_statistics_collection.py
@@ -6,6 +6,7 @@ from hypothesis import strategies as st
 
 from tfrlrl.features.onehot import OneHotFeatureFunction
 from tfrlrl.policies.dense_neural_network import DenseNetworkPolicy
+from tfrlrl.baselines.linear import LinearBaseline
 from tfrlrl.policies.linear_soft_max import LinearSoftMax
 from tfrlrl.sampling.episodic_sampler import EpisodicSampler
 from tfrlrl.sampling.statistics_collection import EpisocidPolicyGradientStatisticsCollector
@@ -54,9 +55,12 @@ class TestEpisocidPolicyGradientStatisticsCollector:
         assert stats_collector.steps == []
 
     @pytest.mark.parametrize('env_id', ['FrozenLake-v1'])
+    @pytest.mark.parametrize('include_baseline', [True, False])
     @given(n_episodes=st.integers(min_value=1, max_value=5))
     @settings(deadline=5000)
-    def test_aggregate_statistics_return_types_and_dimensions(self, env_id: str, n_episodes: int):
+    def test_aggregate_statistics_return_types_and_dimensions(
+        self, env_id: str, n_episodes: int, include_baseline: bool
+    ):
         """
         Test that aggregate_statistics returns two numpy arrays with expected dimensions.
 
@@ -72,7 +76,11 @@ class TestEpisocidPolicyGradientStatisticsCollector:
         feature_fn = OneHotFeatureFunction(env.observation_space.n, env.action_space.n)
         policy = LinearSoftMax(env_id, feature_fn)
 
-        stats_collector = EpisocidPolicyGradientStatisticsCollector(env_id)
+        if include_baseline:
+            baseline = LinearBaseline()
+        else:
+            baseline = None
+        stats_collector = EpisocidPolicyGradientStatisticsCollector(baseline=baseline)
         sampler = EpisodicSampler(
             env_id,
             stats_collector,
@@ -92,9 +100,10 @@ class TestEpisocidPolicyGradientStatisticsCollector:
             assert statistics.observations.shape[-1] == statistics.total_expected_rewards.shape[-1]
 
     @pytest.mark.parametrize('env_id', ['FrozenLake-v1'])
+    @pytest.mark.parametrize('include_baseline', [True, False])
     @given(n_episodes=st.integers(min_value=2, max_value=5))
     @settings(deadline=5000)
-    def test_reset_and_reuse(self, env_id: str, n_episodes: int):
+    def test_reset_and_reuse(self, env_id: str, n_episodes: int, include_baseline: bool):
         """
         Test that after reset, the collector can be reused for new episodes.
 
@@ -107,7 +116,15 @@ class TestEpisocidPolicyGradientStatisticsCollector:
         feature_fn = OneHotFeatureFunction(env.observation_space.n, env.action_space.n)
         policy = LinearSoftMax(env_id, feature_fn)
 
-        stats_collector = EpisocidPolicyGradientStatisticsCollector(env_id)
+        if include_baseline:
+            baseline = LinearBaseline()
+        else:
+            baseline = None
+
+        stats_collector = EpisocidPolicyGradientStatisticsCollector(
+            env_id,
+            baseline=baseline,
+        )
         sampler = EpisodicSampler(
             env_id,
             stats_collector,

--- a/tests/tfrlrl/sampling/test_utils.py
+++ b/tests/tfrlrl/sampling/test_utils.py
@@ -1,0 +1,103 @@
+"""Tests for sampling utility functions."""
+
+from dataclasses import dataclass
+
+import numpy as np
+import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from tfrlrl.data_models.statistics import BaseStatistics, StatisticsException
+from tfrlrl.sampling.utils import merge_optional_statistics
+
+
+@dataclass
+class MockStatistics(BaseStatistics):
+    """Mock statistics class for testing merge_optional_statistics."""
+
+    optional_attr: np.ndarray = None
+
+
+class TestMergeOptionalStatistics:
+    """Tests for the merge_optional_statistics function."""
+
+    def test_all_attributes_none_returns_none(self):
+        """Test that when all attributes are None, the function returns None."""
+        stats = [MockStatistics(optional_attr=None) for _ in range(3)]
+        result = merge_optional_statistics(stats, 'optional_attr')
+        assert result is None
+
+    def test_all_attributes_present_returns_concatenated_array(self):
+        """Test that when all attributes are present, returns concatenated array."""
+        arrays = [np.array([[1, 2]]), np.array([[3, 4]]), np.array([[5, 6]])]
+        stats = [MockStatistics(optional_attr=arr) for arr in arrays]
+
+        result = merge_optional_statistics(stats, 'optional_attr')
+
+        expected = np.array([[1, 2], [3, 4], [5, 6]])
+        np.testing.assert_array_equal(result, expected)
+
+    def test_mixed_none_and_present_raises_exception(self):
+        """Test that mixed None and present attributes raises StatisticsException."""
+        stats = [
+            MockStatistics(optional_attr=np.array([1, 2, 3])),
+            MockStatistics(optional_attr=None),
+            MockStatistics(optional_attr=np.array([4, 5, 6])),
+        ]
+
+        with pytest.raises(StatisticsException) as exc_info:
+            merge_optional_statistics(stats, 'optional_attr')
+
+        assert 'All baseline features should either be None or a NumPy array' in str(exc_info.value)
+
+    def test_concatenate_axis_0(self):
+        """Test concatenation along axis 0 (default)."""
+        arrays = [np.array([[1, 2], [3, 4]]), np.array([[5, 6], [7, 8]])]
+        stats = [MockStatistics(optional_attr=arr) for arr in arrays]
+
+        result = merge_optional_statistics(stats, 'optional_attr', concatenate_axis=0)
+
+        expected = np.array([[1, 2], [3, 4], [5, 6], [7, 8]])
+        np.testing.assert_array_equal(result, expected)
+
+    def test_concatenate_axis_1(self):
+        """Test concatenation along axis 1."""
+        arrays = [np.array([[1, 2], [3, 4]]), np.array([[5, 6], [7, 8]])]
+        stats = [MockStatistics(optional_attr=arr) for arr in arrays]
+
+        result = merge_optional_statistics(stats, 'optional_attr', concatenate_axis=1)
+
+        expected = np.array([[1, 2, 5, 6], [3, 4, 7, 8]])
+        np.testing.assert_array_equal(result, expected)
+
+    def test_single_statistics_all_none(self):
+        """Test with single statistics object where attribute is None."""
+        stats = [MockStatistics(optional_attr=None)]
+        result = merge_optional_statistics(stats, 'optional_attr')
+        assert result is None
+
+    def test_single_statistics_present(self):
+        """Test with single statistics object where attribute is present."""
+        arr = np.array([[1, 2, 3]])
+        stats = [MockStatistics(optional_attr=arr)]
+
+        result = merge_optional_statistics(stats, 'optional_attr')
+
+        np.testing.assert_array_equal(result, arr)
+
+    @given(n_stats=st.integers(min_value=2, max_value=10))
+    @settings(deadline=1000)
+    def test_concatenation_preserves_total_elements(self, n_stats: int):
+        """
+        Test that concatenation preserves the total number of elements.
+
+        :param n_stats: The number of statistics objects to merge.
+        """
+        arrays = [np.random.random((3, 4)) for _ in range(n_stats)]
+        stats = [MockStatistics(optional_attr=arr) for arr in arrays]
+
+        result = merge_optional_statistics(stats, 'optional_attr', concatenate_axis=0)
+
+        assert result.shape == (3 * n_stats, 4)
+        total_elements = sum(arr.size for arr in arrays)
+        assert result.size == total_elements

--- a/tests/tfrlrl/training_algorithms/test_sgd.py
+++ b/tests/tfrlrl/training_algorithms/test_sgd.py
@@ -72,7 +72,7 @@ class TestTrainPolicyGradient:
             policy = LinearSoftMax(env_id, feature_fn)
 
         if use_baseline:
-            baseline = LinearBaseline()
+            baseline = LinearBaseline(env_id=env_id)
         else:
             baseline = None
 
@@ -183,7 +183,23 @@ class TestTrainPolicyGradient:
         assert np.average(statistics.total_reward) > 0.8
 
     @pytest.mark.slow
-    @pytest.mark.parametrize('env_id', ['FrozenLake-v1', 'InvertedPendulum-v5'])
+    @pytest.mark.parametrize(
+        'env_id, use_baseline',
+        [
+            (
+                'FrozenLake-v1',
+                False,
+            ),
+            (
+                'InvertedPendulum-v5',
+                False,
+            ),
+            (
+                'InvertedPendulum-v5',
+                True,
+            ),
+        ],
+    )
     @given(
         n_iterations=st.integers(min_value=2, max_value=5),
         n_episodes=st.integers(min_value=10, max_value=20),
@@ -193,6 +209,7 @@ class TestTrainPolicyGradient:
     def test_ray_train_policy_gradient_returns_policy(
         self,
         env_id: str,
+        use_baseline: bool,
         n_iterations: int,
         n_episodes: int,
         alpha: float,
@@ -203,6 +220,7 @@ class TestTrainPolicyGradient:
 
         Args:
             env_id: The Gym environment ID to be used in training.
+            use_baseline: A Boolean indicating whether to use a linear baseline.
             n_iterations: The number of policy updates to perform.
             n_episodes: The number of episodes to sample during each policy update.
             alpha: The initial step size for stochastic gradient ascent.
@@ -220,6 +238,11 @@ class TestTrainPolicyGradient:
             feature_fn = OneHotFeatureFunction(env.observation_space.n, env.action_space.n)
             policy = LinearSoftMax(env_id, feature_fn)
 
+        if use_baseline:
+            baseline = LinearBaseline(env_id=env_id)
+        else:
+            baseline = None
+
         # Train the policy
         trained_policy = train_policy_gradient(
             env_id=env_id,
@@ -228,6 +251,7 @@ class TestTrainPolicyGradient:
             n_episodes=n_episodes,
             alpha=alpha,
             n_samplers=n_samplers,
+            baseline=baseline,
         )
 
         # Verify that a policy is returned

--- a/tests/tfrlrl/training_algorithms/test_sgd.py
+++ b/tests/tfrlrl/training_algorithms/test_sgd.py
@@ -6,6 +6,7 @@ import pytest
 from hypothesis import given, settings
 from hypothesis import strategies as st
 
+from tfrlrl.baselines.linear import LinearBaseline
 from tfrlrl.features.onehot import OneHotFeatureFunction
 from tfrlrl.policies.dense_neural_network import DenseNetworkPolicy
 from tfrlrl.policies.linear_soft_max import LinearSoftMax
@@ -17,7 +18,23 @@ from tfrlrl.training_algorithms.sgd import train_policy_gradient
 class TestTrainPolicyGradient:
     """Unit tests for the train_policy_gradient function."""
 
-    @pytest.mark.parametrize('env_id', ['FrozenLake-v1', 'InvertedPendulum-v5'])
+    @pytest.mark.parametrize(
+        'env_id, use_baseline',
+        [
+            (
+                'FrozenLake-v1',
+                False,
+            ),
+            (
+                'InvertedPendulum-v5',
+                False,
+            ),
+            (
+                'InvertedPendulum-v5',
+                True,
+            ),
+        ],
+    )
     @given(
         n_iterations=st.integers(min_value=2, max_value=5),
         n_episodes=st.integers(min_value=10, max_value=100),
@@ -27,6 +44,7 @@ class TestTrainPolicyGradient:
     def test_train_policy_gradient_returns_policy(
         self,
         env_id: str,
+        use_baseline: bool,
         n_iterations: int,
         n_episodes: int,
         alpha: float,
@@ -36,6 +54,7 @@ class TestTrainPolicyGradient:
 
         Args:
             env_id: The Gym environment ID to be used in training.
+            use_baseline: A Boolean indicating whether to use a linear baseline.
             n_iterations: The number of policy updates to perform.
             n_episodes: The number of episodes to sample during each policy update.
             alpha: The initial step size for stochastic gradient ascent.
@@ -52,6 +71,11 @@ class TestTrainPolicyGradient:
             feature_fn = OneHotFeatureFunction(env.observation_space.n, env.action_space.n)
             policy = LinearSoftMax(env_id, feature_fn)
 
+        if use_baseline:
+            baseline = LinearBaseline()
+        else:
+            baseline = None
+
         # Train the policy
         trained_policy = train_policy_gradient(
             env_id=env_id,
@@ -59,6 +83,7 @@ class TestTrainPolicyGradient:
             n_iterations=n_iterations,
             n_episodes=n_episodes,
             alpha=alpha,
+            baseline=baseline,
         )
 
         # Verify that a policy is returned


### PR DESCRIPTION
This PR adds an initial linear baseline class. This is done to reduce the variance of the policy gradient estimates. 


- [x] Update the docstring of the base baseline class. It currently references the number of features in the linear baseline class.
- [x] Update the docstring of the linear baseline class to reference the paper. 
- [x] Add validation that the linear baseline class is not being used on a discrete state space.  