### PR TITLE
Add multi-paradigm reward modelling (AverageEpisodic and Discounted)

### DIFF
--- a/src/tfrlrl/cli/reinforce.py
+++ b/src/tfrlrl/cli/reinforce.py
@@ -7,6 +7,7 @@ from torch.optim import (
     AdamW,
 )
 
+from tfrlrl.data_models.reward_models import AverageEpisodicReward, DiscountedReward
 from tfrlrl.features.onehot import OneHotFeatureFunction
 from tfrlrl.policies.dense_neural_network import DenseNetworkPolicy
 from tfrlrl.policies.linear_soft_max import LinearSoftMax
@@ -77,6 +78,19 @@ def parse_args(args=None):
         default=[16, 32],
         help='The number of hidden dimensions to use in a dense policy network.',
     )
+    parser.add_argument(
+        '--reward-model',
+        type=str,
+        default='average-episodic',
+        choices=['average-episodic', 'discounted'],
+        help='Reward model to use when computing returns.',
+    )
+    parser.add_argument(
+        '--gamma',
+        type=float,
+        default=None,
+        help='Discount factor (required when --reward-model=discounted).',
+    )
     return parser.parse_args(args)
 
 
@@ -102,6 +116,14 @@ def main(args=None):
     if env_kwargs is not None:
         logger.info('Environment Arguments: %s', env_kwargs)
 
+    if parsed_args.reward_model == 'discounted':
+        if parsed_args.gamma is None:
+            logger.error('--gamma is required when --reward-model=discounted')
+            return 1
+        reward_model = DiscountedReward(gamma=parsed_args.gamma)
+    else:
+        reward_model = AverageEpisodicReward()
+
     if parsed_args.policy_class == 'linear':
         logger.info('Using a linear policy with a one-hot feature encoding.')
         env = gym.make(parsed_args.env_id)
@@ -123,5 +145,6 @@ def main(args=None):
         n_episodes=parsed_args.n_episodes,
         optimizer=optimizer,
         n_samplers=parsed_args.n_samplers,
+        reward_model=reward_model,
         **env_kwargs,
     )

--- a/src/tfrlrl/data_models/__init__.py
+++ b/src/tfrlrl/data_models/__init__.py
@@ -1,0 +1,3 @@
+from tfrlrl.data_models.reward_models import AverageEpisodicReward, DiscountedReward
+
+__all__ = ['AverageEpisodicReward', 'DiscountedReward']

--- a/src/tfrlrl/data_models/reward_models.py
+++ b/src/tfrlrl/data_models/reward_models.py
@@ -1,0 +1,48 @@
+"""Reward model dataclasses for different ways of estimating total expected reward."""
+
+from dataclasses import dataclass
+
+import numpy as np
+
+
+@dataclass
+class AverageEpisodicReward:
+    """Average episodic return: G_t = (r_t + r_{t+1} + ... + r_{T-1}) / T."""
+
+    def compute(self, rewards: np.ndarray) -> np.ndarray:
+        """
+        Compute the average episodic return for each step.
+
+        Args:
+            rewards: 1-D array of rewards of length T.
+
+        Returns:
+            1-D array of length T where each element is the average future return from that step.
+
+        """
+        T = rewards.size
+        return np.matmul(rewards, np.tril(np.ones(T))) / T
+
+
+@dataclass
+class DiscountedReward:
+    """Discounted return: G_t = r_t + γ·r_{t+1} + γ²·r_{t+2} + ... + γ^(T-1-t)·r_{T-1}."""
+
+    gamma: float
+
+    def compute(self, rewards: np.ndarray) -> np.ndarray:
+        """
+        Compute the discounted return for each step.
+
+        Args:
+            rewards: 1-D array of rewards of length T.
+
+        Returns:
+            1-D array of length T where each element is the discounted future return from that step.
+
+        """
+        T = rewards.size
+        i_idx = np.arange(T)[:, None]
+        j_idx = np.arange(T)[None, :]
+        discount_matrix = np.where(i_idx >= j_idx, np.power(self.gamma, i_idx - j_idx), 0.0)
+        return np.matmul(rewards, discount_matrix)

--- a/src/tfrlrl/sampling/statistics_collection.py
+++ b/src/tfrlrl/sampling/statistics_collection.py
@@ -1,11 +1,12 @@
 import logging
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional, Sequence
+from typing import Any, Dict, List, Optional, Sequence, Union
 
 import numpy as np
 
 from tfrlrl.baselines.linear import Baseline
+from tfrlrl.data_models.reward_models import AverageEpisodicReward, DiscountedReward
 from tfrlrl.data_models.statistics import BaseStatistics
 from tfrlrl.data_models.step import StepProtocol, construct_step_dataclasses
 from tfrlrl.sampling.utils import merge_optional_statistics
@@ -116,7 +117,12 @@ class EpisocidPolicyGradientStatisticsCollector(BaseStatisticsCollector[EpisodeP
 
     """
 
-    def __init__(self, env_id: str, baseline: Optional[Baseline] = None):
+    def __init__(
+        self,
+        env_id: str,
+        baseline: Optional[Baseline] = None,
+        reward_model: Optional[Union[AverageEpisodicReward, DiscountedReward]] = None,
+    ):
         """
         Initialise the policy-gradients statistics collector.
 
@@ -124,12 +130,15 @@ class EpisocidPolicyGradientStatisticsCollector(BaseStatisticsCollector[EpisodeP
             env_id: The I.D. of the environment from which to collect statistics.
             baseline: If given, an instance of the baseline class, which will be used for
             variance reduction when estimating policy gradients.
+            reward_model: The reward model to use when computing total expected rewards. Defaults
+            to AverageEpisodicReward if not specified.
 
         """
         super().__init__(
             env_id=env_id,
             baseline=baseline,
         )
+        self.reward_model = reward_model if reward_model is not None else AverageEpisodicReward()
         self.steps: List[StepProtocol] = []
 
     def reset(self) -> None:
@@ -163,7 +172,7 @@ class EpisocidPolicyGradientStatisticsCollector(BaseStatisticsCollector[EpisodeP
         steps = self.steps_cls(sample_steps=self.steps)
 
         T = steps.rewards.size
-        total_expected_rewards = np.matmul(steps.rewards, np.tril(np.ones(T))) / T
+        total_expected_rewards = self.reward_model.compute(steps.rewards)
 
         baseline_features = None
         if self.baseline is not None:

--- a/src/tfrlrl/training_algorithms/reinforce.py
+++ b/src/tfrlrl/training_algorithms/reinforce.py
@@ -16,6 +16,7 @@ from torch.optim import (
 
 from tfrlrl import settings
 from tfrlrl.baselines.linear import Baseline
+from tfrlrl.data_models.reward_models import AverageEpisodicReward, DiscountedReward
 from tfrlrl.policies.base import BasePyTorchPolicy
 from tfrlrl.sampling.episodic_sampler import (
     EpisodicSampler,
@@ -34,6 +35,7 @@ def train_policy_gradient(
     optimizer: Optimizer,
     n_samplers: int = 1,
     baseline: Optional[Baseline] = None,
+    reward_model: Optional[Union[AverageEpisodicReward, DiscountedReward]] = None,
     n_iteration_logging: int = 10,
     **kwargs,
 ) -> BasePyTorchPolicy:
@@ -48,6 +50,8 @@ def train_policy_gradient(
         optimizer: An instance of a PyTorch optimizer class that will be used to optimise the policy.
         n_samplers: The number of samplers to used to sample from the environment.
         baseline: An instance of a baseline class, if one is given.
+        reward_model: The reward model to use when computing total expected rewards. Defaults to
+        AverageEpisodicReward if not specified.
         n_iteration_logging: The number of algorithm iterations between logging algorithm performance.
         kwargs: Additional keyword arguments to pass to the EpisodicSampler (e.g., is_slippery).
 
@@ -58,6 +62,7 @@ def train_policy_gradient(
     statistics_collector = EpisocidPolicyGradientStatisticsCollector(
         env_id,
         baseline=baseline,
+        reward_model=reward_model,
     )
 
     if n_samplers > 1:

--- a/tests/tfrlrl/cli/test_reinforce.py
+++ b/tests/tfrlrl/cli/test_reinforce.py
@@ -84,6 +84,43 @@ class TestParseArgs:
         with pytest.raises(SystemExit):
             parse_args(['--n-iterations', '10'])
 
+    def test_parse_args_reward_model_has_default(self):
+        """Test that --reward-model has a default value (without asserting what it is)."""
+        parsed = parse_args(['--env-id', 'FrozenLake-v1', '--policy-class', 'dense'])
+        assert parsed.reward_model is not None
+
+    def test_parse_args_invalid_reward_model(self):
+        """Test that an invalid --reward-model raises SystemExit."""
+        with pytest.raises(SystemExit):
+            parse_args(['--env-id', 'FrozenLake-v1', '--policy-class', 'dense', '--reward-model', 'invalid'])
+
+    @pytest.mark.parametrize(
+        'args,expected_reward_model',
+        [
+            (
+                ['--env-id', 'FrozenLake-v1', '--policy-class', 'dense', '--reward-model', 'average-episodic'],
+                'average-episodic',
+            ),
+            (
+                [
+                    '--env-id',
+                    'FrozenLake-v1',
+                    '--policy-class',
+                    'dense',
+                    '--reward-model',
+                    'discounted',
+                    '--gamma',
+                    '0.95',
+                ],
+                'discounted',
+            ),
+        ],
+    )
+    def test_parse_args_reward_model(self, args, expected_reward_model):
+        """Test that --reward-model is parsed correctly."""
+        parsed = parse_args(args)
+        assert parsed.reward_model == expected_reward_model
+
 
 class TestMain:
     """Tests for the main function."""
@@ -216,6 +253,64 @@ class TestMain:
         exit_code = main(args)
 
         assert exit_code is None or exit_code == 0
+
+    @pytest.mark.parametrize(
+        'env_id, policy_class, reward_model, gamma',
+        [
+            ('FrozenLake-v1', 'linear', 'average-episodic', None),
+            ('FrozenLake-v1', 'linear', 'discounted', '0.95'),
+        ],
+    )
+    def test_main_with_reward_model(self, env_id: str, policy_class: str, reward_model: str, gamma):
+        """
+        Test main function with different reward model settings.
+
+        Args:
+            env_id: The Gym environment ID to be used in training.
+            policy_class: The policy class to use in SGD.
+            reward_model: The reward model to use.
+            gamma: The discount factor (only used when reward_model='discounted').
+
+        """
+        args = [
+            '--env-id',
+            env_id,
+            '--policy-class',
+            policy_class,
+            '--n-iterations',
+            '2',
+            '--n-episodes',
+            '5',
+            '--alpha',
+            '1.0',
+            '--reward-model',
+            reward_model,
+        ]
+        if gamma is not None:
+            args += ['--gamma', gamma]
+
+        exit_code = main(args)
+
+        assert exit_code is None or exit_code == 0
+
+    def test_main_discounted_reward_model_requires_gamma(self):
+        """Test that using --reward-model=discounted without --gamma returns exit code 1."""
+        args = [
+            '--env-id',
+            'FrozenLake-v1',
+            '--policy-class',
+            'linear',
+            '--n-iterations',
+            '1',
+            '--n-episodes',
+            '5',
+            '--alpha',
+            '1.0',
+            '--reward-model',
+            'discounted',
+        ]
+        exit_code = main(args)
+        assert exit_code == 1
 
     @pytest.mark.parametrize(
         'malformed_json',

--- a/tests/tfrlrl/data_models/test_reward_models.py
+++ b/tests/tfrlrl/data_models/test_reward_models.py
@@ -1,0 +1,111 @@
+"""Tests for reward model dataclasses."""
+
+import numpy as np
+import pytest
+
+from tfrlrl.data_models.reward_models import AverageEpisodicReward, DiscountedReward
+
+
+class TestAverageEpisodicReward:
+    """Tests for the AverageEpisodicReward dataclass."""
+
+    def test_compute_returns_ndarray(self):
+        """Test that compute returns a numpy array."""
+        model = AverageEpisodicReward()
+        rewards = np.array([1.0, 2.0, 3.0])
+        result = model.compute(rewards)
+        assert isinstance(result, np.ndarray)
+
+    def test_compute_output_length_matches_input(self):
+        """Test that the output length equals the number of steps."""
+        model = AverageEpisodicReward()
+        rewards = np.array([1.0, 2.0, 3.0, 4.0])
+        result = model.compute(rewards)
+        assert result.shape == (rewards.size,)
+
+    def test_compute_known_sequence(self):
+        """Test compute against a known reward sequence."""
+        model = AverageEpisodicReward()
+        # rewards = [1, 1, 1], T=3
+        # G_0 = (1+1+1)/3 = 1.0, G_1 = (1+1)/3 = 2/3, G_2 = 1/3
+        rewards = np.array([1.0, 1.0, 1.0])
+        result = model.compute(rewards)
+        expected = np.array([3.0 / 3, 2.0 / 3, 1.0 / 3])
+        np.testing.assert_allclose(result, expected)
+
+    def test_compute_single_step(self):
+        """Test compute with a single-step episode."""
+        model = AverageEpisodicReward()
+        rewards = np.array([5.0])
+        result = model.compute(rewards)
+        np.testing.assert_allclose(result, np.array([5.0]))
+
+    def test_compute_all_zero_rewards(self):
+        """Test compute with all-zero rewards returns zeros."""
+        model = AverageEpisodicReward()
+        rewards = np.zeros(4)
+        result = model.compute(rewards)
+        np.testing.assert_allclose(result, np.zeros(4))
+
+
+class TestDiscountedReward:
+    """Tests for the DiscountedReward dataclass."""
+
+    def test_compute_returns_ndarray(self):
+        """Test that compute returns a numpy array."""
+        model = DiscountedReward(gamma=0.9)
+        rewards = np.array([1.0, 2.0, 3.0])
+        result = model.compute(rewards)
+        assert isinstance(result, np.ndarray)
+
+    def test_compute_output_length_matches_input(self):
+        """Test that the output length equals the number of steps."""
+        model = DiscountedReward(gamma=0.9)
+        rewards = np.array([1.0, 2.0, 3.0, 4.0])
+        result = model.compute(rewards)
+        assert result.shape == (rewards.size,)
+
+    def test_compute_gamma_zero_returns_only_current_reward(self):
+        """Test that gamma=0 returns only the immediate reward at each step."""
+        model = DiscountedReward(gamma=0.0)
+        rewards = np.array([1.0, 2.0, 3.0])
+        result = model.compute(rewards)
+        # With gamma=0, G_t = r_t
+        np.testing.assert_allclose(result, rewards)
+
+    def test_compute_gamma_one_equals_cumulative_sum(self):
+        """Test that gamma=1 produces a simple cumulative sum of future rewards."""
+        model = DiscountedReward(gamma=1.0)
+        rewards = np.array([1.0, 2.0, 3.0])
+        result = model.compute(rewards)
+        # G_0 = 1+2+3 = 6, G_1 = 2+3 = 5, G_2 = 3
+        expected = np.array([6.0, 5.0, 3.0])
+        np.testing.assert_allclose(result, expected)
+
+    def test_compute_known_sequence(self):
+        """Test compute against a known discounted reward sequence."""
+        gamma = 0.5
+        model = DiscountedReward(gamma=gamma)
+        rewards = np.array([1.0, 1.0, 1.0])
+        result = model.compute(rewards)
+        # G_0 = 1 + 0.5 + 0.25 = 1.75
+        # G_1 = 1 + 0.5 = 1.5
+        # G_2 = 1
+        expected = np.array([1.75, 1.5, 1.0])
+        np.testing.assert_allclose(result, expected)
+
+    def test_compute_single_step(self):
+        """Test compute with a single-step episode."""
+        model = DiscountedReward(gamma=0.99)
+        rewards = np.array([5.0])
+        result = model.compute(rewards)
+        np.testing.assert_allclose(result, np.array([5.0]))
+
+    @pytest.mark.parametrize('gamma', [0.1, 0.5, 0.9, 0.99])
+    def test_compute_returns_decrease_over_time(self, gamma: float):
+        """Test that returns are non-increasing for constant positive rewards."""
+        model = DiscountedReward(gamma=gamma)
+        rewards = np.ones(5)
+        result = model.compute(rewards)
+        # Later steps have fewer remaining rewards, so returns should be non-increasing
+        assert np.all(np.diff(result) <= 0)

--- a/tests/tfrlrl/sampling/test_statistics_collection.py
+++ b/tests/tfrlrl/sampling/test_statistics_collection.py
@@ -5,6 +5,7 @@ from hypothesis import given, settings
 from hypothesis import strategies as st
 
 from tfrlrl.baselines.linear import LinearBaseline
+from tfrlrl.data_models.reward_models import AverageEpisodicReward, DiscountedReward
 from tfrlrl.data_models.statistics import StatisticsException
 from tfrlrl.features.onehot import OneHotFeatureFunction
 from tfrlrl.policies.dense_neural_network import DenseNetworkPolicy
@@ -316,3 +317,42 @@ class TestEpisocidPolicyGradientStatisticsCollector:
 
         with pytest.raises(StatisticsException):
             EpisocidPolicyGradientStatisticsCollector.merge_statistics([statistics1, statistics2])
+
+    @pytest.mark.parametrize(
+        'env_id, reward_model',
+        [
+            ('FrozenLake-v1', AverageEpisodicReward()),
+            ('FrozenLake-v1', DiscountedReward(gamma=0.99)),
+        ],
+    )
+    @given(n_episodes=st.integers(min_value=1, max_value=3))
+    @settings(deadline=5000)
+    def test_aggregate_statistics_with_reward_models(self, env_id: str, reward_model, n_episodes: int):
+        """
+        Test that aggregate_statistics works correctly with different reward models.
+
+        Args:
+            env_id: The Gym environment ID to be used in testing.
+            reward_model: The reward model to use.
+            n_episodes: The number of episodes to sample.
+
+        """
+        env = gym.make(env_id)
+        feature_fn = OneHotFeatureFunction(env.observation_space.n, env.action_space.n)
+        policy = LinearSoftMax(env_id, feature_fn)
+
+        stats_collector = EpisocidPolicyGradientStatisticsCollector(
+            env_id=env_id,
+            reward_model=reward_model,
+        )
+        sampler = EpisodicSampler(
+            env_id,
+            stats_collector,
+            n_episodes=n_episodes,
+            policy=policy,
+            is_slippery=False,
+        )
+
+        for statistics in sampler:
+            assert isinstance(statistics.total_expected_rewards, np.ndarray)
+            assert statistics.total_expected_rewards.shape[-1] == statistics.observations.shape[-1]


### PR DESCRIPTION
Introduces AverageEpisodicReward and DiscountedReward dataclasses so the REINFORCE algorithm can support different ways of estimating the total expected reward.

## Changes

- New reward_models.py with AverageEpisodicReward and DiscountedReward dataclasses
- DiscountedReward.gamma is a required field (no default) to prevent fragile tests
- EpisocidPolicyGradientStatisticsCollector accepts optional reward_model parameter
- train_policy_gradient threads reward_model to the statistics collector
- CLI adds --reward-model {average-episodic,discounted} and --gamma flags
- Tests cover both models without asserting specific default values

Closes #44

Generated with [Claude Code](https://claude.ai/code)