### PR TITLE
Add multi-paradigm reward modelling (AverageEpisodicReward and DiscountedReward)

### DIFF
--- a/src/tfrlrl/cli/reinforce.py
+++ b/src/tfrlrl/cli/reinforce.py
@@ -7,6 +7,7 @@ from torch.optim import (
     AdamW,
 )
 
+from tfrlrl.data_models.reward_models import AverageEpisodicReward, DiscountedReward
 from tfrlrl.features.onehot import OneHotFeatureFunction
 from tfrlrl.policies.dense_neural_network import DenseNetworkPolicy
 from tfrlrl.policies.linear_soft_max import LinearSoftMax
@@ -77,6 +78,19 @@ def parse_args(args=None):
         default=[16, 32],
         help='The number of hidden dimensions to use in a dense policy network.',
     )
+    parser.add_argument(
+        '--reward-model',
+        type=str,
+        default='average-episodic',
+        choices=['average-episodic', 'discounted'],
+        help='Reward model to use when computing returns.',
+    )
+    parser.add_argument(
+        '--gamma',
+        type=float,
+        default=0.99,
+        help='Discount factor (only used when --reward-model=discounted).',
+    )
     return parser.parse_args(args)
 
 
@@ -116,6 +130,11 @@ def main(args=None):
 
     optimizer = AdamW(policy.get_parameters(), lr=parsed_args.alpha)
 
+    if parsed_args.reward_model == 'discounted':
+        reward_model = DiscountedReward(gamma=parsed_args.gamma)
+    else:
+        reward_model = AverageEpisodicReward()
+
     train_policy_gradient(
         env_id=parsed_args.env_id,
         policy=policy,
@@ -123,5 +142,6 @@ def main(args=None):
         n_episodes=parsed_args.n_episodes,
         optimizer=optimizer,
         n_samplers=parsed_args.n_samplers,
+        reward_model=reward_model,
         **env_kwargs,
     )

--- a/src/tfrlrl/data_models/__init__.py
+++ b/src/tfrlrl/data_models/__init__.py
@@ -1,0 +1,3 @@
+from tfrlrl.data_models.reward_models import AverageEpisodicReward, DiscountedReward
+
+__all__ = ["AverageEpisodicReward", "DiscountedReward"]

--- a/src/tfrlrl/data_models/reward_models.py
+++ b/src/tfrlrl/data_models/reward_models.py
@@ -1,0 +1,48 @@
+"""Reward model dataclasses for different ways of estimating the total expected reward."""
+
+from dataclasses import dataclass
+
+import numpy as np
+
+
+@dataclass
+class AverageEpisodicReward:
+    """Average episodic return: G_t = (r_t + r_{t+1} + ... + r_{T-1}) / T."""
+
+    def compute(self, rewards: np.ndarray) -> np.ndarray:
+        """
+        Compute the average episodic return for each time step.
+
+        Args:
+            rewards: A 1-D array of per-step rewards with length T.
+
+        Returns:
+            A 1-D array of length T where element t is the sum of future rewards divided by T.
+
+        """
+        T = rewards.size
+        return np.matmul(rewards, np.tril(np.ones(T))) / T
+
+
+@dataclass
+class DiscountedReward:
+    """Discounted return: G_t = r_t + gamma*r_{t+1} + gamma^2*r_{t+2} + ... + gamma^(T-1-t)*r_{T-1}."""
+
+    gamma: float = 0.99
+
+    def compute(self, rewards: np.ndarray) -> np.ndarray:
+        """
+        Compute the discounted return for each time step.
+
+        Args:
+            rewards: A 1-D array of per-step rewards with length T.
+
+        Returns:
+            A 1-D array of length T where element t is the discounted sum of future rewards.
+
+        """
+        T = rewards.size
+        i_idx = np.arange(T)[:, None]
+        j_idx = np.arange(T)[None, :]
+        discount_matrix = np.where(i_idx >= j_idx, np.power(self.gamma, i_idx - j_idx), 0.0)
+        return np.matmul(rewards, discount_matrix)

--- a/src/tfrlrl/sampling/statistics_collection.py
+++ b/src/tfrlrl/sampling/statistics_collection.py
@@ -1,11 +1,12 @@
 import logging
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional, Sequence
+from typing import Any, Dict, List, Optional, Sequence, Union
 
 import numpy as np
 
 from tfrlrl.baselines.linear import Baseline
+from tfrlrl.data_models.reward_models import AverageEpisodicReward, DiscountedReward
 from tfrlrl.data_models.statistics import BaseStatistics
 from tfrlrl.data_models.step import StepProtocol, construct_step_dataclasses
 from tfrlrl.sampling.utils import merge_optional_statistics
@@ -116,7 +117,12 @@ class EpisocidPolicyGradientStatisticsCollector(BaseStatisticsCollector[EpisodeP
 
     """
 
-    def __init__(self, env_id: str, baseline: Optional[Baseline] = None):
+    def __init__(
+        self,
+        env_id: str,
+        baseline: Optional[Baseline] = None,
+        reward_model: Optional[Union[AverageEpisodicReward, DiscountedReward]] = None,
+    ):
         """
         Initialise the policy-gradients statistics collector.
 
@@ -124,12 +130,15 @@ class EpisocidPolicyGradientStatisticsCollector(BaseStatisticsCollector[EpisodeP
             env_id: The I.D. of the environment from which to collect statistics.
             baseline: If given, an instance of the baseline class, which will be used for
             variance reduction when estimating policy gradients.
+            reward_model: The reward model to use when computing the total expected rewards.
+            Defaults to AverageEpisodicReward if not specified.
 
         """
         super().__init__(
             env_id=env_id,
             baseline=baseline,
         )
+        self.reward_model = reward_model if reward_model is not None else AverageEpisodicReward()
         self.steps: List[StepProtocol] = []
 
     def reset(self) -> None:
@@ -163,7 +172,7 @@ class EpisocidPolicyGradientStatisticsCollector(BaseStatisticsCollector[EpisodeP
         steps = self.steps_cls(sample_steps=self.steps)
 
         T = steps.rewards.size
-        total_expected_rewards = np.matmul(steps.rewards, np.tril(np.ones(T))) / T
+        total_expected_rewards = self.reward_model.compute(steps.rewards)
 
         baseline_features = None
         if self.baseline is not None:

--- a/src/tfrlrl/training_algorithms/reinforce.py
+++ b/src/tfrlrl/training_algorithms/reinforce.py
@@ -16,6 +16,7 @@ from torch.optim import (
 
 from tfrlrl import settings
 from tfrlrl.baselines.linear import Baseline
+from tfrlrl.data_models.reward_models import AverageEpisodicReward, DiscountedReward
 from tfrlrl.policies.base import BasePyTorchPolicy
 from tfrlrl.sampling.episodic_sampler import (
     EpisodicSampler,
@@ -34,6 +35,7 @@ def train_policy_gradient(
     optimizer: Optimizer,
     n_samplers: int = 1,
     baseline: Optional[Baseline] = None,
+    reward_model: Optional[Union[AverageEpisodicReward, DiscountedReward]] = None,
     n_iteration_logging: int = 10,
     **kwargs,
 ) -> BasePyTorchPolicy:
@@ -48,6 +50,8 @@ def train_policy_gradient(
         optimizer: An instance of a PyTorch optimizer class that will be used to optimise the policy.
         n_samplers: The number of samplers to used to sample from the environment.
         baseline: An instance of a baseline class, if one is given.
+        reward_model: The reward model to use when computing total expected rewards. Defaults to
+        AverageEpisodicReward if not specified.
         n_iteration_logging: The number of algorithm iterations between logging algorithm performance.
         kwargs: Additional keyword arguments to pass to the EpisodicSampler (e.g., is_slippery).
 
@@ -58,6 +62,7 @@ def train_policy_gradient(
     statistics_collector = EpisocidPolicyGradientStatisticsCollector(
         env_id,
         baseline=baseline,
+        reward_model=reward_model,
     )
 
     if n_samplers > 1:

--- a/tests/tfrlrl/cli/test_reinforce.py
+++ b/tests/tfrlrl/cli/test_reinforce.py
@@ -33,6 +33,8 @@ class TestParseArgs:
                     'alpha': 1.0,
                     'env_kwargs': '{}',
                     'policy_class': 'dense',
+                    'reward_model': 'average-episodic',
+                    'gamma': 0.99,
                 },
             ),
             (
@@ -44,6 +46,8 @@ class TestParseArgs:
                     'alpha': 100.0,
                     'env_kwargs': '{"is_slippery": false}',
                     'policy_class': 'dense',
+                    'reward_model': 'average-episodic',
+                    'gamma': 0.99,
                 },
             ),
             (
@@ -66,6 +70,30 @@ class TestParseArgs:
                     'alpha': 1.0,
                     'env_kwargs': '{}',
                     'policy_class': 'linear',
+                    'reward_model': 'average-episodic',
+                    'gamma': 0.99,
+                },
+            ),
+            (
+                [
+                    '--env-id',
+                    'FrozenLake-v1',
+                    '--policy-class',
+                    'linear',
+                    '--reward-model',
+                    'discounted',
+                    '--gamma',
+                    '0.95',
+                ],
+                {
+                    'env_id': 'FrozenLake-v1',
+                    'n_iterations': 100,
+                    'n_episodes': 100,
+                    'alpha': 100.0,
+                    'env_kwargs': '{}',
+                    'policy_class': 'linear',
+                    'reward_model': 'discounted',
+                    'gamma': 0.95,
                 },
             ),
         ],
@@ -78,11 +106,18 @@ class TestParseArgs:
         assert parsed.n_episodes == expected['n_episodes']
         assert parsed.alpha == expected['alpha']
         assert parsed.env_kwargs == expected['env_kwargs']
+        assert parsed.reward_model == expected['reward_model']
+        assert parsed.gamma == expected['gamma']
 
     def test_parse_args_missing_required(self):
         """Test that missing required arguments raises SystemExit."""
         with pytest.raises(SystemExit):
             parse_args(['--n-iterations', '10'])
+
+    def test_parse_args_invalid_reward_model(self):
+        """Test that an invalid reward model choice raises SystemExit."""
+        with pytest.raises(SystemExit):
+            parse_args(['--env-id', 'FrozenLake-v1', '--policy-class', 'linear', '--reward-model', 'invalid'])
 
 
 class TestMain:
@@ -211,6 +246,45 @@ class TestMain:
             '5',
             '--alpha',
             '1.0',
+        ]
+
+        exit_code = main(args)
+
+        assert exit_code is None or exit_code == 0
+
+    @pytest.mark.parametrize(
+        'env_id, policy_class, reward_model, gamma',
+        [
+            ('FrozenLake-v1', 'linear', 'discounted', '0.95'),
+            ('FrozenLake-v1', 'linear', 'average-episodic', '0.99'),
+        ],
+    )
+    def test_main_with_reward_model(self, env_id: str, policy_class: str, reward_model: str, gamma: str):
+        """
+        Test main function with different reward model options.
+
+        Args:
+            env_id: The Gym environment ID to be used in training.
+            policy_class: The policy class to use in SGD.
+            reward_model: The reward model to use.
+            gamma: The discount factor.
+
+        """
+        args = [
+            '--env-id',
+            env_id,
+            '--policy-class',
+            policy_class,
+            '--n-iterations',
+            '2',
+            '--n-episodes',
+            '5',
+            '--alpha',
+            '1.0',
+            '--reward-model',
+            reward_model,
+            '--gamma',
+            gamma,
         ]
 
         exit_code = main(args)

--- a/tests/tfrlrl/data_models/test_reward_models.py
+++ b/tests/tfrlrl/data_models/test_reward_models.py
@@ -1,0 +1,114 @@
+"""Tests for reward model dataclasses."""
+
+import numpy as np
+import pytest
+
+from tfrlrl.data_models.reward_models import AverageEpisodicReward, DiscountedReward
+
+
+class TestAverageEpisodicReward:
+    """Tests for the AverageEpisodicReward dataclass."""
+
+    def test_single_step(self):
+        """A single-step episode: G_0 = r_0 / 1."""
+        model = AverageEpisodicReward()
+        rewards = np.array([5.0])
+        result = model.compute(rewards)
+        np.testing.assert_allclose(result, np.array([5.0]))
+
+    def test_uniform_rewards(self):
+        """All rewards equal to 1: each G_t = (T - t) / T."""
+        model = AverageEpisodicReward()
+        T = 4
+        rewards = np.ones(T)
+        result = model.compute(rewards)
+        expected = np.array([(T - t) / T for t in range(T)])
+        np.testing.assert_allclose(result, expected)
+
+    def test_known_sequence(self):
+        """Verify against the manual lower-triangular matrix formula."""
+        model = AverageEpisodicReward()
+        rewards = np.array([1.0, 2.0, 3.0])
+        T = rewards.size
+        expected = np.matmul(rewards, np.tril(np.ones(T))) / T
+        result = model.compute(rewards)
+        np.testing.assert_allclose(result, expected)
+
+    def test_returns_ndarray(self):
+        """compute() must return a numpy array."""
+        model = AverageEpisodicReward()
+        result = model.compute(np.array([1.0, 2.0]))
+        assert isinstance(result, np.ndarray)
+
+    def test_output_length_matches_input(self):
+        """Output array length must equal the input reward length."""
+        model = AverageEpisodicReward()
+        for T in [1, 3, 10]:
+            rewards = np.arange(T, dtype=float)
+            assert model.compute(rewards).shape == (T,)
+
+
+class TestDiscountedReward:
+    """Tests for the DiscountedReward dataclass."""
+
+    def test_single_step(self):
+        """A single-step episode: G_0 = r_0 regardless of gamma."""
+        model = DiscountedReward(gamma=0.9)
+        rewards = np.array([7.0])
+        result = model.compute(rewards)
+        np.testing.assert_allclose(result, np.array([7.0]))
+
+    def test_gamma_zero(self):
+        """gamma=0: each G_t equals only the immediate reward r_t."""
+        model = DiscountedReward(gamma=0.0)
+        rewards = np.array([1.0, 2.0, 3.0])
+        result = model.compute(rewards)
+        np.testing.assert_allclose(result, rewards)
+
+    def test_gamma_one_equals_cumulative_sum(self):
+        """gamma=1: G_t = r_t + r_{t+1} + ... + r_{T-1} (undiscounted sum)."""
+        model = DiscountedReward(gamma=1.0)
+        rewards = np.array([1.0, 2.0, 3.0])
+        T = rewards.size
+        expected = np.matmul(rewards, np.tril(np.ones(T)))
+        result = model.compute(rewards)
+        np.testing.assert_allclose(result, expected)
+
+    def test_known_discounted_sequence(self):
+        """Verify discounted returns for a known reward sequence and gamma."""
+        gamma = 0.5
+        model = DiscountedReward(gamma=gamma)
+        rewards = np.array([1.0, 1.0, 1.0])
+        # G_0 = 1 + 0.5 + 0.25 = 1.75
+        # G_1 = 1 + 0.5 = 1.5
+        # G_2 = 1
+        expected = np.array([1.75, 1.5, 1.0])
+        result = model.compute(rewards)
+        np.testing.assert_allclose(result, expected)
+
+    def test_default_gamma(self):
+        """Default gamma should be 0.99."""
+        model = DiscountedReward()
+        assert model.gamma == 0.99
+
+    def test_returns_ndarray(self):
+        """compute() must return a numpy array."""
+        model = DiscountedReward(gamma=0.99)
+        result = model.compute(np.array([1.0, 2.0]))
+        assert isinstance(result, np.ndarray)
+
+    def test_output_length_matches_input(self):
+        """Output array length must equal the input reward length."""
+        model = DiscountedReward(gamma=0.99)
+        for T in [1, 3, 10]:
+            rewards = np.arange(T, dtype=float)
+            assert model.compute(rewards).shape == (T,)
+
+    @pytest.mark.parametrize('gamma', [0.9, 0.95, 0.99])
+    def test_returns_decrease_with_discount(self, gamma: float):
+        """G_t >= G_{t+1} for positive rewards when gamma <= 1."""
+        model = DiscountedReward(gamma=gamma)
+        rewards = np.ones(5)
+        result = model.compute(rewards)
+        for t in range(len(result) - 1):
+            assert result[t] >= result[t + 1]

--- a/tests/tfrlrl/sampling/test_statistics_collection.py
+++ b/tests/tfrlrl/sampling/test_statistics_collection.py
@@ -5,6 +5,7 @@ from hypothesis import given, settings
 from hypothesis import strategies as st
 
 from tfrlrl.baselines.linear import LinearBaseline
+from tfrlrl.data_models.reward_models import AverageEpisodicReward, DiscountedReward
 from tfrlrl.data_models.statistics import StatisticsException
 from tfrlrl.features.onehot import OneHotFeatureFunction
 from tfrlrl.policies.dense_neural_network import DenseNetworkPolicy
@@ -316,3 +317,47 @@ class TestEpisocidPolicyGradientStatisticsCollector:
 
         with pytest.raises(StatisticsException):
             EpisocidPolicyGradientStatisticsCollector.merge_statistics([statistics1, statistics2])
+
+    @pytest.mark.parametrize(
+        'env_id, reward_model',
+        [
+            ('FrozenLake-v1', AverageEpisodicReward()),
+            ('FrozenLake-v1', DiscountedReward(gamma=0.99)),
+        ],
+    )
+    @given(n_episodes=st.integers(min_value=1, max_value=3))
+    @settings(deadline=5000)
+    def test_aggregate_statistics_with_reward_model(
+        self,
+        env_id: str,
+        reward_model,
+        n_episodes: int,
+    ):
+        """
+        Test that aggregate_statistics correctly delegates reward computation to the reward model.
+
+        Args:
+            env_id: The Gym environment ID to be used in testing.
+            reward_model: The reward model to use.
+            n_episodes: The number of episodes to sample.
+
+        """
+        env = gym.make(env_id)
+        feature_fn = OneHotFeatureFunction(env.observation_space.n, env.action_space.n)
+        policy = LinearSoftMax(env_id, feature_fn)
+
+        stats_collector = EpisocidPolicyGradientStatisticsCollector(
+            env_id=env_id,
+            reward_model=reward_model,
+        )
+        sampler = EpisodicSampler(
+            env_id,
+            stats_collector,
+            n_episodes=n_episodes,
+            policy=policy,
+            is_slippery=False,
+        )
+
+        for statistics in sampler:
+            assert isinstance(statistics.total_expected_rewards, np.ndarray)
+            assert statistics.total_expected_rewards.shape[-1] == statistics.observations.shape[-1]


### PR DESCRIPTION
Introduces reward model dataclasses so the REINFORCE algorithm can support different ways of estimating the total expected reward.

## Changes

- New `AverageEpisodicReward` and `DiscountedReward` dataclasses in `src/tfrlrl/data_models/reward_models.py`
- `EpisocidPolicyGradientStatisticsCollector` now accepts an optional `reward_model` parameter
- `train_policy_gradient` threads `reward_model` through to the statistics collector
- CLI adds `--reward-model` and `--gamma` flags

The existing average-episodic behaviour is preserved as the default; new paradigms can be added by writing a new dataclass with a `compute(rewards)` method.

Closes #44

Generated with [Claude Code](https://claude.ai/code)